### PR TITLE
Modifying spec calls either ugrade/update/deploy

### DIFF
--- a/config/samples/upgrade.yaml
+++ b/config/samples/upgrade.yaml
@@ -1,0 +1,222 @@
+apiVersion: maestro.k8s.io/v1alpha1
+kind: Framework
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: upgrade
+---
+apiVersion: maestro.k8s.io/v1alpha1
+kind: FrameworkVersion
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: upgrade-v1
+  namespace: default
+spec:
+  version: "1.0.0"
+  connectionString: ""
+  framework:
+    name: upgrade
+    kind: Framework
+  templates:
+    something.yaml: blah
+  defaults.config:
+    SLEEP: "15"
+  plans:
+    deploy:
+      strategy: serial
+      phases:
+        - name: par
+          strategy: serial
+          steps:
+            - name: par-one
+              mustache: |
+                apiVersion: batch/v1
+                kind: Job
+                metadata:
+                  namespace: default
+                  name: deploy-job
+                spec:
+                  template:
+                    metadata:
+                      name: deploy-job
+                    spec:
+                      restartPolicy: OnFailure
+                      containers:
+                      - name: bb
+                        image: busybox:latest
+                        imagePullPolicy: IfNotPresent
+                        command:
+                        - /bin/sh
+                        - -c
+                        - "sleep {{SLEEP}}"
+    upgrade:
+      strategy: serial
+      phases:
+        - name: upgrade
+          strategy: serial
+          steps:
+            - name: upgrade-one
+              mustache: |
+                apiVersion: batch/v1
+                kind: Job
+                metadata:
+                  namespace: default
+                  name: upgrade-job
+                spec:
+                  template:
+                    metadata:
+                      name: upgrade-job
+                    spec:
+                      restartPolicy: OnFailure
+                      containers:
+                      - name: bb
+                        image: busybox:latest
+                        imagePullPolicy: IfNotPresent
+                        command:
+                        - /bin/sh
+                        - -c
+                        - "sleep {{SLEEP}}"
+    update:
+      strategy: serial
+      phases:
+        - name: update
+          strategy: serial
+          steps:
+            - name: update-one
+              mustache: |
+                apiVersion: batch/v1
+                kind: Job
+                metadata:
+                  namespace: default
+                  name: update-job
+                spec:
+                  template:
+                    metadata:
+                      name: update-job
+                    spec:
+                      restartPolicy: OnFailure
+                      containers:
+                      - name: bb
+                        image: busybox:latest
+                        imagePullPolicy: IfNotPresent
+                        command:
+                        - /bin/sh
+                        - -c
+                        - "sleep {{SLEEP}}"         
+---
+apiVersion: maestro.k8s.io/v1alpha1
+kind: FrameworkVersion
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: upgrade-v2
+  namespace: default
+spec:
+  version: "1.0.1"
+  connectionString: ""
+  framework:
+    name: upgrade
+    kind: Framework
+  templates:
+    something.yaml: blah
+  defaults.config:
+    SLEEP: "15"
+  plans:
+    deploy:
+      strategy: serial
+      phases:
+        - name: deploy
+          strategy: serial
+          steps:
+            - name: deploy-one
+              mustache: |
+                apiVersion: batch/v1
+                kind: Job
+                metadata:
+                  namespace: default
+                  name: deploy-job
+                spec:
+                  template:
+                    metadata:
+                      name: deploy-job
+                    spec:
+                      restartPolicy: OnFailure
+                      containers:
+                      - name: bb
+                        image: busybox:latest
+                        imagePullPolicy: IfNotPresent
+                        command:
+                        - /bin/sh
+                        - -c
+                        - "sleep {{SLEEP}}"
+    upgrade:
+      strategy: serial
+      phases:
+        - name: upgrade
+          strategy: serial
+          steps:
+            - name: upgrade-one
+              mustache: |
+                apiVersion: batch/v1
+                kind: Job
+                metadata:
+                  namespace: default
+                  name: upgrade-job
+                spec:
+                  template:
+                    metadata:
+                      name: upgrade-job
+                    spec:
+                      restartPolicy: OnFailure
+                      containers:
+                      - name: bb
+                        image: busybox:latest
+                        imagePullPolicy: IfNotPresent
+                        command:
+                        - /bin/sh
+                        - -c
+                        - "sleep {{SLEEP}}"
+    update:
+      strategy: serial
+      phases:
+        - name: update
+          strategy: serial
+          steps:
+            - name: update-one
+              mustache: |
+                apiVersion: batch/v1
+                kind: Job
+                metadata:
+                  namespace: default
+                  name: update-job
+                spec:
+                  template:
+                    metadata:
+                      name: update-job
+                    spec:
+                      restartPolicy: OnFailure
+                      containers:
+                      - name: bb
+                        image: busybox:latest
+                        imagePullPolicy: IfNotPresent
+                        command:
+                        - /bin/sh
+                        - -c
+                        - "sleep {{SLEEP}}"                   
+---
+apiVersion: maestro.k8s.io/v1alpha1
+kind: Instance
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+    framework: upgrade
+  name: up
+spec:
+  frameworkVersion:
+    name: upgrade-v1
+    namespace: default
+    type: FrameworkVersions
+  # Add fields here
+  parameters:
+    SLEEP: "15"


### PR DESCRIPTION
This new example shows how different plans get called automatically based on the changes in the instance object.

Upon creation, the deploy plan gets run.
Modifying the frameworkVersion calls the upgrade plan
Modifying the parameters calls the update plan.