### PR TITLE
Added health check for instance object.  

### DIFF
--- a/pkg/controller/planexecution/planexecution_controller.go
+++ b/pkg/controller/planexecution/planexecution_controller.go
@@ -444,7 +444,7 @@ func (r *ReconcilePlanExecution) Reconcile(request reconcile.Request) (reconcile
 					planExecution.Status.Phases[i].Steps[j].State = maestrov1alpha1.PhaseStateError
 					return reconcile.Result{}, err
 				}
-				err = health.IsHealthy(obj)
+				err = health.IsHealthy(r.Client, obj)
 				if err != nil {
 					fmt.Printf("Obj is NOT healthy: %v\n", obj)
 					planExecution.Status.Phases[i].Steps[j].State = maestrov1alpha1.PhaseStateInProgress


### PR DESCRIPTION
Needed to put Instance object as element in Task.

Needed to change the interface since the Instance's state is captured in the ActivePlans' Status.

In the future we could look at any of the following:

1) HealthCheck Plan (run arbitrary code).  This allows more customized healthchecks like looking at logs/data/etc
2) http get (current Kubernetes Spec)
3) exec call (current Kubernetes Spec)