### PR TITLE
Created ability to trigger specific plans when parameters change

### DIFF
--- a/config/samples/mysql.yaml
+++ b/config/samples/mysql.yaml
@@ -24,6 +24,7 @@ spec:
     description: "Filename to save the backups to"
     default: "backup.sql"
     displayName: "BackupFile"
+    trigger: backup
   - name: PASSWORD
     default: "password"
   tasks:
@@ -252,6 +253,7 @@ spec:
   # Add fields here
   parameters:
     PASSWORD: password
+    BACKUP_FILE: backup.sql
 
 
 

--- a/pkg/apis/maestro/v1alpha1/frameworkversion_types.go
+++ b/pkg/apis/maestro/v1alpha1/frameworkversion_types.go
@@ -88,6 +88,10 @@ type Parameter struct {
 	//Default is a default value if no paramter is provided by the instance
 	Default string `json:"default,omitempty"`
 
+	//Trigger identifies the plan that gets executed when this parameter changes in the Instance object.
+	//Default is `update` if present, or `deploy` if not present
+	Trigger string `json:"trigger,omitempty"`
+
 	//TODO Add generated parameters (e.g. passwords)
 	//These values should be saved off in a secret instead of updating the spec
 	// with values so viewing the instance doesn't give crednetials

--- a/pkg/controller/instance/instance_controller.go
+++ b/pkg/controller/instance/instance_controller.go
@@ -154,7 +154,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 						}
 					}
 				}
-				//Not currentl doing anything for Dependency changes
+				//Not currently doing anything for Dependency changes
 			} else {
 				log.Println("InstanceController: Old and new spec matched...")
 				planName = "deploy"

--- a/pkg/controller/instance/instance_controller.go
+++ b/pkg/controller/instance/instance_controller.go
@@ -104,6 +104,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 				//since its linking to a bad FV
 				return false
 			}
+			//Identify plan to be executed by this change
 			var planName string
 			var ok bool
 			if old.Spec.FrameworkVersion != new.Spec.FrameworkVersion {
@@ -126,17 +127,34 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 					planName = "upgrade"
 				}
 			} else if !reflect.DeepEqual(old.Spec, new.Spec) {
-				_, ok = fv.Spec.Plans["update"]
-				if !ok {
-					_, ok = fv.Spec.Plans["deploy"]
-					if !ok {
-						log.Println("InstanceController: Could not find any plan to use for update")
-					} else {
-						planName = "deploy"
+				for k, v := range new.Spec.Parameters {
+					if old.Spec.Parameters[k] != v {
+						//Find the right parameter in the FV
+						for _, param := range fv.Spec.Parameters {
+							if param.Name == k {
+								planName = param.Trigger
+								ok = true
+							}
+						}
+						if !ok {
+							log.Printf("InstanceController: Instance %v updated parameter %v, but parameter not found in FrameworkVersion %v\n", new.Name, k, fv.Name)
+						} else if planName == "" {
+							_, ok = fv.Spec.Plans["update"]
+							if !ok {
+								_, ok = fv.Spec.Plans["deploy"]
+								if !ok {
+									log.Println("InstanceController: Could not find any plan to use for update")
+								} else {
+									planName = "deploy"
+								}
+							} else {
+								planName = "update"
+							}
+							log.Printf("InstanceController: Instance %v updated parameter %v, but no specified trigger.  Using default plan %v\n", new.Name, k, planName)
+						}
 					}
-				} else {
-					planName = "update"
 				}
+				//Not currentl doing anything for Dependency changes
 			} else {
 				log.Println("InstanceController: Old and new spec matched...")
 				planName = "deploy"


### PR DESCRIPTION
```bash
$kubectl apply -f config/samples/mysql.yaml
framework.maestro.k8s.io/mysql created
frameworkversion.maestro.k8s.io/mysql-57 created
instance.maestro.k8s.io/mysql created

$kubectl get planexecutions
NAME                     AGE
mysql-deploy-300930000   13s

$k get pods
NAME                           READY   STATUS      RESTARTS   AGE
mysql-deploy-job-95k6r         0/1     Completed   0          5s
mysql-mysql-864c69cf97-5xfbw   1/1     Running     0          31s

$ kubectl patch instance mysql -p '{"spec":{"parameters":{"BACKUP_FILE":"new-backup.sql"}}}' --type=merge
instance.maestro.k8s.io/mysql patched

$ kubectl get planexecutions
NAME                     AGE
mysql-backup-690459000   7s
mysql-deploy-300930000   1m
```