### PR TITLE
Update to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,28 @@
+---
+name: Bug report
+about: Report a bug encountered while operating KUDO
+title: ''
+labels: kind/bug
+assignees: ''
+
+---
+
+<!-- Please use this template while reporting a bug and provide as much info as possible. Not doing so may result in your bug not being addressed in a timely manner. Thanks!
+-->
+
+
+**What happened**:
+
+**What you expected to happen**:
+
+**How to reproduce it (as minimally and precisely as possible)**:
+
+**Anything else we need to know?**:
+
+**Environment**:
+- Kubernetes version (use `kubectl version`):
+- Cloud provider or hardware configuration:
+- OS (e.g. from /etc/os-release):
+- Kernel (e.g. `uname -a`):
+- Install tools:
+- Others:

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -21,6 +21,9 @@ assignees: ''
 
 **Environment**:
 - Kubernetes version (use `kubectl version`):
+- Kudo version (use `kubectl kudoctl version`): 
+- Framework:
+- Frameworkversion:
 - Cloud provider or hardware configuration:
 - OS (e.g. from /etc/os-release):
 - Kernel (e.g. `uname -a`):

--- a/.github/ISSUE_TEMPLATE/enhancement-request.md
+++ b/.github/ISSUE_TEMPLATE/enhancement-request.md
@@ -1,0 +1,14 @@
+---
+name: Enhancement Request
+about: Suggest an enhancement to the KUDO project
+title: ''
+labels: kind/kep
+assignees: ''
+
+---
+
+<!-- Please only use this template for submitting enhancement requests -->
+
+**What would you like to be added**:
+
+**Why is this needed**:

--- a/.github/ISSUE_TEMPLATE/enhancement-request.md
+++ b/.github/ISSUE_TEMPLATE/enhancement-request.md
@@ -2,12 +2,14 @@
 name: Enhancement Request
 about: Suggest an enhancement to the KUDO project
 title: ''
-labels: kind/kep
+labels: kind/enhancement
 assignees: ''
 
 ---
 
-<!-- Please only use this template for submitting enhancement requests -->
+<!-- Please only use this template for submitting enhancement requests.
+Implementing your enhancement will follow the KEP process: https://github.com/kudobuilder/kudo/blob/master/keps/0001-kep-process.md
+-->
 
 **What would you like to be added**:
 


### PR DESCRIPTION
I propose two issue templates that should cover most cases I can think of right now:

- Bug reports
- Enhancement Requests

Feature requests would imo be Enhancement Requests as the current flow would be to create a kep out of it.

The ISSUE_TEMPLATES were created with the issue builder inspired by https://github.com/kubernetes/kubernetes/tree/master/.github/ISSUE_TEMPLATE

This references also https://github.com/kudobuilder/kudo/issues/113