### PR TITLE
Fixing HealthUtil StatefulSet Log Output

### DIFF
--- a/pkg/util/health/ready.go
+++ b/pkg/util/health/ready.go
@@ -18,11 +18,7 @@ func IsHealthy(c client.Client, obj runtime.Object) error {
 	switch obj.(type) {
 	case *appsv1.StatefulSet:
 		ss := obj.(*appsv1.StatefulSet)
-		log.Println("------HEALTH---------")
-		log.Printf("Looking at Statefulset: %v\n", ss.Name)
 		b, _ := json.MarshalIndent(ss, "", "\t")
-		log.Printf("\n%v\n", string(b))
-		log.Println("---------------------")
 		if ss.Spec.Replicas == nil {
 			return fmt.Errorf("replicas not set, so can't be healthy")
 		}

--- a/pkg/util/health/ready.go
+++ b/pkg/util/health/ready.go
@@ -2,7 +2,6 @@ package health
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	kudov1alpha1 "github.com/kudobuilder/kudo/pkg/apis/kudo/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -18,7 +17,6 @@ func IsHealthy(c client.Client, obj runtime.Object) error {
 	switch obj.(type) {
 	case *appsv1.StatefulSet:
 		ss := obj.(*appsv1.StatefulSet)
-		b, _ := json.MarshalIndent(ss, "", "\t")
 		if ss.Spec.Replicas == nil {
 			return fmt.Errorf("replicas not set, so can't be healthy")
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kudo/blob/master/CONTRIBUTING.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kudobuilder/kudo/blob/master/RELEASE.md
3. Ensure you have added or ran the appropriate tests for your PR
4. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What type of PR is this?**
/component operator

**What this PR does / why we need it**:
Right now the log output of KUDO shows the entire passed StatefulSet object printed to stdout which makes it hard to read through logs.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #140

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```