### PR TITLE
Removed ubuntu:latest and fixed tag to 18.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ COPY vendor/ vendor/
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager github.com/kudobuilder/kudo/cmd/manager
 
 # Copy the controller-manager into a thin image
-FROM ubuntu:latest
+FROM ubuntu:18.04
 WORKDIR /root/
 COPY --from=builder /go/src/github.com/kudobuilder/kudo/manager .
 ENTRYPOINT ["./manager"]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:


-->

**What type of PR is this?**

/kind cleanup


**What this PR does / why we need it**:

Prevents building Docker Image from a `:latest` tag

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
None
```