### PR TITLE
Adding kubectl version 1.12 to pre-requisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Before you get started:
 - Install Go `1.11` or later
 - Latest version of `dep`
 - Kubernetes Cluster `1.12` or later (e.g. [Minikube](https://kubernetes.io/docs/tasks/tools/install-minikube/))
-- [Configure kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
+- [Configure kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) with version `1.12` or later
 
 ## Installation Instructions
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -31,6 +31,7 @@ This document demonstrates how to use the CLI but also shows what happens in `KU
 
 ### Requirements
 
+- Kubectl version of `1.12.0` or later
 - GitHub set up
   - GitHub OTP token in `$HOME/.git-credentials` OR
   - GitHub Basic Auth via `GIT_USER` and `GIT_PASSWORD` environment variables exposed


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

Making sure users using a version of kubectl that supports plugin features needed for our CLI.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

Fixes https://kubernetes.slack.com/archives/CG3HTFCMV/p1554919242069900

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```