### PR TITLE
Fix the formatting script

### DIFF
--- a/pkg/kudoctl/cmd/install.go
+++ b/pkg/kudoctl/cmd/install.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+
 	"github.com/kudobuilder/kudo/pkg/kudoctl/cmd/install"
 	"github.com/kudobuilder/kudo/pkg/kudoctl/util/vars"
 	"github.com/spf13/cobra"

--- a/pkg/kudoctl/cmd/install/install.go
+++ b/pkg/kudoctl/cmd/install/install.go
@@ -2,6 +2,8 @@ package install
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/kudobuilder/kudo/pkg/kudoctl/util/check"
 	"github.com/kudobuilder/kudo/pkg/kudoctl/util/github"
 	"github.com/kudobuilder/kudo/pkg/kudoctl/util/helpers"
@@ -10,7 +12,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/tools/clientcmd"
-	"strings"
 )
 
 func InstallCmd(cmd *cobra.Command, args []string) error {

--- a/pkg/kudoctl/cmd/install/install_test.go
+++ b/pkg/kudoctl/cmd/install/install_test.go
@@ -1,9 +1,10 @@
 package install
 
 import (
+	"testing"
+
 	"github.com/kudobuilder/kudo/pkg/kudoctl/util/vars"
 	"github.com/spf13/cobra"
-	"testing"
 )
 
 func TestInstallCmd(t *testing.T) {

--- a/pkg/kudoctl/util/check/check.go
+++ b/pkg/kudoctl/util/check/check.go
@@ -1,11 +1,12 @@
 package check
 
 import (
-	"github.com/kudobuilder/kudo/pkg/kudoctl/util/vars"
-	"github.com/pkg/errors"
 	"os"
 	"os/user"
 	"path/filepath"
+
+	"github.com/kudobuilder/kudo/pkg/kudoctl/util/vars"
+	"github.com/pkg/errors"
 )
 
 const (

--- a/pkg/kudoctl/util/check/check_test.go
+++ b/pkg/kudoctl/util/check/check_test.go
@@ -1,8 +1,9 @@
 package check
 
 import (
-	"github.com/kudobuilder/kudo/pkg/kudoctl/util/vars"
 	"testing"
+
+	"github.com/kudobuilder/kudo/pkg/kudoctl/util/vars"
 )
 
 func TestKubeConfigPath(t *testing.T) {

--- a/pkg/kudoctl/util/github/client.go
+++ b/pkg/kudoctl/util/github/client.go
@@ -3,14 +3,15 @@ package github
 import (
 	"context"
 	"fmt"
+	"os"
+	"strings"
+
 	"github.com/google/go-github/github" // with go modules disabled
 	"github.com/kudobuilder/kudo/pkg/apis/kudo/v1alpha1"
 	"github.com/kudobuilder/kudo/pkg/kudoctl/util/helpers"
 	"github.com/kudobuilder/kudo/pkg/kudoctl/util/vars"
 	"github.com/pkg/errors"
-	"os"
 	"sigs.k8s.io/yaml"
-	"strings"
 )
 
 type GithubClient struct {

--- a/pkg/kudoctl/util/github/client_test.go
+++ b/pkg/kudoctl/util/github/client_test.go
@@ -1,10 +1,11 @@
 package github
 
 import (
-	"github.com/google/go-github/github"
-	"github.com/kudobuilder/kudo/pkg/kudoctl/util/vars"
 	"os"
 	"testing"
+
+	"github.com/google/go-github/github"
+	"github.com/kudobuilder/kudo/pkg/kudoctl/util/vars"
 )
 
 // Todo: implementing a mocking interface ala https://github.com/google/go-github/issues/113

--- a/pkg/kudoctl/util/github/credential.go
+++ b/pkg/kudoctl/util/github/credential.go
@@ -1,10 +1,11 @@
 package github
 
 import (
-	"github.com/kudobuilder/kudo/pkg/kudoctl/util/vars"
-	"github.com/pkg/errors"
 	"io/ioutil"
 	"strings"
+
+	"github.com/kudobuilder/kudo/pkg/kudoctl/util/vars"
+	"github.com/pkg/errors"
 )
 
 // GetGithubCredentials stores credentials to GithubCredentials variable.

--- a/pkg/kudoctl/util/github/credential_test.go
+++ b/pkg/kudoctl/util/github/credential_test.go
@@ -1,8 +1,9 @@
 package github
 
 import (
-	"github.com/kudobuilder/kudo/pkg/kudoctl/util/vars"
 	"testing"
+
+	"github.com/kudobuilder/kudo/pkg/kudoctl/util/vars"
 )
 
 func TestGetGithubCredentials(t *testing.T) {

--- a/pkg/kudoctl/util/helpers/helpers.go
+++ b/pkg/kudoctl/util/helpers/helpers.go
@@ -2,9 +2,10 @@ package helpers
 
 import (
 	"fmt"
-	"github.com/google/go-github/github" // with go modules disabled
 	"sort"
 	"strconv"
+
+	"github.com/google/go-github/github" // with go modules disabled
 )
 
 // askForConfirmation uses Scanln to parse user input. A user must type in "yes" or "no" and

--- a/pkg/kudoctl/util/helpers/helpers_test.go
+++ b/pkg/kudoctl/util/helpers/helpers_test.go
@@ -1,9 +1,10 @@
 package helpers
 
 import (
-	"github.com/google/go-github/github"
 	"reflect"
 	"testing"
+
+	"github.com/google/go-github/github"
 )
 
 func TestSortDirectoryContent(t *testing.T) {

--- a/pkg/kudoctl/util/kudo/kudo.go
+++ b/pkg/kudoctl/util/kudo/kudo.go
@@ -9,7 +9,7 @@ import (
 	"github.com/kudobuilder/kudo/pkg/client/clientset/versioned"
 	"github.com/kudobuilder/kudo/pkg/kudoctl/util/vars"
 	"github.com/pkg/errors"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/clientcmd"
 )
 

--- a/pkg/kudoctl/util/kudo/kudo.go
+++ b/pkg/kudoctl/util/kudo/kudo.go
@@ -2,14 +2,15 @@ package kudo
 
 import (
 	"fmt"
+	"strings"
+	"time"
+
 	"github.com/kudobuilder/kudo/pkg/apis/kudo/v1alpha1"
 	"github.com/kudobuilder/kudo/pkg/client/clientset/versioned"
 	"github.com/kudobuilder/kudo/pkg/kudoctl/util/vars"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/clientcmd"
-	"strings"
-	"time"
 )
 
 type KudoClient struct {

--- a/pkg/kudoctl/util/kudo/kudo_test.go
+++ b/pkg/kudoctl/util/kudo/kudo_test.go
@@ -346,7 +346,7 @@ func TestK2oClient_InstallFrameworkVersionObjToCluster(t *testing.T) {
 		{"", "frameworkversions.kudo.k8s.io \"\" not found", "default", nil},         // 2
 		{"", "frameworkversions.kudo.k8s.io \"\" not found", "kudo", nil},            // 3
 		{"test2", "frameworkversions.kudo.k8s.io \"test2\" not found", "kudo", &obj}, // 4
-		{"test", "", "kudo", &obj},                                                   // 5
+		{"test", "", "kudo", &obj}, // 5
 
 	}
 

--- a/pkg/kudoctl/util/kudo/kudo_test.go
+++ b/pkg/kudoctl/util/kudo/kudo_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/kudobuilder/kudo/pkg/apis/kudo/v1alpha1"
 	"github.com/kudobuilder/kudo/pkg/client/clientset/versioned/fake"
 	"github.com/kudobuilder/kudo/pkg/kudoctl/util/vars"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/pkg/kudoctl/util/kudo/kudo_test.go
+++ b/pkg/kudoctl/util/kudo/kudo_test.go
@@ -1,12 +1,13 @@
 package kudo
 
 import (
+	"testing"
+
 	"github.com/kudobuilder/kudo/pkg/apis/kudo/v1alpha1"
 	"github.com/kudobuilder/kudo/pkg/client/clientset/versioned/fake"
 	"github.com/kudobuilder/kudo/pkg/kudoctl/util/vars"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"testing"
 )
 
 func newTestSimpleK2o() *KudoClient {
@@ -345,7 +346,7 @@ func TestK2oClient_InstallFrameworkVersionObjToCluster(t *testing.T) {
 		{"", "frameworkversions.kudo.k8s.io \"\" not found", "default", nil},         // 2
 		{"", "frameworkversions.kudo.k8s.io \"\" not found", "kudo", nil},            // 3
 		{"test2", "frameworkversions.kudo.k8s.io \"test2\" not found", "kudo", &obj}, // 4
-		{"test", "", "kudo", &obj}, // 5
+		{"test", "", "kudo", &obj},                                                   // 5
 
 	}
 

--- a/test/formatting.sh
+++ b/test/formatting.sh
@@ -5,15 +5,6 @@ set -x -e -o pipefail
 ROOT=$(dirname "${BASH_SOURCE}")/..
 PACKAGES="${ROOT}/pkg/ ${ROOT}/cmd/"
 
-# Make sure go fmt doesn't change anything
-echo "gofmt -d ${PACKAGES}"
-differences=`gofmt -d ${PACKAGES}`
-if [[ ! "$differences" == "" ]]; then
-    echo "gofmt found the following differences"
-    echo "$differences"
-    exit 1
-fi
-
 # Make sure goimports doesn't find any errors
 echo "goimports -d ${PACKAGES}"
 differences=`goimports -d ${PACKAGES}`

--- a/test/formatting.sh
+++ b/test/formatting.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -x -e -o pipefail
+
 ROOT=$(dirname "${BASH_SOURCE}")/..
 PACKAGES="${ROOT}/pkg/ ${ROOT}/cmd/"
 

--- a/test/formatting.sh
+++ b/test/formatting.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 ROOT=$(dirname "${BASH_SOURCE}")/..
 PACKAGES="${ROOT}/pkg/ ${ROOT}/cmd/"


### PR DESCRIPTION
**What type of PR is this?**

/kind infrastructure

**What this PR does / why we need it**:
The format checking script was advertising /bin/sh instead of /bin/bash while it was using features not available in bourne shell. By changing the shebang the build finally started failing and because of that this PR also includes formatting fixes.