### PR TITLE
Fix inline JSON struct tags

### DIFF
--- a/config/crds/kudo_v1alpha1_framework.yaml
+++ b/config/crds/kudo_v1alpha1_framework.yaml
@@ -14,16 +14,16 @@ spec:
   validation:
     openAPIV3Schema:
       properties:
-        inline:
-          type: object
+        apiVersion:
+          type: string
+        kind:
+          type: string
         metadata:
           type: object
         spec:
           type: object
         status:
           type: object
-      required:
-      - inline
   version: v1alpha1
 status:
   acceptedNames:

--- a/config/crds/kudo_v1alpha1_frameworkversion.yaml
+++ b/config/crds/kudo_v1alpha1_frameworkversion.yaml
@@ -14,8 +14,10 @@ spec:
   validation:
     openAPIV3Schema:
       properties:
-        inline:
-          type: object
+        apiVersion:
+          type: string
+        kind:
+          type: string
         metadata:
           type: object
         spec:
@@ -68,8 +70,6 @@ spec:
           type: object
         status:
           type: object
-      required:
-      - inline
   version: v1alpha1
 status:
   acceptedNames:

--- a/config/crds/kudo_v1alpha1_instance.yaml
+++ b/config/crds/kudo_v1alpha1_instance.yaml
@@ -14,8 +14,10 @@ spec:
   validation:
     openAPIV3Schema:
       properties:
-        inline:
-          type: object
+        apiVersion:
+          type: string
+        kind:
+          type: string
         metadata:
           type: object
         spec:
@@ -44,8 +46,6 @@ spec:
             status:
               type: string
           type: object
-      required:
-      - inline
   version: v1alpha1
 status:
   acceptedNames:

--- a/config/crds/kudo_v1alpha1_planexecution.yaml
+++ b/config/crds/kudo_v1alpha1_planexecution.yaml
@@ -14,8 +14,10 @@ spec:
   validation:
     openAPIV3Schema:
       properties:
-        inline:
-          type: object
+        apiVersion:
+          type: string
+        kind:
+          type: string
         metadata:
           type: object
         spec:
@@ -63,8 +65,6 @@ spec:
             strategy:
               type: string
           type: object
-      required:
-      - inline
   version: v1alpha1
 status:
   acceptedNames:

--- a/pkg/apis/kudo/v1alpha1/framework_types.go
+++ b/pkg/apis/kudo/v1alpha1/framework_types.go
@@ -40,7 +40,7 @@ type FrameworkStatus struct {
 // Framework is the Schema for the frameworks API
 // +k8s:openapi-gen=true
 type Framework struct {
-	metav1.TypeMeta   `json:"inline"`
+	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	Spec   FrameworkSpec   `json:"spec,omitempty"`
@@ -51,7 +51,7 @@ type Framework struct {
 
 // FrameworkList contains a list of Framework
 type FrameworkList struct {
-	metav1.TypeMeta `json:"inline"`
+	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []Framework `json:"items"`
 }

--- a/pkg/apis/kudo/v1alpha1/frameworkversion_types.go
+++ b/pkg/apis/kudo/v1alpha1/frameworkversion_types.go
@@ -133,7 +133,7 @@ type FrameworkVersionStatus struct {
 // FrameworkVersion is the Schema for the frameworkversions API
 // +k8s:openapi-gen=true
 type FrameworkVersion struct {
-	metav1.TypeMeta   `json:"inline"`
+	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	Spec   FrameworkVersionSpec   `json:"spec,omitempty"`
@@ -144,7 +144,7 @@ type FrameworkVersion struct {
 
 // FrameworkVersionList contains a list of FrameworkVersion
 type FrameworkVersionList struct {
-	metav1.TypeMeta `json:"inline"`
+	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []FrameworkVersion `json:"items"`
 }

--- a/pkg/apis/kudo/v1alpha1/instance_types.go
+++ b/pkg/apis/kudo/v1alpha1/instance_types.go
@@ -87,7 +87,7 @@ const PhaseStateSuspend PhaseState = "SUSPEND"
 // Instance is the Schema for the instances API
 // +k8s:openapi-gen=true
 type Instance struct {
-	metav1.TypeMeta   `json:"inline"`
+	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	Spec   InstanceSpec   `json:"spec,omitempty"`
@@ -98,7 +98,7 @@ type Instance struct {
 
 // InstanceList contains a list of Instance
 type InstanceList struct {
-	metav1.TypeMeta `json:"inline"`
+	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []Instance `json:"items"`
 }

--- a/pkg/apis/kudo/v1alpha1/planexecution_types.go
+++ b/pkg/apis/kudo/v1alpha1/planexecution_types.go
@@ -70,7 +70,7 @@ type StepStatus struct {
 // PlanExecution is the Schema for the planexecutions API
 // +k8s:openapi-gen=true
 type PlanExecution struct {
-	metav1.TypeMeta   `json:"inline"`
+	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	Spec   PlanExecutionSpec   `json:"spec,omitempty"`
@@ -81,7 +81,7 @@ type PlanExecution struct {
 
 // PlanExecutionList contains a list of PlanExecution
 type PlanExecutionList struct {
-	metav1.TypeMeta `json:"inline"`
+	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []PlanExecution `json:"items"`
 }


### PR DESCRIPTION
These were originally reported by staticcheck, but staticcheck master has been fixed to account for openapi-gen mis-using the `json` struct tags.