### PR TITLE
Adding the kep for the previous values in update plans

### DIFF
--- a/keps/draft-20190418-previous-values-in-update-plans-and-conditional-phases.md
+++ b/keps/draft-20190418-previous-values-in-update-plans-and-conditional-phases.md
@@ -1,0 +1,35 @@
+---
+kep-number: draft-20190418
+title: Previous values in update plans and conditional phases
+authors:
+  - "@djannot"
+owners:
+  - TBD
+editor: TBD
+creation-date: 2019-04-18
+status: provisional
+---
+
+# Previous values in update plans and conditional phases
+
+## Table of Contents
+
+  * [Table of Contents](#table-of-contents)
+  * [Summary](#summary)
+  * [Motivation](#motivation)
+
+Created by [gh-md-toc](https://github.com/ekalinin/github-markdown-toc)
+
+## Summary
+
+In order to develop the logic behind an `update` `Plan`, you generally need to know what were the previous values.
+
+For example, if the number of replicas of a `StatefulSet` is updated, you often need to add a new `Plan` to reconfigure your cluster.
+
+But currently, you don't know what has changed. You don't know if the number of replicas has changed and if it has changed you don't know what was the previous value.
+
+We would need a way to access the previous values, but also probably to be able to define `Plans` that need to be run based on conditions.
+
+## Motivation
+
+Knowing what were the previous values will help someone who develop a KUDO framework to define the logic that needs to take place when an update occurs.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kudo/blob/master/CONTRIBUTING.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kudobuilder/kudo/blob/master/RELEASE.md
3. Ensure you have added or ran the appropriate tests for your PR
4. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What type of PR is this?**

/kind kep

**What this PR does / why we need it**:

Knowing what were the previous values will help someone who develop a KUDO framework to define the logic that needs to take place when an update occurs.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```