### PR TITLE
Update bug_report.md to fix

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -22,7 +22,7 @@ If the matter is security sensitive, please disclose it privately to a security 
 
 **Environment**:
 - Kubernetes version (use `kubectl version`):
-- Kudo version (use `kubectl kudoctl version`): 
+- Kudo version (use `kubectl kudo version`): 
 - Framework:
 - Frameworkversion:
 - Cloud provider or hardware configuration:


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

This is a small and quick fix to something I just noticed today. The provided command to post the KUDO version when filing bug reports inherited an old name. The  command via the CLI should refer to `kubectl kudo version` and not `kubectl kudoctl version`. If someone would copy&paste the current instructions, it simply wouldn't work. This PR fixes this.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```