### PR TITLE
Fix broken link to Kafka example in 'getting started' section

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -42,4 +42,4 @@ The username is your GitHub user name and the credential is your password. If yo
 
 ## Deploy your first Application
 
-Follow the instructions in the [Apache Kafka example](/docs/examples/apache-kafka.md) to deploy a Kafka cluster along with its dependency Zookeeper.
+Follow the instructions in the [Apache Kafka example](/docs/examples/apache-kafka/) to deploy a Kafka cluster along with its dependency Zookeeper.


### PR DESCRIPTION
**What this PR does / why we need it**:

A minor fix which amends the link to the Kafka example in the 'getting started' section, as it's likely newcomers would stumble on this page.

/kind documentation

```release-note
NONE
```