### PR TITLE
Add note on creating a k8s cluster via minikube with more RAM / CPU

### DIFF
--- a/config/samples/kafka-instance.yaml
+++ b/config/samples/kafka-instance.yaml
@@ -12,7 +12,7 @@ spec:
     type: FrameworkVersion
   # Add fields here
   dependency:
-    - referenaceName: zookeeper
+    - referenceName: zookeeper
       name: zk
       type: Instance
   parameters:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -27,9 +27,17 @@ Before you get started:
 - `make install-crds` to deploy universal CRDs
 - `make run` to run the Operator with local go environment
 
+### Notes on Minikube
+If you plan on developing and testing KUDO locally via Minikube, you'll need to launch your cluster with a reasonable amount of memory allocated.  By default, this is only 2GB - we recommend at least 8GB, especially if you're working with applications such as [Kafka](/docs/examples/apache-kafka/).  You can start Minikube with some suitable resource adjustments as follows:
+
+``` shell
+minikube start --cpus=4 --memory=8192 --disk-size=40g
+```
+
 **Before** `make install-crds` you will need to have:
-- minikube running
-- `~/.git-credentials` must exist with git credentials with details below.
+
+ * minikube running
+ * `~/.git-credentials` must exist with git credentials with details below.
 
 ### Setting up GitHub Credentials
 In order to setup `~/.git-credentials` the file needs to have the format of:


### PR DESCRIPTION
**What this PR does / why we need it**:
Complicated application stacks and their lifecycles require more memory than Minikube allocates by default to the Kubernetes clusters that it creates.  This commit adds a comment with an example command and suggested limits.

Also fix a minor typo in the Kafka instance definition and some formatting problems.

**Which issue(s) this PR fixes**:
Fixes #92 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/kind documentation