### PR TITLE
Fix up - indent install-crds alternative

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -25,9 +25,9 @@ Before you get started:
 - Get KUDO repo: `go get github.com/kudobuilder/kudo/`
 - `cd $GOPATH/src/github.com/kudobuilder/kudo`
 - `make install-crds` to deploy the universal CRDs
-- Alternatively, you can use kubectl to install the CRDs :
-
- `kubectl apply -f config/crds`
+  - Alternatively, you can use kubectl to install the CRDs :
+    
+    `kubectl apply -f config/crds`
 - `make run` to run the Operator with local go environment
 
 ### Notes on Minikube


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

Indented the bullet item for alternatively using kubectl to install CRDs. This should allow the `make run` bullet item to stay at the same level as the other steps and not be rendered to the same line after `kubectl apply -f config/crds`


**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```