### PR TITLE
Fix `GetIncubatingFrameworkContentDir` unit test

### DIFF
--- a/pkg/kudoctl/util/github/client_test.go
+++ b/pkg/kudoctl/util/github/client_test.go
@@ -132,7 +132,7 @@ func TestGithubClient_GetIncubatingFrameworkContentDir(t *testing.T) {
 	}{
 		{"", "no framework provided"}, // 1
 		{"kafka", "incubating framework not found: GET https://api.github.com/repos/kudobuilder/frameworks/contents/repo/incubating/kafka/versions: 404 Not Found []"}, // 2
-		{"flink", ""}, // 3
+		{"redis", ""}, // 3
 	}
 
 	for i, tt := range tests {


### PR DESCRIPTION
which was trying to fetch Flink framework versions from the incubating frameworks. Flink has been promoted to stable so we test with Redis instead.

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /component generator
> /component kudoctl
> /component operator
> /kind api-change
> /kind bug
/kind cleanup
> /kind design
> /kind documentation
> /kind feature
> /kind enhancement
> /kind infrastructure
> /kind kep

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```