### PR TITLE
Refactor unit test to not use filesystem

### DIFF
--- a/pkg/kudoctl/cmd/install/install.go
+++ b/pkg/kudoctl/cmd/install/install.go
@@ -23,7 +23,7 @@ func CmdErrorProcessor(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("get flag: %+v", err)
 	}
 
-	err = check.KubeConfigPath()
+	err = check.ValidateKubeConfigPath()
 	if err != nil {
 		return errors.WithMessage(err, "could not check kubeconfig path")
 	}

--- a/pkg/kudoctl/util/check/check.go
+++ b/pkg/kudoctl/util/check/check.go
@@ -14,22 +14,30 @@ const (
 	defaultGithubCredentialPath = ".git-credentials"
 )
 
-// KubeConfigPath checks if the kubeconfig file exists.
-func KubeConfigPath() error {
-	// if KubeConfigPath is not specified, search for the default kubeconfig file under the $HOME/.kube/config.
-	if len(vars.KubeConfigPath) == 0 {
-		usr, err := user.Current()
-		if err != nil {
-			return errors.Wrap(err, "failed to determine user's home dir")
-		}
-		vars.KubeConfigPath = filepath.Join(usr.HomeDir, defaultKubeConfigPath)
+// ValidateKubeConfigPath checks if the kubeconfig file exists.
+func ValidateKubeConfigPath() error {
+	path, err := getKubeConfigLocation()
+	if err != nil {
+		return err
 	}
 
-	_, err := os.Stat(vars.KubeConfigPath)
-	if err != nil && os.IsNotExist(err) {
+	vars.KubeConfigPath = path
+	if _, err := os.Stat(vars.KubeConfigPath); os.IsNotExist(err) {
 		return errors.Wrap(err, "failed to find kubeconfig file")
 	}
 	return nil
+}
+
+func getKubeConfigLocation() (string, error) {
+	// if vars.KubeConfigPath is not specified, search for the default kubeconfig file under the $HOME/.kube/config.
+	if len(vars.KubeConfigPath) == 0 {
+		usr, err := user.Current()
+		if err != nil {
+			return "", errors.Wrap(err, "failed to determine user's home dir")
+		}
+		return filepath.Join(usr.HomeDir, defaultKubeConfigPath), nil
+	}
+	return vars.KubeConfigPath, nil
 }
 
 // GithubCredentials checks if the credential file exists.

--- a/pkg/kudoctl/util/check/check_test.go
+++ b/pkg/kudoctl/util/check/check_test.go
@@ -1,42 +1,34 @@
 package check
 
 import (
+	"os/user"
+	"path/filepath"
 	"testing"
 
 	"github.com/kudobuilder/kudo/pkg/kudoctl/util/vars"
 )
 
 func TestKubeConfigPath(t *testing.T) {
+	// first we test that the vars.KubeConfigPath is propagated correctly when resolving the path
 	vars.KubeConfigPath = "/tmp/;"
-
-	testNonExisting := []struct {
-		expected string
-	}{
-		{"failed to find kubeconfig file: stat /tmp/;: no such file or directory"}, // 1
+	location, err := getKubeConfigLocation()
+	if err != nil {
+		t.Errorf("expected kubeconfig path '%v' to be propagated from vars, got error instead %v", vars.KubeConfigPath, err)
+	}
+	if location != vars.KubeConfigPath {
+		t.Errorf("expected kubeconfig path '%v' to be propagated from vars, kubeconfig path instead resolved as %v", vars.KubeConfigPath, location)
 	}
 
-	for _, tt := range testNonExisting {
-		actual := KubeConfigPath()
-		if actual != nil {
-			if actual.Error() != tt.expected {
-				t.Errorf("non existing test:\nexpected: %v\n     got: %v", tt.expected, actual)
-			}
-		}
-	}
-
+	// then we test that default is used when no path is provided in vars
 	vars.KubeConfigPath = ""
-
-	testZero := []struct {
-		expected *string
-	}{
-		{nil}, // 1
+	usr, _ := user.Current()
+	expectedPath := filepath.Join(usr.HomeDir, defaultKubeConfigPath)
+	location, err = getKubeConfigLocation()
+	if err != nil {
+		t.Errorf("expected kubeconfig path '%v', got error instead %v", expectedPath, err)
 	}
-
-	for _, tt := range testZero {
-		actual := KubeConfigPath()
-		if actual != nil {
-			t.Errorf("empty path test:\nexpected: %v\n     got: %v", tt.expected, actual)
-		}
+	if location != expectedPath {
+		t.Errorf("expected kubeconfig path '%v', kubeconfig path instead resolved as %v", expectedPath, location)
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kudo/blob/master/CONTRIBUTING.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kudobuilder/kudo/blob/master/RELEASE.md
3. Ensure you have added or ran the appropriate tests for your PR
4. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
Right now the test was directly using os.Stat accessing the filesystem. That's not good idea in unit tests - then it cannot be run in an environment without .kubeconfig at the expected location.
One option I was investigating was using https://github.com/spf13/afero but then I decided to go with no extra dependencies and just refactored the code and test to not use the filesystem.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```