### PR TITLE
Fix use of date command so it's compatible with BSD and GNU date

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,8 @@ GIT_COMMIT_PATH := github.com/kudobuilder/kudo/pkg/version.gitCommit
 GIT_COMMIT := $(shell git rev-parse HEAD)
 SOURCE_DATE_EPOCH := $(shell git show -s --format=format:%ct HEAD)
 BUILD_DATE_PATH := github.com/kudobuilder/kudo/pkg/version.buildDate
-BUILD_DATE := $(shell date -r ${SOURCE_DATE_EPOCH} '+%Y-%m-%dT%H:%M:%SZ')
+DATE_FMT := "%Y-%m-%dT%H:%M:%SZ"
+BUILD_DATE := $(shell date -u -d "@$SOURCE_DATE_EPOCH" "+${DATE_FMT}" 2>/dev/null || date -u -r "${SOURCE_DATE_EPOCH}" "+${DATE_FMT}" 2>/dev/null || date -u "+${DATE_FMT}")
 LDFLAGS := -X ${GIT_VERSION_PATH}=${GIT_VERSION} -X ${GIT_COMMIT_PATH}=${GIT_COMMIT} -X ${BUILD_DATE_PATH}=${BUILD_DATE}
 
 export GO111MODULE=on


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
Use syntax recommended[0] by the Reproducible Builds project so that the
output of date in the desired format works across GNU and BSD userlands

[0] https://reproducible-builds.org/docs/source-date-epoch/

**Which issue(s) this PR fixes**:

Fixes #265 

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```