### PR TITLE
Use Helm-style parameters for `kudoctl kudo install` command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -45,6 +45,7 @@ require (
 	github.com/spf13/afero v1.2.1 // indirect
 	github.com/spf13/cobra v0.0.3
 	github.com/spf13/pflag v1.0.3 // indirect
+	github.com/stretchr/testify v1.3.0
 	github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca
 	go.uber.org/atomic v1.3.2 // indirect
 	go.uber.org/multierr v1.1.0 // indirect

--- a/pkg/kudoctl/cmd/install.go
+++ b/pkg/kudoctl/cmd/install.go
@@ -37,7 +37,7 @@ func NewInstallCmd() *cobra.Command {
 	installCmd.Flags().StringVar(&vars.GithubCredentialPath, "githubcredential", "", "The file path to GitHub credential file. (default \"$HOME/.git-credentials\")")
 	installCmd.Flags().StringVar(&vars.Instance, "instance", "", "The instance name. (default to Framework name)")
 	installCmd.Flags().StringVar(&vars.Namespace, "namespace", "default", "The namespace where the operator watches for changes. (default to")
-	installCmd.Flags().StringArrayVarP(&vars.Parameter, "parameter", "p", nil, "The parameter name.")
+	installCmd.Flags().StringArrayVarP(&vars.Parameter, "parameter", "p", nil, "The parameter name and value separated by '='")
 	installCmd.Flags().StringVar(&vars.PackageVersion, "package-version", "", "A specific package version on the official GitHub repo. (default to the most recent)")
 
 	const usageFmt = "Usage:\n  %s\n\nFlags:\n%s"

--- a/pkg/kudoctl/cmd/install_test.go
+++ b/pkg/kudoctl/cmd/install_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"github.com/stretchr/testify/assert"
 	"reflect"
 	"testing"
 )
@@ -22,4 +23,23 @@ func TestNewCmdInstallReturnsCmd(t *testing.T) {
 	if reflect.ValueOf(sub.Flags().GetNormalizeFunc()).Pointer() != reflect.ValueOf(newCmdInstall.Flags().GetNormalizeFunc()).Pointer() {
 		t.Fatal("child and root commands should have the same normalization functions")
 	}
+}
+
+func TestNewCmdInstall_WithParameters(t *testing.T) {
+	newCmdInstall := NewInstallCmd()
+
+	newCmdInstall.Flags().Set("parameter", "foo")
+	err := newCmdInstall.RunE(newCmdInstall, []string{})
+	assert.NotNil(t, err, "a parameter without value worked")
+
+	newCmdInstall = NewInstallCmd()
+	newCmdInstall.Flags().Set("parameter", "bar=")
+	err = newCmdInstall.RunE(newCmdInstall, []string{})
+	assert.NotNil(t, err, "a parameter with empty value worked")
+
+	newCmdInstall = NewInstallCmd()
+	newCmdInstall.Flags().Set("parameter", "foo=bar")
+	newCmdInstall.Flags().Set("parameter", "fiz=")
+	err = newCmdInstall.RunE(newCmdInstall, []string{})
+	assert.NotNil(t, err, "one of many parameters with empty value worked")
 }

--- a/pkg/kudoctl/cmd/install_test.go
+++ b/pkg/kudoctl/cmd/install_test.go
@@ -26,21 +26,23 @@ func TestNewCmdInstallReturnsCmd(t *testing.T) {
 	}
 }
 
-func TestNewCmdInstall_WithParameters(t *testing.T) {
-	newCmdInstall := NewInstallCmd()
+var parameterTests = []struct {
+	flags        []string
+	errorMessage string
+}{
+	{[]string{"foo"}, "a parameter without value worked"},                           // 1
+	{[]string{"bar="}, "a parameter with empty value worked"},                       // 2
+	{[]string{"foo=bar", "fiz="}, "one of many parameters with empty value worked"}, // 3
+	{[]string{"foo", "bar"}, "multiple empty parameters worked"},                    // 4
+}
 
-	newCmdInstall.Flags().Set("parameter", "foo")
-	err := newCmdInstall.RunE(newCmdInstall, []string{})
-	assert.NotNil(t, err, "a parameter without value worked")
-
-	newCmdInstall = NewInstallCmd()
-	newCmdInstall.Flags().Set("parameter", "bar=")
-	err = newCmdInstall.RunE(newCmdInstall, []string{})
-	assert.NotNil(t, err, "a parameter with empty value worked")
-
-	newCmdInstall = NewInstallCmd()
-	newCmdInstall.Flags().Set("parameter", "foo=bar")
-	newCmdInstall.Flags().Set("parameter", "fiz=")
-	err = newCmdInstall.RunE(newCmdInstall, []string{})
-	assert.NotNil(t, err, "one of many parameters with empty value worked")
+func TestTableNewInstallCmd_WithParameters(t *testing.T) {
+	for _, test := range parameterTests {
+		newCmdInstall := NewInstallCmd()
+		for _, flag := range test.flags {
+			newCmdInstall.Flags().Set("parameter", flag)
+		}
+		err := newCmdInstall.RunE(newCmdInstall, []string{})
+		assert.NotNil(t, err, test.errorMessage)
+	}
 }

--- a/pkg/kudoctl/cmd/install_test.go
+++ b/pkg/kudoctl/cmd/install_test.go
@@ -1,9 +1,10 @@
 package cmd
 
 import (
-	"github.com/stretchr/testify/assert"
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestNewCmdInstallReturnsCmd(t *testing.T) {


### PR DESCRIPTION
So instead of `kubectl kudo install kafka -p foo,bar` it would be: `kubectl kudo install kafka -p foo=bar`

Additionally, parameter validation is now done before the actual command execution to avoid potential failures down the road.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kudo/blob/master/CONTRIBUTING.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kudobuilder/kudo/blob/master/RELEASE.md
3. Ensure you have added or ran the appropriate tests for your PR
4. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /component generator

/component kudoctl
> /component operator
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind feature
> /kind enhancement
> /kind infrastructure
> /kind kep

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #225 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
`kudoctl kudo install` command now uses Helm-style parameters e.g. `kubectl kudo install kafka -p foo=bar`
```

Co-authored-by: Alena Varkockova <avarkockova@mesosphere.com>