### PR TITLE
Add "kudoctl delete" command

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -50,6 +50,7 @@ Install the plugin from your `$GOPATH/src/github.com/kudobuilder/kudo` root fold
 |---|---|
 | `kubectl kudo install <name> [flags]`  |  Installs a Framework from the official [KUDO repo](https://github.com/kudobuilder/frameworks). |
 | `kubectl kudo get instances [flags]` | Show all available instances. |
+| `kubectl kudo delete <name>` | Delete an instance. |
 | `kubectl kudo plan status [flags]` | View all available plans. |
 | `kubectl kudo plan history <name> [flags]` | View all available plans. |
 | `kubectl kudo version` | Print the current KUDO package version. |
@@ -357,6 +358,12 @@ Finally, the status information for the `Active-Plan` is nested in this part:
 ```
 
 Apparently, KUDO's tree view makes this information easier to understand and prevents you from putting together the bits and pieces of various commands.
+
+### Delete Instances
+
+An instance can be deleted (uninstalled from the cluster) using the `delete` command, this triggers the removal of all the objects owned by the instance:
+
+`kubectl kudo delete <instanceName>`
 
 ### Get the History to PlanExecutions
 

--- a/pkg/kudoctl/cmd/delete.go
+++ b/pkg/kudoctl/cmd/delete.go
@@ -1,0 +1,38 @@
+package cmd
+
+import (
+	"fmt"
+
+	deletePkg "github.com/kudobuilder/kudo/pkg/kudoctl/cmd/delete"
+	"github.com/kudobuilder/kudo/pkg/kudoctl/util/vars"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	deleteExample = `
+		# Delete an instance of a framework from your cluster.
+		kubectl kudo delete flink`
+)
+
+// NewDeleteCmd creates the delete command for the CLI
+func NewDeleteCmd() *cobra.Command {
+	deleteCmd := &cobra.Command{
+		Use:          "delete <instance>",
+		Short:        "-> Delete an instance of a framework.",
+		Long:         "Delete an instance of a framework.",
+		Example:      deleteExample,
+		RunE:         deletePkg.CmdErrorProcessor,
+		SilenceUsage: true,
+	}
+
+	deleteCmd.Flags().StringVar(&vars.KubeConfigPath, "kubeconfig", "", "The file path to Kubernetes configuration file. (default \"$HOME/.kube/config\")")
+	deleteCmd.Flags().StringVar(&vars.Namespace, "namespace", "default", "The namespace where the operator watches for changes. (default \"default\")")
+
+	const usageFmt = "Usage:\n  %s\n\nFlags:\n%s"
+	deleteCmd.SetUsageFunc(func(cmd *cobra.Command) error {
+		fmt.Fprintf(deleteCmd.OutOrStderr(), usageFmt, deleteCmd.UseLine(), deleteCmd.Flags().FlagUsages())
+		return nil
+	})
+	return deleteCmd
+}

--- a/pkg/kudoctl/cmd/delete/delete.go
+++ b/pkg/kudoctl/cmd/delete/delete.go
@@ -1,0 +1,43 @@
+package delete
+
+import (
+	"fmt"
+
+	"github.com/kudobuilder/kudo/pkg/kudoctl/util/check"
+	"github.com/kudobuilder/kudo/pkg/kudoctl/util/kudo"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+)
+
+// CmdErrorProcessor returns the errors associated with cmd env
+func CmdErrorProcessor(cmd *cobra.Command, args []string) error {
+	// This makes --kubeconfig flag optional
+	if _, err := cmd.Flags().GetString("kubeconfig"); err != nil {
+		return fmt.Errorf("get flag: %+v", err)
+	}
+
+	if err := check.ValidateKubeConfigPath(); err != nil {
+		return errors.Wrap(err, "could not check kubeconfig path")
+	}
+
+	if len(args) != 1 {
+		return errors.New("you must provide exactly one framework instance to delete")
+	}
+
+	kudoclient, err := kudo.NewKudoClient()
+	if err != nil {
+		return errors.Wrap(err, "creating kudo client")
+	}
+
+	err = kudoclient.DeleteInstanceFromCluster(args[0])
+	if apierrors.IsNotFound(err) {
+		return errors.Wrap(err, "framework instance not found")
+	}
+
+	if err != nil {
+		return errors.Wrap(err, "could not delete framework instance")
+	}
+
+	return nil
+}

--- a/pkg/kudoctl/cmd/delete_test.go
+++ b/pkg/kudoctl/cmd/delete_test.go
@@ -1,0 +1,42 @@
+package cmd
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewCmdDeleteReturnsCmd(t *testing.T) {
+	newCmdDelete := NewDeleteCmd()
+
+	if newCmdDelete.Parent() != nil {
+		t.Fatal("We expect the newCmdDelete command to be returned")
+	}
+
+	sub := newCmdDelete
+	for sub.HasSubCommands() {
+		sub = sub.Commands()[0]
+	}
+
+	// In case of failure of this test check this PR: spf13/cobra#110
+	if reflect.ValueOf(sub.Flags().GetNormalizeFunc()).Pointer() != reflect.ValueOf(newCmdDelete.Flags().GetNormalizeFunc()).Pointer() {
+		t.Fatal("child and root commands should have the same normalization functions")
+	}
+}
+
+func TestTableNewDeleteCmd_ArgsValidation(t *testing.T) {
+	var tests = []struct {
+		flags        []string
+		errorMessage string
+	}{
+		{[]string{"foo", "bar"}, "more than one framework instance worked"}, // 1
+		{[]string{}, "no framework instance worked"},                        // 2
+	}
+
+	for _, test := range tests {
+		newCmdDelete := NewDeleteCmd()
+		err := newCmdDelete.RunE(newCmdDelete, test.flags)
+		assert.NotNil(t, err, test.errorMessage)
+	}
+}

--- a/pkg/kudoctl/cmd/root.go
+++ b/pkg/kudoctl/cmd/root.go
@@ -28,6 +28,9 @@ and serves as an API aggregation layer.
 	# Get instances
 	kubectl kudo get instances [flags]
 
+	# Delete an instance
+	kubectl kudo delete instance <name>
+
 	# View plan status
 	kubectl kudo plan status [flags]
 
@@ -38,8 +41,9 @@ and serves as an API aggregation layer.
 		Version: version.Get().GitVersion,
 	}
 
-	cmd.AddCommand(NewInstallCmd())
+	cmd.AddCommand(NewDeleteCmd())
 	cmd.AddCommand(NewGetCmd())
+	cmd.AddCommand(NewInstallCmd())
 	cmd.AddCommand(NewPlanCmd())
 	cmd.AddCommand(NewVersionCmd())
 

--- a/pkg/kudoctl/util/kudo/kudo.go
+++ b/pkg/kudoctl/util/kudo/kudo.go
@@ -202,3 +202,15 @@ func (c *Client) InstallInstanceObjToCluster(obj *v1alpha1.Instance) (*v1alpha1.
 	}
 	return createdObj, nil
 }
+
+// DeleteInstanceFromCluster expects a valid Instance name to delete
+func (c *Client) DeleteInstanceFromCluster(name string) error {
+	var zero int64
+	policy := v1.DeletePropagationForeground
+	delOptions := &v1.DeleteOptions{
+		GracePeriodSeconds: &zero,
+		PropagationPolicy:  &policy,
+	}
+
+	return c.clientset.KudoV1alpha1().Instances(vars.Namespace).Delete(name, delOptions)
+}


### PR DESCRIPTION
**What type of PR is this?**
> /component kudoctl

**What this PR does / why we need it**:
This PR adds a "kudoctl delete" command that removes a given framework instance.

**Which issue(s) this PR fixes**:
Fixes #226 

**Does this PR introduce a user-facing change?**:
```release-note
This PR adds a "kudoctl delete" command that can be used to uninstall a framework instance.
``