### PR TITLE
Blogpost: Fixing homebrew tap cmd

### DIFF
--- a/site/content/posts/announcing-kudo-0.2.0.md
+++ b/site/content/posts/announcing-kudo-0.2.0.md
@@ -48,7 +48,7 @@ This is more consistent with tooling such as Helm.
 A Homebrew tap is now available for the KUDO kubectl Plugin. To use it, simply tap the repo and install:
 
 ```
-$ homebrew tap kudobuilder/tap
+$ brew tap kudobuilder/tap
 $ brew install kudo-cli
 ```
 


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
/kind documentation

**What this PR does / why we need it**:

Small fix for the actual command that is not `homebrew` but `brew`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```