### PR TITLE
Allow kudo-manager-role to modify persistentvolumeclaims to fix ZK

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -40,7 +40,7 @@ This document demonstrates how to use the CLI but also shows what happens in `KU
 
 You can either install the CLI plugin using `brew`:
 
-- `homebrew tap kudobuilder/tap`
+- `brew tap kudobuilder/tap`
 - `brew install kudo-cli`
 
 Or you can use compile and install the plugin from your `$GOPATH/src/github.com/kudobuilder/kudo` root folder via:
@@ -69,19 +69,10 @@ Flags:
   -h, --help                      help for install
       --instance string           The instance name. (default to Framework name)
       --kubeconfig string         The file path to Kubernetes configuration file. (default "$HOME/.kube/config")
-      --namespace string          The namespace where the operator watches for changes. (default to (default "default")
+      --namespace string          The namespace used for the framework installation. (default "default" (default "default")
       --package-version string    A specific package version on the official GitHub repo. (default to the most recent)
-  -p, --parameter stringArray     The parameter name.
+  -p, --parameter stringArray     The parameter name and value separated by '='
 ```
-
-## Environment Variables
-
-Environment Variables override flags and are intended to give the user more customizable CLI options.
-
-|  Environment Variable | Description  |
-|---|---|
-| `GIT_USER`  |  Set a GitHub user to connect via the GitHub API with |
-| `GIT_PASSWORD` | Set a GitHub password to connect via the GitHub API with |
 
 ## Examples
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -69,7 +69,7 @@ Flags:
   -h, --help                      help for install
       --instance string           The instance name. (default to Framework name)
       --kubeconfig string         The file path to Kubernetes configuration file. (default "$HOME/.kube/config")
-      --namespace string          The namespace used for the framework installation. (default "default" (default "default")
+      --namespace string          The namespace used for the framework installation. (default "default")
       --package-version string    A specific package version on the official GitHub repo. (default to the most recent)
   -p, --parameter stringArray     The parameter name and value separated by '='
 ```

--- a/docs/deployment/00-prereqs.yaml
+++ b/docs/deployment/00-prereqs.yaml
@@ -64,6 +64,7 @@ rules:
   resources:
   - configmaps
   - events
+  - persistentvolumeclaims
   verbs:
   - get
   - list

--- a/docs/deployment/00-prereqs.yaml
+++ b/docs/deployment/00-prereqs.yaml
@@ -64,7 +64,6 @@ rules:
   resources:
   - configmaps
   - events
-  - persistentvolumeclaims
   verbs:
   - get
   - list


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The Zookeeper sample fails with `Failed to list *v1.PersistentVolumeClaim: persistentvolumeclaims is forbidden: User "system:serviceaccount:kudo-system:kudo-manager" cannot list resource "persistentvolumeclaims" in API group "" at the cluster scope`

This PR adds an authorization for `persistentvolumeclaims` to the `ClusterRole` and cleans up the docs.