### PR TITLE
Make the CI run again after git-credentials removal

### DIFF
--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,7 +1,6 @@
 FROM kudobuilder/golang:1.12
 
 WORKDIR $GOPATH/src/github.com/kudobuilder/kudo
-COPY test/.git-credentials .git-credentials
 
 COPY Makefile go.mod go.sum ./
 RUN make download

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -8,6 +8,4 @@ COPY config/ config/
 COPY pkg/ pkg/
 COPY cmd/ cmd/
 
-RUN cp .git-credentials ~/.git-credentials
-
 ENTRYPOINT make test

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -6,6 +6,7 @@ then
    docker run kudo-test
 else
     echo "Error when building test docker image, cannot run tests."
+    exit 1
 fi
 
 DOCKER_EXIT_CODE=$?


### PR DESCRIPTION
All CI runs now look like this:

```
Step 3/10 : COPY test/.git-credentials .git-credentials
COPY failed: stat /var/lib/docker/tmp/docker-builder611541570/test/.git-credentials: no such file or directory
Error when building test docker image, cannot run tests.
Tests finished successfully! ヽ(•‿•)ノ
```