### PR TITLE
Improve getting started and contributing docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,9 +40,9 @@ When updating the structs under [APIs](https://github.com/kudobuilder/kudo/blob/
 After updating CRD manifests, use `make deploy` to apply the new CRDs to your cluster.
 
 ### Build and run tests using Docker
-If you don't want to install kubebuilder and other dependencies of KUDO locally, you can optionally do as our CI and build KUDO and run the tests inside a Docker container.
+If you don't want to install kubebuilder and other dependencies of KUDO locally, you can build KUDO and run the tests inside a Docker container.
 
-To run tests, you can just execute:
+To run tests inside a Docker container, you can just execute:
 
 `./test/run_tests.sh`
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,26 +22,25 @@ Please see [https://git.k8s.io/community/CLA.md](https://git.k8s.io/community/CL
 
 ### Pre-requisites
 
-Before you get started:
-
-- Install Go `1.12.3` or later
-- [Install Kubebuilder](https://book.kubebuilder.io/getting_started/installation_and_setup.html)
-- Kubernetes Cluster `1.13` or later (e.g. [Minikube](https://kubernetes.io/docs/tasks/tools/install-minikube/))
-- [Configure kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) 
+- Git
+- Go `1.12.3` or later
+- [Kubebuilder](https://book.kubebuilder.io/getting_started/installation_and_setup.html)
+- A Kubernetes Cluster running version `1.13` or later (e.g., [Minikube](https://kubernetes.io/docs/tasks/tools/install-minikube/))
+- [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
 
 ### Build Instructions
 
-- Get KUDO repo: `go get github.com/kudobuilder/kudo/`
+- Get the KUDO repo: `go get github.com/kudobuilder/kudo/` (**Note:** KUDO uses Go Modules. Due to the current state of code generation in [controller-tools](https://github.com/kubernetes-sigs/controller-tools) and [code-generator](https://github.com/kubernetes/code-generator), KUDO currently **must** be cloned into its `$GOPATH`-based location)
 - `cd $GOPATH/src/github.com/kudobuilder/kudo`
 - `make all` to build project
-- [optionally] `make docker-build` to build docker images and `make docker-push` to push images
+- [optionally] `make docker-build` to build Docker images and `make docker-push` to push images
 
-When updating the structs under APIs, or any other code generated item, use `make generate` to generate the new DeepCopy structs. Use `make manifests` to generate out new YAML manifests representing these CRDs.
+When updating the structs under [APIs](https://github.com/kudobuilder/kudo/blob/master/pkg/apis/), or any other code generated item, use `make generate` to generate the new DeepCopy structs. Use `make manifests` to generate out new YAML manifests representing these CRDs.
 
 After updating CRD manifests, use `make deploy` to apply the new CRDs to your cluster.
 
-### Build and run tests using docker
-If you don't want to install kubebuilder and other dependencies of KUDO locally, you can optionally run build and tests inside a docker container which is what our CI does.
+### Build and run tests using Docker
+If you don't want to install kubebuilder and other dependencies of KUDO locally, you can optionally do as our CI and build KUDO and run the tests inside a Docker container.
 
 To run tests, you can just execute:
 
@@ -70,6 +69,7 @@ An enhancement is anything that:
 - users will notice and come to rely on
 
 It is unlikely an enhancement if it is:
+
 - fixing a flaky test
 - refactoring code
 - performance improvements, which are only visible to users as faster API operations, or faster control loops
@@ -80,6 +80,7 @@ If you are not sure, ask someone in the [#kudo](https://kubernetes.slack.com/mes
 ### When to Create a New Enhancement Issue
 
 Create an issue in this repo once you:
+
 - have circulated your idea to see if there is interest
    - through Community Meetings, KUDO meetings, KUDO mailing lists, or an issue in github.com/kudobuilder/kudo
 - (optionally) have done a prototype in your own fork

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,10 +30,10 @@ Please see [https://git.k8s.io/community/CLA.md](https://git.k8s.io/community/CL
 
 ### Build Instructions
 
-- Get the KUDO repo: `go get github.com/kudobuilder/kudo/` (**Note:** KUDO uses Go Modules. Due to the current state of code generation in [controller-tools](https://github.com/kubernetes-sigs/controller-tools) and [code-generator](https://github.com/kubernetes/code-generator), KUDO currently **must** be cloned into its `$GOPATH`-based location)
-- `cd $GOPATH/src/github.com/kudobuilder/kudo`
+- Get the KUDO repo: `git clone https://github.com/kudobuilder/kudo.git`
+- `cd kudo`
 - `make all` to build project
-- [optionally] `make docker-build` to build Docker images and `make docker-push` to push images
+- [optionally] `make docker-build` to build the Docker images
 
 When updating the structs under [APIs](https://github.com/kudobuilder/kudo/blob/master/pkg/apis/), or any other code generated item, use `make generate` to generate the new DeepCopy structs. Use `make manifests` to generate out new YAML manifests representing these CRDs.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -19,7 +19,7 @@ Before you get started:
 - `kubectl create -f https://raw.githubusercontent.com/kudobuilder/kudo/master/docs/deployment/10-crds.yaml`
 - `kubectl create -f https://raw.githubusercontent.com/kudobuilder/kudo/master/docs/deployment/20-deployment.yaml`
 
-If you want to use the KUDO kubctl plugin, you can now follow the [CLI plugin installation instructions](https://kudo.dev/docs/cli/).
+If you want to use the KUDO kubectl plugin, you can now follow the [CLI plugin installation instructions](https://kudo.dev/docs/cli/).
 
 ### Notes on Minikube
 If you plan on developing and testing KUDO locally via Minikube, you'll need to launch your cluster with a reasonable amount of memory allocated.  By default, this is only 2GB - we recommend at least 8GB, especially if you're working with applications such as [Kafka](/docs/examples/apache-kafka/).  You can start Minikube with some suitable resource adjustments as follows:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -10,24 +10,16 @@ weight: 1
 
 Before you get started:
 
-- Install Git
-- Install Go `1.12.3` or later
-- This project uses [Go Modules](https://github.com/golang/go/wiki/Modules). Set `GO111MODULE=on` in your environment.
 - Kubernetes Cluster `1.13` or later (e.g. [Minikube](https://kubernetes.io/docs/tasks/tools/install-minikube/))
 - [Install kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) with version `1.13` or later
-- [Install Kustomize](https://github.com/kubernetes-sigs/kustomize/blob/master/docs/INSTALL.md) with version `2.0.3` or later
-
-## Go Modules
-
-> ⚠️ This project uses Go Modules. Due to the current state of code generation in [controller-tools](https://github.com/kubernetes-sigs/controller-tools) and [code-generator](https://github.com/kubernetes/code-generator), KUDO currently **must** be cloned into its `$GOPATH`-based location.
 
 ## Install KUDO into your cluster
 
-- Get KUDO repo: `git clone git@github.com:kudobuilder/kudo.git`
-- `cd kudo`
-- `kubectl create -f docs/deployment/00-prereqs.yaml`
-- `kubectl create -f docs/deployment/10-crds.yaml`
-- `kubectl create -f docs/deployment/20-deployment.yaml`
+- `kubectl create -f https://raw.githubusercontent.com/kudobuilder/kudo/master/docs/deployment/00-prereqs.yaml`
+- `kubectl create -f https://raw.githubusercontent.com/kudobuilder/kudo/master/docs/deployment/10-crds.yaml`
+- `kubectl create -f https://raw.githubusercontent.com/kudobuilder/kudo/master/docs/deployment/20-deployment.yaml`
+
+If you want to use the KUDO kubctl plugin, you can now follow the [CLI plugin installation instructions](https://kudo.dev/docs/cli/).
 
 ### Notes on Minikube
 If you plan on developing and testing KUDO locally via Minikube, you'll need to launch your cluster with a reasonable amount of memory allocated.  By default, this is only 2GB - we recommend at least 8GB, especially if you're working with applications such as [Kafka](/docs/examples/apache-kafka/).  You can start Minikube with some suitable resource adjustments as follows:
@@ -35,10 +27,6 @@ If you plan on developing and testing KUDO locally via Minikube, you'll need to 
 ``` shell
 minikube start --cpus=4 --memory=8192 --disk-size=40g
 ```
-
-**Before** `kubectl apply -f config/crds` you will need to have:
-
- * minikube running
 
 ## Deploy your first Application
 


### PR DESCRIPTION
**What type of PR is this?**
> /kind documentation

**What this PR does / why we need it**:
Simplifies the getting started doc, trying to streamline the installation process minimizing the number of steps/dependencies required to get started with KUDO.

This PR also improves the documentation on how to build KUDO and start contributing to the project.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```