### PR TITLE
Fail on lint errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ vet:
 # Run go lint against code
 lint:
 	go install golang.org/x/lint/golint
-	golint ./pkg/... ./cmd/...
+	golint -set_exit_status ./pkg/... ./cmd/...
 
 .PHONY: staticcheck
 # Runs static check


### PR DESCRIPTION
`go lint` does not fail on errors by default without `-set_exit_status` present.