### PR TITLE
Fix error reported by linter

### DIFF
--- a/pkg/kudoctl/cmd/install/install.go
+++ b/pkg/kudoctl/cmd/install/install.go
@@ -25,7 +25,7 @@ type Options struct {
 	KubeConfigPath  string
 }
 
-// NewOptions initializes the install command options to its defaults
+// DefaultOptions initializes the install command options to its defaults
 var DefaultOptions = &Options{
 	Namespace: "default",
 }


### PR DESCRIPTION
**What type of PR is this?**
> /kind cleanup

**What this PR does / why we need it**:
Fix error found by the linter. `make lint` passes after applying this patch.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```