### PR TITLE
Refactored install parameters

### DIFF
--- a/pkg/kudoctl/cmd/install.go
+++ b/pkg/kudoctl/cmd/install.go
@@ -2,8 +2,10 @@ package cmd
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/kudobuilder/kudo/pkg/kudoctl/cmd/install"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -19,15 +21,51 @@ var (
 		kubectl kudo install kafka --package-version=0`
 )
 
+// parseParameters parse raw parameter strings into a map of keys and values
+func parseParameters(raw []string, parameters map[string]string) error {
+	var errs []string
+
+	for _, a := range raw {
+		// Using '=' as the delimiter. Split after the first delimiter to support using '=' in values
+		s := strings.SplitN(a, "=", 2)
+		if len(s) < 2 {
+			errs = append(errs, fmt.Sprintf("parameter not set: %+v", a))
+			continue
+		}
+		if s[0] == "" {
+			errs = append(errs, fmt.Sprintf("parameter name can not be empty: %+v", a))
+			continue
+		}
+		if s[1] == "" {
+			errs = append(errs, fmt.Sprintf("parameter value can not be empty: %+v", a))
+			continue
+		}
+		parameters[s[0]] = s[1]
+	}
+
+	if errs != nil {
+		return errors.New(strings.Join(errs, ", "))
+	}
+
+	return nil
+}
+
 // newInstallCmd creates the install command for the CLI
 func newInstallCmd() *cobra.Command {
 	options := install.DefaultOptions
+	var parameters []string
 	installCmd := &cobra.Command{
 		Use:     "install <name>",
 		Short:   "-> Install an official KUDO package.",
 		Long:    `Install a KUDO package from the official GitHub repo.`,
 		Example: installExample,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// Prior to command execution we parse and validate passed parameters
+			options.Parameters = make(map[string]string)
+			if err := parseParameters(parameters, options.Parameters); err != nil {
+				return errors.WithMessage(err, "could not parse parameters")
+			}
+
 			return install.Run(cmd, args, options)
 		},
 		SilenceUsage: true,
@@ -38,7 +76,7 @@ func newInstallCmd() *cobra.Command {
 	installCmd.Flags().StringVar(&options.KubeConfigPath, "kubeconfig", "", "The file path to Kubernetes configuration file. (default \"$HOME/.kube/config\")")
 	installCmd.Flags().StringVar(&options.InstanceName, "instance", "", "The instance name. (default to Framework name)")
 	installCmd.Flags().StringVar(&options.Namespace, "namespace", "default", "The namespace used for the package installation. (default \"default\"")
-	installCmd.Flags().StringArrayVarP(&options.Parameters, "parameter", "p", nil, "The parameter name and value separated by '='")
+	installCmd.Flags().StringArrayVarP(&parameters, "parameter", "p", nil, "The parameter name and value separated by '='")
 	installCmd.Flags().StringVar(&options.PackageVersion, "package-version", "", "A specific package version on the official GitHub repo. (default to the most recent)")
 
 	const usageFmt = "Usage:\n  %s\n\nFlags:\n%s"

--- a/pkg/kudoctl/cmd/install.go
+++ b/pkg/kudoctl/cmd/install.go
@@ -22,8 +22,9 @@ var (
 )
 
 // parseParameters parse raw parameter strings into a map of keys and values
-func parseParameters(raw []string, parameters map[string]string) error {
+func parseParameters(raw []string) (map[string]string, error) {
 	var errs []string
+	parameters := make(map[string]string)
 
 	for _, a := range raw {
 		// Using '=' as the delimiter. Split after the first delimiter to support using '=' in values
@@ -44,10 +45,10 @@ func parseParameters(raw []string, parameters map[string]string) error {
 	}
 
 	if errs != nil {
-		return errors.New(strings.Join(errs, ", "))
+		return nil, errors.New(strings.Join(errs, ", "))
 	}
 
-	return nil
+	return parameters, nil
 }
 
 // newInstallCmd creates the install command for the CLI
@@ -61,8 +62,9 @@ func newInstallCmd() *cobra.Command {
 		Example: installExample,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Prior to command execution we parse and validate passed parameters
-			options.Parameters = make(map[string]string)
-			if err := parseParameters(parameters, options.Parameters); err != nil {
+			var err error
+			options.Parameters, err = parseParameters(parameters)
+			if err != nil {
 				return errors.WithMessage(err, "could not parse parameters")
 			}
 


### PR DESCRIPTION
Summary:
- parameter parsing and validation now happens prior to the `install` command execution
- install `Options.Parameters` is now a map with keys and values (`map[string]string`) 

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kudo/blob/master/CONTRIBUTING.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kudobuilder/kudo/blob/master/RELEASE.md
3. Ensure you have added or ran the appropriate tests for your PR
4. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /component generator

/component kudoctl
> /component operator
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind feature
> /kind enhancement
> /kind infrastructure
> /kind kep

<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```