### PR TITLE
[test harness] Use the test utils CreateOrUpdate method to update CRDs and manifests.

### DIFF
--- a/pkg/test/utils/kubernetes.go
+++ b/pkg/test/utils/kubernetes.go
@@ -252,7 +252,7 @@ func InstallManifests(ctx context.Context, client client.Client, dClient discove
 				}
 			}
 
-			if err := client.Create(ctx, obj); err != nil {
+			if err := CreateOrUpdate(ctx, client, obj, true); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Previously, the test harness would exit with failure if it was asked to install CRDs or manifests prior to running.

This PR uses the testutils CreateOrUpdate method to update the resources if they already exist.

**Does this PR introduce a user-facing change?**:

```release-note
* Test harness will now update CRDs and Frameworks before being run, rather than exiting with failure.
```