### PR TITLE
Hide integration tests behind the integration build tag.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,22 @@ When updating the structs under [APIs](https://github.com/kudobuilder/kudo/blob/
 
 After updating CRD manifests, use `make deploy` to apply the new CRDs to your cluster.
 
+#### Testing
+
+You can run the unit tests:
+
+```
+make test
+```
+
+Or the integration tests:
+
+```
+make integration-test
+```
+
+See [the testing documentation](https://kudo.dev/docs/testing) for more details.
+
 ### Build and run tests using Docker
 If you don't want to install kubebuilder and other dependencies of KUDO locally, you can build KUDO and run the tests inside a Docker container.
 

--- a/Makefile
+++ b/Makefile
@@ -24,10 +24,15 @@ all: test manager
 test:
 	go test ./pkg/... ./cmd/... -v -mod=readonly -coverprofile cover.out
 
+.PHONY: integration-test
+# Run integration tests
+integration-test:
+	go test -tags integration ./pkg/... ./cmd/... -v -mod=readonly -coverprofile cover-integration.out
+
 .PHONY: test-clean
 # Clean test reports
 test-clean:
-	rm -f cover.out
+	rm -f cover.out cover-integration.out
 
 .PHONY: check-formatting
 check-formatting: vet lint staticcheck

--- a/pkg/test/case_test.go
+++ b/pkg/test/case_test.go
@@ -220,15 +220,3 @@ func TestCollectTestStepFiles(t *testing.T) {
 		})
 	}
 }
-
-func TestRunWithKudo(t *testing.T) {
-	harness := Harness{
-		T:                 t,
-		CRDDir:            "../../config/crds/",
-		ManifestsDir:      "../../config/samples/test-framework/",
-		TestDirs:          []string{"./test_data/"},
-		StartControlPlane: true,
-	}
-
-	harness.Run()
-}

--- a/pkg/test/harness_integration_test.go
+++ b/pkg/test/harness_integration_test.go
@@ -1,0 +1,19 @@
+// +build integration
+
+package test
+
+import (
+	"testing"
+)
+
+func TestRunWithKudo(t *testing.T) {
+	harness := Harness{
+		T:                 t,
+		CRDDir:            "../../config/crds/",
+		ManifestsDir:      "../../config/samples/test-framework/",
+		TestDirs:          []string{"./test_data/"},
+		StartControlPlane: true,
+	}
+
+	harness.Run()
+}

--- a/pkg/test/utils/kubernetes_integration_test.go
+++ b/pkg/test/utils/kubernetes_integration_test.go
@@ -1,0 +1,62 @@
+// +build integration
+
+package utils
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+)
+
+func TestCreateOrUpdate(t *testing.T) {
+	env := &envtest.Environment{}
+
+	config, err := env.Start()
+	assert.Nil(t, err)
+
+	defer env.Stop()
+
+	client, err := client.New(config, client.Options{})
+	assert.Nil(t, err)
+
+	// Run the test a bunch of times to try to trigger a conflict and ensure that it handles conflicts properly.
+	for i := 0; i < 10; i++ {
+		depToUpdate := WithSpec(NewPod("update-me", fmt.Sprintf("default-%d", i)), map[string]interface{}{
+			"containers": []map[string]interface{}{
+				{
+					"image": "nginx",
+					"name":  "nginx",
+				},
+			},
+		})
+
+		assert.Nil(t, CreateOrUpdate(context.TODO(), client, SetAnnotation(depToUpdate, "test", "hi"), true))
+
+		quit := make(chan bool)
+
+		go func() {
+			for {
+				select {
+				case <-quit:
+					return
+				default:
+					CreateOrUpdate(context.TODO(), client, SetAnnotation(depToUpdate, "test", fmt.Sprintf("%d", i)), false)
+					time.Sleep(time.Millisecond * 75)
+				}
+			}
+		}()
+
+		time.Sleep(time.Millisecond * 50)
+
+		assert.Nil(t, CreateOrUpdate(context.TODO(), client, SetAnnotation(depToUpdate, "test", "hello"), true))
+
+		quit <- true
+	}
+}

--- a/pkg/test/utils/kubernetes_integration_test.go
+++ b/pkg/test/utils/kubernetes_integration_test.go
@@ -9,8 +9,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"k8s.io/apimachinery/pkg/api/meta"
-	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 )

--- a/pkg/test/utils/kubernetes_test.go
+++ b/pkg/test/utils/kubernetes_test.go
@@ -1,16 +1,11 @@
 package utils
 
 import (
-	"context"
-	"fmt"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/envtest"
 )
 
 func TestNamespaced(t *testing.T) {
@@ -49,51 +44,5 @@ func TestNamespaced(t *testing.T) {
 			assert.Equal(t, namespace, actualNamespace)
 			assert.Equal(t, namespace, m.GetNamespace())
 		})
-	}
-}
-
-func TestCreateOrUpdate(t *testing.T) {
-	env := &envtest.Environment{}
-
-	config, err := env.Start()
-	assert.Nil(t, err)
-
-	defer env.Stop()
-
-	client, err := client.New(config, client.Options{})
-	assert.Nil(t, err)
-
-	// Run the test a bunch of times to try to trigger a conflict and ensure that it handles conflicts properly.
-	for i := 0; i < 10; i++ {
-		depToUpdate := WithSpec(NewPod("update-me", fmt.Sprintf("default-%d", i)), map[string]interface{}{
-			"containers": []map[string]interface{}{
-				{
-					"image": "nginx",
-					"name":  "nginx",
-				},
-			},
-		})
-
-		assert.Nil(t, CreateOrUpdate(context.TODO(), client, SetAnnotation(depToUpdate, "test", "hi"), true))
-
-		quit := make(chan bool)
-
-		go func() {
-			for {
-				select {
-				case <-quit:
-					return
-				default:
-					CreateOrUpdate(context.TODO(), client, SetAnnotation(depToUpdate, "test", fmt.Sprintf("%d", i)), false)
-					time.Sleep(time.Millisecond * 75)
-				}
-			}
-		}()
-
-		time.Sleep(time.Millisecond * 50)
-
-		assert.Nil(t, CreateOrUpdate(context.TODO(), client, SetAnnotation(depToUpdate, "test", "hello"), true))
-
-		quit <- true
 	}
 }

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -8,4 +8,4 @@ COPY config/ config/
 COPY pkg/ pkg/
 COPY cmd/ cmd/
 
-ENTRYPOINT make test
+ENTRYPOINT make integration-test


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kudo/blob/master/CONTRIBUTING.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kudobuilder/kudo/blob/master/RELEASE.md
3. Ensure you have added or ran the appropriate tests for your PR
4. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This gates integration tests behind the `integration` tag.

To run unit tests: `make test`

To run integration tests: `make integration-test`

**Which issue(s) this PR fixes**:

Fixes #338

**Special notes for your reviewer**:

https://github.com/kudobuilder/kudo/pull/358 removes the rest of the autogenerated integration tests.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```