### PR TITLE
[test harness] Use the test utils CreateOrUpdate method to update CRDs and manifests.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -74,7 +74,7 @@ require (
 	gopkg.in/yaml.v2 v2.2.2
 	honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a
 	k8s.io/api v0.0.0-20181213150558-05914d821849
-	k8s.io/apiextensions-apiserver v0.0.0-20181213153335-0fe22c71c476 // indirect
+	k8s.io/apiextensions-apiserver v0.0.0-20181213153335-0fe22c71c476
 	k8s.io/apimachinery v0.0.0-20181127025237-2b1284ed4c93
 	k8s.io/client-go v0.0.0-20181213151034-8d9ed539ba31
 	k8s.io/code-generator v0.0.0-20181117043124-c2090bec4d9b

--- a/pkg/test/harness.go
+++ b/pkg/test/harness.go
@@ -222,15 +222,15 @@ func (h *Harness) Run() {
 		h.T.Fatal(err)
 	}
 
+	// Install required manifests.
+	if _, err := testutils.InstallManifests(context.TODO(), cl, dClient, h.TestSuite.ManifestsDir); err != nil {
+		h.T.Fatal(err)
+	}
+
 	if h.TestSuite.StartKUDO || h.TestSuite.StartControlPlane {
 		if err := h.RunKUDO(); err != nil {
 			h.T.Fatal(err)
 		}
-	}
-
-	// Install required manifests.
-	if _, err := testutils.InstallManifests(context.TODO(), cl, dClient, h.TestSuite.ManifestsDir); err != nil {
-		h.T.Fatal(err)
 	}
 
 	h.RunTests()

--- a/pkg/test/harness.go
+++ b/pkg/test/harness.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kudobuilder/kudo/pkg/apis"
 	kudo "github.com/kudobuilder/kudo/pkg/apis/kudo/v1alpha1"
 	"github.com/kudobuilder/kudo/pkg/controller"
 	testutils "github.com/kudobuilder/kudo/pkg/test/utils"
@@ -94,36 +93,16 @@ func (h *Harness) Config() (*rest.Config, error) {
 }
 
 // RunKUDO starts the KUDO controllers and installs the required CRDs.
-func (h *Harness) RunKUDO(crdPath string) error {
+func (h *Harness) RunKUDO() error {
 	config, err := h.Config()
 	if err != nil {
 		return err
 	}
 
-	if h.TestSuite.CRDDir != "" {
-		crds, err := envtest.InstallCRDs(config, envtest.CRDInstallOptions{
-			Paths:              []string{h.TestSuite.CRDDir},
-			ErrorIfPathMissing: true,
-		})
-		if err != nil {
-			return err
-		}
-
-		err = envtest.WaitForCRDs(config, crds, envtest.CRDInstallOptions{
-			Paths:              []string{h.TestSuite.CRDDir},
-			ErrorIfPathMissing: true,
-		})
-		if err != nil {
-			return err
-		}
-	}
-
-	mgr, err := manager.New(config, manager.Options{})
+	mgr, err := manager.New(config, manager.Options{
+		Scheme: testutils.Scheme(),
+	})
 	if err != nil {
-		return err
-	}
-
-	if err = apis.AddToScheme(mgr.GetScheme()); err != nil {
 		return err
 	}
 
@@ -142,8 +121,8 @@ func (h *Harness) RunKUDO(crdPath string) error {
 }
 
 // Client returns the current Kubernetes client for the test harness.
-func (h *Harness) Client() (client.Client, error) {
-	if h.client != nil {
+func (h *Harness) Client(forceNew bool) (client.Client, error) {
+	if h.client != nil && !forceNew {
 		return h.client, nil
 	}
 
@@ -152,7 +131,9 @@ func (h *Harness) Client() (client.Client, error) {
 		return nil, err
 	}
 
-	h.client, err = client.New(config, client.Options{})
+	h.client, err = client.New(config, client.Options{
+		Scheme: testutils.Scheme(),
+	})
 	return h.client, err
 }
 
@@ -174,12 +155,12 @@ func (h *Harness) DiscoveryClient() (discovery.DiscoveryInterface, error) {
 // RunTests should be called from within a Go test (t) and launches all of the KUDO integration
 // tests at dir.
 func (h *Harness) RunTests() {
-	cl, err := h.Client()
+	cl, err := h.Client(false)
 	if err != nil {
 		h.T.Fatal(err)
 	}
 
-	dClient, err := h.DiscoveryClient()
+	dclient, err := h.DiscoveryClient()
 	if err != nil {
 		h.T.Fatal(err)
 	}
@@ -197,7 +178,7 @@ func (h *Harness) RunTests() {
 	h.T.Run("harness", func(t *testing.T) {
 		for _, test := range tests {
 			test.Client = cl
-			test.DiscoveryClient = dClient
+			test.DiscoveryClient = dclient
 
 			if err := test.LoadTestSteps(); err != nil {
 				t.Fatal(err)
@@ -215,13 +196,7 @@ func (h *Harness) Run() {
 
 	defer h.Stop()
 
-	if h.TestSuite.StartKUDO || h.TestSuite.StartControlPlane {
-		if err := h.RunKUDO("../../config/crds/"); err != nil {
-			h.T.Fatal(err)
-		}
-	}
-
-	cl, err := h.Client()
+	cl, err := h.Client(false)
 	if err != nil {
 		h.T.Fatal(err)
 	}
@@ -231,7 +206,30 @@ func (h *Harness) Run() {
 		h.T.Fatal(err)
 	}
 
-	if err := testutils.InstallManifests(context.TODO(), cl, dClient, h.TestSuite.ManifestsDir); err != nil {
+	// Install CRDs
+	crds, err := testutils.InstallManifests(context.TODO(), cl, dClient, h.TestSuite.CRDDir)
+	if err != nil {
+		h.T.Fatal(err)
+	}
+
+	if err := testutils.WaitForCRDs(dClient, crds); err != nil {
+		h.T.Fatal(err)
+	}
+
+	// Create a new client to bust the client's CRD cache.
+	cl, err = h.Client(true)
+	if err != nil {
+		h.T.Fatal(err)
+	}
+
+	if h.TestSuite.StartKUDO || h.TestSuite.StartControlPlane {
+		if err := h.RunKUDO(); err != nil {
+			h.T.Fatal(err)
+		}
+	}
+
+	// Install required manifests.
+	if _, err := testutils.InstallManifests(context.TODO(), cl, dClient, h.TestSuite.ManifestsDir); err != nil {
 		h.T.Fatal(err)
 	}
 

--- a/pkg/test/utils/kubernetes_integration_test.go
+++ b/pkg/test/utils/kubernetes_integration_test.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/client-go/discovery"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 )
@@ -57,4 +59,41 @@ func TestCreateOrUpdate(t *testing.T) {
 
 		quit <- true
 	}
+}
+
+func TestWaitForCRDs(t *testing.T) {
+	env := &envtest.Environment{}
+
+	config, err := env.Start()
+	assert.Nil(t, err)
+
+	defer env.Stop()
+
+	cl, err := client.New(config, client.Options{
+		Scheme: Scheme(),
+	})
+	assert.Nil(t, err)
+	dClient, err := discovery.NewDiscoveryClientForConfig(config)
+	assert.Nil(t, err)
+
+	instance := NewResource("kudo.k8s.io/v1alpha1", "Instance", "zk", "ns")
+
+	// Verify that we cannot create the instance, because the test environment is empty.
+	assert.IsType(t, &meta.NoKindMatchError{}, cl.Create(context.TODO(), instance))
+
+	// Install all of the CRDs.
+	crds, err := InstallManifests(context.TODO(), cl, dClient, "../../../config/crds/")
+	assert.Nil(t, err)
+
+	// WaitForCRDs to be created.
+	assert.Nil(t, WaitForCRDs(dClient, crds))
+
+	// Kubernetes client caches the types, se we need to re-initialize it.
+	cl, err = client.New(config, client.Options{
+		Scheme: Scheme(),
+	})
+	assert.Nil(t, err)
+
+	// make sure that we can create an object of this type now
+	assert.Nil(t, cl.Create(context.TODO(), instance))
 }

--- a/pkg/test/utils/kubernetes_test.go
+++ b/pkg/test/utils/kubernetes_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 func TestNamespaced(t *testing.T) {
@@ -45,4 +46,22 @@ func TestNamespaced(t *testing.T) {
 			assert.Equal(t, namespace, m.GetNamespace())
 		})
 	}
+}
+
+func TestGETAPIResource(t *testing.T) {
+	fake := FakeDiscoveryClient()
+
+	apiResource, err := GetAPIResource(fake, schema.GroupVersionKind{
+		Kind:    "Pod",
+		Version: "v1",
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, apiResource.Kind, "Pod")
+
+	apiResource, err = GetAPIResource(fake, schema.GroupVersionKind{
+		Kind:    "NonExistentResourceType",
+		Version: "v1",
+	})
+	assert.NotNil(t, err)
+	assert.Equal(t, err.Error(), "resource type not found")
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Previously, the test harness would exit with failure if it was asked to install CRDs or manifests prior to running that already existed.

This PR uses the testutils CreateOrUpdate method to update the resources if they already exist.

**Does this PR introduce a user-facing change?**:

```release-note
* Test harness will now update CRDs and Frameworks before being run, rather than exiting with failure.
```