### PR TITLE
Update getting-started.md - fixed typo

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -30,4 +30,4 @@ minikube start --cpus=4 --memory=8192 --disk-size=40g
 
 ## Deploy your first Application
 
-Follow the instructions in the [Apache Kafka example](/docs/examples/apache-kafka/) to deploy a Kafka cluster along with its dependency Zookeeper.
+Follow the instructions in the [Apache Kafka example](/docs/examples/apache-kafka.md) to deploy a Kafka cluster along with its dependency Zookeeper.


### PR DESCRIPTION
The Apache Kafka example points towards `/docs/examples/apache-kafka/` instead of the correct target `/docs/examples/apache-kafka.md`

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kudo/blob/master/CONTRIBUTING.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kudobuilder/kudo/blob/master/RELEASE.md
3. Ensure you have added or ran the appropriate tests for your PR
4. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /component generator
> /component kudoctl
> /component operator
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
/kind documentation
> /kind feature
> /kind enhancement
> /kind infrastructure
> /kind kep

**What this PR does / why we need it**:
A fix on the getting started guide
**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```