### PR TITLE
Refactor of bundle

### DIFF
--- a/pkg/kudoctl/cmd/install/install.go
+++ b/pkg/kudoctl/cmd/install/install.go
@@ -108,7 +108,7 @@ func getPackageCRDs(name string, options *Options, repository repo.FrameworkRepo
 	}
 
 	// TODO: Below is repository functionality. All we want is a bundle!
-	// Construct the package name and download the package from the remote repo
+	// Construct the package name and download the index file from the remote repo
 	indexFile, err := repository.DownloadIndexFile()
 	if err != nil {
 		return nil, errors.WithMessage(err, "could not download repository index file: %v")

--- a/pkg/kudoctl/cmd/install/install.go
+++ b/pkg/kudoctl/cmd/install/install.go
@@ -83,7 +83,7 @@ func installFrameworks(args []string, options *Options) error {
 	}
 
 	for _, name := range args {
-		err := installFramework(name, "", *r, kc, options)
+		err := installFramework(name, "", r, kc, options)
 		if err != nil {
 			return err
 		}
@@ -97,7 +97,7 @@ func installFrameworks(args []string, options *Options) error {
 // - a framework name in the remote repository
 // in that order. Should there exist a local folder e.g. `cassandra` it will take precedence
 // over the remote repository package with the same name.
-func getPackageCRDs(name string, options *Options, repository repo.FrameworkRepository) (*repo.PackageCRDs, error) {
+func getPackageCRDs(name string, options *Options, repository repo.Repository) (*repo.PackageCRDs, error) {
 	// Local files/folder have priority
 	if _, err := os.Stat(name); err == nil {
 		b, err := repo.NewBundle(name)
@@ -107,42 +107,17 @@ func getPackageCRDs(name string, options *Options, repository repo.FrameworkRepo
 		return b.GetCRDs()
 	}
 
-	// TODO: Below is repository functionality. All we want is a bundle!
-	// Construct the package name and download the index file from the remote repo
-	indexFile, err := repository.DownloadIndexFile()
-	if err != nil {
-		return nil, errors.WithMessage(err, "could not download repository index file: %v")
-	}
-
-	var bundleVersion *repo.BundleVersion
-
-	if options.PackageVersion == "" {
-		bv, err := indexFile.GetByName(name)
-		if err != nil {
-			return nil, errors.Wrapf(err, "getting %s in index file", name)
-		}
-		bundleVersion = bv
-	} else {
-		bv, err := indexFile.GetByNameAndVersion(name, options.PackageVersion)
-		if err != nil {
-			return nil, errors.Wrapf(err, "getting %s in index file", name)
-		}
-		bundleVersion = bv
-	}
-
-	packageName := bundleVersion.Name + "-" + bundleVersion.Version
-
-	reader, err := repository.GetPackage(packageName)
+	bundle, err := repository.GetPackageBundle(name, options.PackageVersion)
 	if err != nil {
 		return nil, err
 	}
-	return repo.NewBundleFromReader(reader).GetCRDs()
+	return bundle.GetCRDs()
 }
 
 // installFramework is the umbrella for a single framework installation that gathers the business logic
 // for a cluster and returns an error in case there is a problem
 // TODO: needs testing
-func installFramework(name, previous string, repository repo.FrameworkRepository, kc *kudo.Client, options *Options) error {
+func installFramework(name, previous string, repository repo.Repository, kc *kudo.Client, options *Options) error {
 	crds, err := getPackageCRDs(name, options, repository)
 	if err != nil {
 		return errors.Wrapf(err, "failed to install package: %s", name)

--- a/pkg/kudoctl/cmd/install/install.go
+++ b/pkg/kudoctl/cmd/install/install.go
@@ -107,7 +107,7 @@ func getPackageCRDs(name string, options *Options, repository repo.FrameworkRepo
 		return b.GetCRDs()
 	}
 
-	// TODO: Below is repository functionality.   All we want is a bundle!
+	// TODO: Below is repository functionality. All we want is a bundle!
 	// Construct the package name and download the package from the remote repo
 	indexFile, err := repository.DownloadIndexFile()
 	if err != nil {

--- a/pkg/kudoctl/cmd/install/install.go
+++ b/pkg/kudoctl/cmd/install/install.go
@@ -94,7 +94,7 @@ func installFrameworks(args []string, options *Options) error {
 // getPackageCRDs tries to look for package files resolving the framework name to:
 // - a local tar.gz file
 // - a local directory
-// - a framework name in the remote repository (default)
+// - a framework name in the remote repository
 // in that order. Should there exist a local folder e.g. `cassandra` it will take precedence
 // over the remote repository package with the same name.
 func getPackageCRDs(name string, options *Options, repository repo.FrameworkRepository) (*repo.PackageCRDs, error) {

--- a/pkg/kudoctl/cmd/install/install.go
+++ b/pkg/kudoctl/cmd/install/install.go
@@ -187,7 +187,6 @@ func installFramework(name, previous string, repository repo.FrameworkRepository
 
 	}
 
-
 	// Dependencies of the particular FrameworkVersion
 	if options.AllDependencies {
 		dependencyFrameworks, err := repo.GetFrameworkVersionDependencies(crds.FrameworkVersion)
@@ -278,4 +277,3 @@ func installSingleInstanceToCluster(name, previous string, instance *v1alpha1.In
 	fmt.Printf("instance.%s/%s created\n", instance.APIVersion, instance.Name)
 	return nil
 }
-

--- a/pkg/kudoctl/util/repo/bundle.go
+++ b/pkg/kudoctl/util/repo/bundle.go
@@ -1,0 +1,166 @@
+package repo
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"fmt"
+	"github.com/pkg/errors"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// This is an abstraction which abstracts the underlying bundle, which is likely file system or compressed file.
+// There should be a complete separation between retrieving a bundle if not local and working with a bundle.
+
+// todo: Does it belong in this package?   I think it should be separate from the repo... more thoughts   I think bundle and package are tightly coupled and repo is not.
+
+// Bundle is an abstraction of the collection of files that makes up a package.  It is anything we can retrieve the PackageCRDs from.
+type Bundle interface {
+	GetCRDs() (*PackageCRDs, error)
+}
+
+// NewBundle creates the implementation of the bundle based on the path.   The expectation is the bundle
+// is always local .  The path can be relative or absolute location of the bundle.
+func NewBundle(path string) (Bundle, error) {
+	//	make sure file exists
+	fi, err := os.Stat(path)
+	if err != nil {
+		return nil, fmt.Errorf("unsupported file system format %v. Expect either a tar.gz file or a folder", path)
+	}
+	// order of discovery
+	// 1. tarball
+	// 2. file based
+	if fi.Mode().IsRegular() && strings.HasSuffix(path, ".tar.gz") {
+		r, err := getFileReader(path)
+		if err != nil {
+			return nil, err
+		}
+		return tarBundle{r}, nil
+	} else if fi.IsDir() {
+		return fileBundle{path}, nil
+	} else {
+		return nil, fmt.Errorf("unsupported file system format %v. Expect either a tar.gz file or a folder", path)
+	}
+}
+
+func getFileReader(path string) (io.Reader, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	return f, nil
+}
+
+// NewBundleFromReader is a bundle from a reader.  This should only be used when a file cache isn't used.
+func NewBundleFromReader(r io.Reader) Bundle {
+	return tarBundle{r}
+}
+
+type tarBundle struct {
+	reader io.Reader
+}
+
+func (b tarBundle) GetCRDs() (*PackageCRDs, error) {
+
+	p, err := parseTarPackage(b.reader)
+	if err != nil {
+		return nil, errors.Wrap(err, "while extracting package files")
+	}
+	return p.getCRDs()
+}
+
+type fileBundle struct {
+	path string
+}
+
+func (b fileBundle) GetCRDs() (*PackageCRDs, error) {
+	p, err := fromFolder(b.path)
+	if err != nil {
+		return nil, errors.Wrap(err, "while reading package from the file system")
+	}
+	return p.getCRDs()
+}
+
+func fromFolder(packagePath string) (*PackageFiles, error) {
+	result := newPackageFiles()
+	err := filepath.Walk(packagePath, func(path string, file os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if file.IsDir() {
+			// skip directories
+			return nil
+		}
+		if path == packagePath {
+			// skip the root folder, as Walk always starts there
+			return nil
+		}
+		bytes, err := ioutil.ReadFile(path)
+		if err != nil {
+			return err
+		}
+
+		return parsePackageFile(path, bytes, &result)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+func parseTarPackage(r io.Reader) (*PackageFiles, error) {
+	gzr, err := gzip.NewReader(r)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		err := gzr.Close()
+		if err != nil {
+			fmt.Printf("Error when closing gzip reader: %s", err)
+		}
+	}()
+
+	tr := tar.NewReader(gzr)
+
+	result := newPackageFiles()
+	for {
+		header, err := tr.Next()
+
+		switch {
+
+		// if no more files are found return
+		case err == io.EOF:
+			return &result, nil
+
+		// return any other error
+		case err != nil:
+			return nil, err
+
+		// if the header is nil, just skip it (not sure how this happens)
+		case header == nil:
+			continue
+		}
+
+		// check the file type
+		switch header.Typeflag {
+
+		case tar.TypeDir:
+			// we don't need to handle folders, files have folder name in their names and that should be enough
+
+		// if it's a file create it
+		case tar.TypeReg:
+			bytes, err := ioutil.ReadAll(tr)
+			if err != nil {
+				return nil, errors.Wrapf(err, "while reading file from bundle tarball %s", header.Name)
+			}
+
+			err = parsePackageFile(header.Name, bytes, &result)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+}

--- a/pkg/kudoctl/util/repo/bundle.go
+++ b/pkg/kudoctl/util/repo/bundle.go
@@ -16,11 +16,17 @@ import (
 // This is an abstraction which abstracts the underlying bundle, which is likely file system or compressed file.
 // There should be a complete separation between retrieving a bundle if not local and working with a bundle.
 
-// todo: Does it belong in this package?   I think it should be separate from the repo... more thoughts   I think bundle and package are tightly coupled and repo is not.
-
 // Bundle is an abstraction of the collection of files that makes up a package.  It is anything we can retrieve the PackageCRDs from.
 type Bundle interface {
 	GetCRDs() (*PackageCRDs, error)
+}
+
+type tarBundle struct {
+	reader io.Reader
+}
+
+type fileBundle struct {
+	path string
 }
 
 // NewBundle creates the implementation of the bundle based on the path.   The expectation is the bundle
@@ -60,10 +66,6 @@ func NewBundleFromReader(r io.Reader) Bundle {
 	return tarBundle{r}
 }
 
-type tarBundle struct {
-	reader io.Reader
-}
-
 func (b tarBundle) GetCRDs() (*PackageCRDs, error) {
 
 	p, err := parseTarPackage(b.reader)
@@ -71,10 +73,6 @@ func (b tarBundle) GetCRDs() (*PackageCRDs, error) {
 		return nil, errors.Wrap(err, "while extracting package files")
 	}
 	return p.getCRDs()
-}
-
-type fileBundle struct {
-	path string
 }
 
 func (b fileBundle) GetCRDs() (*PackageCRDs, error) {

--- a/pkg/kudoctl/util/repo/bundle.go
+++ b/pkg/kudoctl/util/repo/bundle.go
@@ -4,12 +4,13 @@ import (
 	"archive/tar"
 	"compress/gzip"
 	"fmt"
-	"github.com/pkg/errors"
 	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/pkg/errors"
 )
 
 // This is an abstraction which abstracts the underlying bundle, which is likely file system or compressed file.

--- a/pkg/kudoctl/util/repo/package.go
+++ b/pkg/kudoctl/util/repo/package.go
@@ -36,7 +36,6 @@ type PackageFiles struct {
 	Params    []v1alpha1.Parameter
 }
 
-
 func parsePackageFile(filePath string, fileBytes []byte, currentPackage *PackageFiles) error {
 	isFrameworkFile := func(name string) bool {
 		return strings.HasSuffix(name, frameworkFileName)

--- a/pkg/kudoctl/util/repo/package.go
+++ b/pkg/kudoctl/util/repo/package.go
@@ -1,13 +1,7 @@
 package repo
 
 import (
-	"archive/tar"
-	"compress/gzip"
 	"fmt"
-	"io"
-	"io/ioutil"
-	"os"
-	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -42,75 +36,6 @@ type PackageFiles struct {
 	Params    []v1alpha1.Parameter
 }
 
-// ReadTarGzPackage reads package from tarball and converts it to the CRD format
-func ReadTarGzPackage(r io.Reader) (*PackageCRDs, error) {
-	p, err := parsePackage(r)
-	if err != nil {
-		return nil, errors.Wrap(err, "while extracting package files")
-	}
-	return p.getCRDs()
-}
-
-// ReadFileSystemPackage reads package from filesystem and converts it to the CRD format
-func ReadFileSystemPackage(path string) (*PackageCRDs, error) {
-	isTarGz := func() bool {
-		if fi, err := os.Stat(path); err == nil {
-			return fi.Mode().IsRegular() && strings.HasSuffix(path, ".tar.gz")
-		}
-		return false
-	}
-
-	isFolder := func() bool {
-		if fi, err := os.Stat(path); err == nil {
-			return fi.IsDir()
-		}
-		return false
-	}
-
-	switch {
-	case isTarGz():
-		f, err := os.Open(path)
-		if err != nil {
-			return nil, err
-		}
-		return ReadTarGzPackage(f)
-	case isFolder():
-		p, err := fromFolder(path)
-		if err != nil {
-			return nil, errors.Wrap(err, "while reading package from the file system")
-		}
-		return p.getCRDs()
-	default:
-		return nil, fmt.Errorf("unsupported file system format %v. Expect either a tar.gz file or a folder", path)
-	}
-}
-
-func fromFolder(packagePath string) (*PackageFiles, error) {
-	result := newPackageFiles()
-	err := filepath.Walk(packagePath, func(path string, file os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		if file.IsDir() {
-			// skip directories
-			return nil
-		}
-		if path == packagePath {
-			// skip the root folder, as Walk always starts there
-			return nil
-		}
-		bytes, err := ioutil.ReadFile(path)
-		if err != nil {
-			return err
-		}
-
-		return parsePackageFile(path, bytes, &result)
-	})
-	if err != nil {
-		return nil, err
-	}
-	return &result, nil
-}
 
 func parsePackageFile(filePath string, fileBytes []byte, currentPackage *PackageFiles) error {
 	isFrameworkFile := func(name string) bool {
@@ -154,60 +79,6 @@ func parsePackageFile(filePath string, fileBytes []byte, currentPackage *Package
 		return fmt.Errorf("unexpected file when reading package from filesystem: %s", filePath)
 	}
 	return nil
-}
-
-func parsePackage(r io.Reader) (*PackageFiles, error) {
-	gzr, err := gzip.NewReader(r)
-	if err != nil {
-		return nil, err
-	}
-	defer func() {
-		err := gzr.Close()
-		if err != nil {
-			fmt.Printf("Error when closing gzip reader: %s", err)
-		}
-	}()
-
-	tr := tar.NewReader(gzr)
-
-	result := newPackageFiles()
-	for {
-		header, err := tr.Next()
-
-		switch {
-
-		// if no more files are found return
-		case err == io.EOF:
-			return &result, nil
-
-		// return any other error
-		case err != nil:
-			return nil, err
-
-		// if the header is nil, just skip it (not sure how this happens)
-		case header == nil:
-			continue
-		}
-
-		// check the file type
-		switch header.Typeflag {
-
-		case tar.TypeDir:
-			// we don't need to handle folders, files have folder name in their names and that should be enough
-
-		// if it's a file create it
-		case tar.TypeReg:
-			bytes, err := ioutil.ReadAll(tr)
-			if err != nil {
-				return nil, errors.Wrapf(err, "while reading file from bundle tarball %s", header.Name)
-			}
-
-			err = parsePackageFile(header.Name, bytes, &result)
-			if err != nil {
-				return nil, err
-			}
-		}
-	}
 }
 
 func newPackageFiles() PackageFiles {

--- a/pkg/kudoctl/util/repo/package_test.go
+++ b/pkg/kudoctl/util/repo/package_test.go
@@ -27,7 +27,11 @@ func TestReadFileSystemPackage(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(fmt.Sprintf("%s-from-%s", tt.name, tt.path), func(t *testing.T) {
-			actual, err := ReadFileSystemPackage(tt.path)
+			bundle, err := NewBundle(tt.path)
+			if err != nil {
+				t.Fatalf("Found unexpected error: %v", err)
+			}
+			actual, err := bundle.GetCRDs()
 			if err != nil {
 				t.Fatalf("Found unexpected error: %v", err)
 			}

--- a/pkg/kudoctl/util/repo/repo_framework.go
+++ b/pkg/kudoctl/util/repo/repo_framework.go
@@ -2,6 +2,7 @@ package repo
 
 import (
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/url"
 	"strings"
@@ -60,7 +61,7 @@ func (r *FrameworkRepository) DownloadIndexFile() (*IndexFile, error) {
 }
 
 // GetPackage downloads the tgz file from the remote repository and unmarshals it to the package CRDs
-func (r *FrameworkRepository) GetPackage(packageName string) (*PackageCRDs, error) {
+func (r *FrameworkRepository) GetPackage(packageName string) (io.Reader, error) {
 	var fileURL string
 	parsedURL, err := url.Parse(r.Config.URL)
 	if err != nil {
@@ -75,8 +76,7 @@ func (r *FrameworkRepository) GetPackage(packageName string) (*PackageCRDs, erro
 		return nil, errors.Wrap(err, "getting file url")
 	}
 
-	fvPackage, err := ReadTarGzPackage(resp)
-	return fvPackage, err
+	return resp, nil
 }
 
 // GetFrameworkVersionDependencies helper method returns a slice of strings that contains the names of all


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/kind design

**What this PR does / why we need it**:
Refactors bundle (explanation follows)
1. This PR is built around the concept that there are 3 separate abstractions: bundle, packages and repository.  Prior to this PR they were all 3 conflated and bundle wasn't explicit and had more than 1 code path for the same abstraction (tarballs).  From my mental model, a bundle is a way to bundle package files (so they are closely related).   Bundles currently are files and tarballs, but one could also see zip files etc.   
2. This PR is built with the expectation that we should be able to get CRDs (packages) completely separate from how the bundle is found. A bundle could be local, could be a url to a tarball (not implemented), could be discovered in a repository.   This is a completely separate thing and should be tested as such.  The function of the repository code should be to find a path or reader to a bundle (from the perspective of reading a bundle)... that is it.
3. The Bundle interface will likely be a great way of testing by providing a fake or fixture of a Bundle.
4. IMO we should also provide a caching mechanism in the repository discovery.  `.kudo` should be similar to an `/.ivy` or `/.m2`.  With this approach in mind we can further see the separation of discovery from `getCRDs` from a "bundle".
5. I made all internal details private, including what type of `Bundle` it is.

I wanted to get feedback prior to completing.  There is a little cleanup remaining.  At a min, I don't think `bundle` and `package` should be in the `repo` package.   `repo` should have all the stuff for finding and downloading a tarball.   IMO we should have a `package` package :)  or `bundle` package.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```