### PR TITLE
Add -skip-instance flag to kudoctl install to skip installing instances.

### DIFF
--- a/pkg/kudoctl/cmd/install.go
+++ b/pkg/kudoctl/cmd/install.go
@@ -91,6 +91,7 @@ func newInstallCmd() *cobra.Command {
 	installCmd.Flags().StringVar(&options.Namespace, "namespace", "default", "The namespace used for the package installation. (default \"default\"")
 	installCmd.Flags().StringArrayVarP(&parameters, "parameter", "p", nil, "The parameter name and value separated by '='")
 	installCmd.Flags().StringVar(&options.PackageVersion, "package-version", "", "A specific package version on the official GitHub repo. (default to the most recent)")
+	installCmd.Flags().BoolVar(&options.SkipInstance, "skip-instance", false, "If set, install will install the Operator and OperatorVersion, but not an instance. (default \"false\")")
 
 	const usageFmt = "Usage:\n  %s\n\nFlags:\n%s"
 	installCmd.SetUsageFunc(func(cmd *cobra.Command) error {

--- a/pkg/kudoctl/cmd/install/install.go
+++ b/pkg/kudoctl/cmd/install/install.go
@@ -23,6 +23,7 @@ type Options struct {
 	Parameters      map[string]string
 	PackageVersion  string
 	KubeConfigPath  string
+	SkipInstance    bool
 }
 
 // DefaultOptions initializes the install command options to its defaults
@@ -188,6 +189,11 @@ func installOperator(operatorArgument string, isDependencyInstall bool, reposito
 
 	// First make sure that our instance object is up to date with overrides from commandline
 	applyInstanceOverrides(crds.Instance, options, isDependencyInstall)
+
+	// The user opted not to install the instance.
+	if options.SkipInstance {
+		return nil
+	}
 
 	// Check if Instance exists in cluster
 	// It won't create the Instance if any in combination with given Operator Name, OperatorVersion and Instance OperatorName exists


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kudo/blob/master/CONTRIBUTING.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kudobuilder/kudo/blob/master/RELEASE.md
3. Ensure you have added or ran the appropriate tests for your PR
4. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What type of PR is this?**

/component kudoctl
/kind feature

**What this PR does / why we need it**:

This adds a `-skip-instance` flag that allows installing Operators and OperatorVersions without installing Instances. This is useful in a testing scenario - we install all of the Operators and OperatorVersions but don't want to install the Instances until later.

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
kudoctl install now supports -skip-instance flag which skips installing an Instance when installing Operator and OperatorVersions.
```