### PR TITLE
Fix marshalling of patched objects.

### DIFF
--- a/pkg/controller/planexecution/planexecution_controller_test.go
+++ b/pkg/controller/planexecution/planexecution_controller_test.go
@@ -1,0 +1,68 @@
+package planexecution
+
+import (
+	"testing"
+
+	testutils "github.com/kudobuilder/kudo/pkg/test/utils"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func TestPatchObject(t *testing.T) {
+	tests := []struct {
+		name     string
+		actual   runtime.Object
+		expected runtime.Object
+		patch    string
+	}{
+		{
+			name:     "empty patch",
+			actual:   testutils.NewPod("hello", "world"),
+			expected: testutils.NewPod("hello", "world"),
+			patch:    `{"metadata": {"annotations": {}}, "spec": {}}`,
+		},
+		{
+			name:     "add annotations",
+			actual:   testutils.NewPod("hello", "world"),
+			expected: testutils.WithAnnotations(testutils.NewPod("hello", "world"), map[string]string{"app": "nginx"}),
+			patch:    `{"metadata": {"annotations": {"app":"nginx"}}, "spec": {}}`,
+		},
+		{
+			name:     "add spec",
+			actual:   testutils.NewPod("hello", "world"),
+			expected: testutils.WithSpec(testutils.NewPod("hello", "world"), map[string]interface{}{"RestartPolicy": "Always"}),
+			patch:    `{"metadata": {"annotations": {}}, "spec": {"RestartPolicy":"Always"}}`,
+		},
+		{
+			name:     "remove annotations",
+			actual:   testutils.WithAnnotations(testutils.NewPod("hello", "world"), map[string]string{"app": "nginx"}),
+			expected: testutils.NewPod("hello", "world"),
+			patch:    `{"metadata": {"annotations": {}}, "spec": {}}`,
+		},
+		{
+			name:     "remove spec",
+			actual:   testutils.WithSpec(testutils.NewPod("hello", "world"), map[string]interface{}{"RestartPolicy": "Always"}),
+			expected: testutils.NewPod("hello", "world"),
+			patch:    `{"metadata": {"annotations": {}}, "spec": {}}`,
+		},
+		{
+			name:     "change annotations",
+			actual:   testutils.WithAnnotations(testutils.NewPod("hello", "world"), map[string]string{"app": "memcached"}),
+			expected: testutils.WithAnnotations(testutils.NewPod("hello", "world"), map[string]string{"app": "nginx"}),
+			patch:    `{"metadata": {"annotations": {"app":"nginx"}}, "spec": {}}`,
+		},
+		{
+			name:     "change spec",
+			actual:   testutils.WithSpec(testutils.NewPod("hello", "world"), map[string]interface{}{"RestartPolicy": "Never"}),
+			expected: testutils.WithSpec(testutils.NewPod("hello", "world"), map[string]interface{}{"RestartPolicy": "Always"}),
+			patch:    `{"metadata": {"annotations": {}}, "spec": {"RestartPolicy":"Always"}}`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			patch, err := patchObject(tt.expected, tt.actual)
+			assert.Nil(t, err)
+			assert.Equal(t, tt.patch, patch)
+		})
+	}
+}

--- a/pkg/test/utils/kubernetes.go
+++ b/pkg/test/utils/kubernetes.go
@@ -401,6 +401,16 @@ func WithLabels(obj runtime.Object, labels map[string]string) runtime.Object {
 	return obj
 }
 
+// WithAnnotations sets the annotations on an object.
+func WithAnnotations(obj runtime.Object, annotations map[string]string) runtime.Object {
+	obj = obj.DeepCopyObject()
+
+	m, _ := meta.Accessor(obj)
+	m.SetAnnotations(annotations)
+
+	return obj
+}
+
 // FakeDiscoveryClient returns a fake discovery client that is populated with some types for use in
 // unit tests.
 func FakeDiscoveryClient() discovery.DiscoveryInterface {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kudo/blob/master/CONTRIBUTING.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kudobuilder/kudo/blob/master/RELEASE.md
3. Ensure you have added or ran the appropriate tests for your PR
4. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

If the JSON patch returned no annotations or no spec, then the JSON that was created would be invalid.

```
2019/06/27 17:06:46 Going to apply patch
{"metadata": {"annotations": }, "spec": {"clusterIP":null,"ports":[{"name":"client","port":6379,"targetPort":6379},{"name":"gossip","port":16379,"targetPort":16379}],"sessionAffinity":null}}

to object
```

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```