### PR TITLE
Use Kind instead of Singular when looking up types in test harness.

### DIFF
--- a/pkg/test/utils/kubernetes.go
+++ b/pkg/test/utils/kubernetes.go
@@ -506,7 +506,7 @@ func WaitForCRDs(dClient discovery.DiscoveryInterface, crds []runtime.Object) er
 		waitingFor = append(waitingFor, schema.GroupVersionKind{
 			Group:   crd.Spec.Group,
 			Version: crd.Spec.Version,
-			Kind:    crd.Spec.Names.Singular,
+			Kind:    crd.Spec.Names.Kind,
 		})
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kudo/blob/master/CONTRIBUTING.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kudobuilder/kudo/blob/master/RELEASE.md
3. Ensure you have added or ran the appropriate tests for your PR
4. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

The new CRDs that we generated have a `Kind` and `Plural` set, but not `Singular`. It seems like we should use Kind instead.

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```