### PR TITLE
Use KUBECONFIG envvar if set when creating a new client

### DIFF
--- a/pkg/kudoctl/cmd/install/install.go
+++ b/pkg/kudoctl/cmd/install/install.go
@@ -19,10 +19,10 @@ type Options struct {
 	AllDependencies bool
 	AutoApprove     bool
 	InstanceName    string
+	KubeConfigPath  string
 	Namespace       string
 	Parameters      map[string]string
 	PackageVersion  string
-	KubeConfigPath  string
 	SkipInstance    bool
 }
 
@@ -38,6 +38,11 @@ func Run(cmd *cobra.Command, args []string, options *Options) error {
 	// This makes --kubeconfig flag optional
 	if _, err := cmd.Flags().GetString("kubeconfig"); err != nil {
 		return fmt.Errorf("get flag: %+v", err)
+	}
+
+	// If the $KUBECONFIG environment variable is set, use that
+	if len(os.Getenv("KUBECONFIG")) > 0 {
+		options.KubeConfigPath = os.Getenv("KUBECONFIG")
 	}
 
 	configPath, err := check.KubeConfigLocationOrDefault(options.KubeConfigPath)


### PR DESCRIPTION
**What type of PR is this?**
/component kudoctl

**What this PR does / why we need it**:

There's a user expectation that if they've set the `KUBECONFIG` environment variable in their shell to a valid cluster configuration, this should be picked up and used.

**Which issue(s) this PR fixes**:

Fixes #462 

**Does this PR introduce a user-facing change?**:
```release-note
Allow use of KUBECONFIG shell environment variable as a way of specifying target cluster configuration.
```