### PR TITLE
Look for KUBECONFIG environment variable for 'get' and 'plan'

### DIFF
--- a/pkg/kudoctl/cmd/plan/plan_history.go
+++ b/pkg/kudoctl/cmd/plan/plan_history.go
@@ -3,6 +3,7 @@ package plan
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/kudobuilder/kudo/pkg/kudoctl/util/check"
@@ -51,6 +52,11 @@ func runHistory(cmd *cobra.Command, args []string, options *historyOptions) erro
 	instanceFlag, err := cmd.Flags().GetString("instance")
 	if err != nil || instanceFlag == "" {
 		return fmt.Errorf("flag Error: Please set instance flag, e.g. \"--instance=<instanceName>\"")
+	}
+
+	// If the $KUBECONFIG environment variable is set, use that
+	if len(os.Getenv("KUBECONFIG")) > 0 {
+		options.kubeConfigPath = os.Getenv("KUBECONFIG")
 	}
 
 	configPath, err := check.KubeConfigLocationOrDefault(options.kubeConfigPath)

--- a/pkg/kudoctl/cmd/plan/plan_status.go
+++ b/pkg/kudoctl/cmd/plan/plan_status.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"os"
 
 	kudov1alpha1 "github.com/kudobuilder/kudo/pkg/apis/kudo/v1alpha1"
 	"github.com/kudobuilder/kudo/pkg/kudoctl/util/check"
@@ -50,6 +51,11 @@ func runStatus(cmd *cobra.Command, args []string, options *statusOptions) error 
 	instanceFlag, err := cmd.Flags().GetString("instance")
 	if err != nil || instanceFlag == "" {
 		return fmt.Errorf("flag Error: Please set instance flag, e.g. \"--instance=<instanceName>\"")
+	}
+
+	// If the $KUBECONFIG environment variable is set, use that
+	if len(os.Getenv("KUBECONFIG")) > 0 {
+		options.kubeConfigPath = os.Getenv("KUBECONFIG")
 	}
 
 	configPath, err := check.KubeConfigLocationOrDefault(options.kubeConfigPath)


### PR DESCRIPTION

**What type of PR is this?**
/component kudoctl

**What this PR does / why we need it**:

As with #472, the `get` and `plan` KUDO commands should also honour the $KUBECONFIG environment variable, if it's set.

**Which issue(s) this PR fixes**:
Fixes #462 

**Does this PR introduce a user-facing change?**:
```release-note
Ensure the `get` and `plan` commands are also aware of the KUBECONFIG environment variable.
```