### PR TITLE
Small test harness logging improvements: enable verbose test logging, log created/updated resources, time to start test environment.

### DIFF
--- a/pkg/test/harness.go
+++ b/pkg/test/harness.go
@@ -66,10 +66,14 @@ func (h *Harness) LoadTests(dir string) ([]*Case, error) {
 func (h *Harness) RunTestEnv() (*rest.Config, error) {
 	h.env = &envtest.Environment{}
 
+	started := time.Now()
+
 	config, err := h.env.Start()
 	if err != nil {
 		return nil, err
 	}
+
+	h.T.Log("started test environment (kube-apiserver and etcd) in", time.Since(started))
 
 	return config, nil
 }

--- a/pkg/test/step.go
+++ b/pkg/test/step.go
@@ -64,8 +64,14 @@ func (s *Step) Create(namespace string) []error {
 			continue
 		}
 
-		if err = testutils.CreateOrUpdate(context.TODO(), s.Client, obj, true); err != nil {
+		if updated, err := testutils.CreateOrUpdate(context.TODO(), s.Client, obj, true); err != nil {
 			errors = append(errors, err)
+		} else {
+			action := "created"
+			if updated {
+				action = "updated"
+			}
+			s.Logger.Log(testutils.ResourceID(obj), action)
 		}
 	}
 

--- a/pkg/test/utils/kubernetes_integration_test.go
+++ b/pkg/test/utils/kubernetes_integration_test.go
@@ -37,7 +37,8 @@ func TestCreateOrUpdate(t *testing.T) {
 			},
 		})
 
-		assert.Nil(t, CreateOrUpdate(context.TODO(), client, SetAnnotation(depToUpdate, "test", "hi"), true))
+		_, err = CreateOrUpdate(context.TODO(), client, SetAnnotation(depToUpdate, "test", "hi"), true)
+		assert.Nil(t, err)
 
 		quit := make(chan bool)
 
@@ -55,7 +56,8 @@ func TestCreateOrUpdate(t *testing.T) {
 
 		time.Sleep(time.Millisecond * 50)
 
-		assert.Nil(t, CreateOrUpdate(context.TODO(), client, SetAnnotation(depToUpdate, "test", "hello"), true))
+		_, err = CreateOrUpdate(context.TODO(), client, SetAnnotation(depToUpdate, "test", "hello"), true)
+		assert.Nil(t, err)
 
 		quit <- true
 	}

--- a/pkg/test/utils/testing.go
+++ b/pkg/test/utils/testing.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"flag"
 	"io"
 	"os"
 	"regexp"
@@ -11,6 +12,9 @@ import (
 // RunTests runs a Go test method without requiring the Go compiler.
 // This does not currently support test caching.
 func RunTests(testName string, testFunc func(*testing.T)) {
+	// Set the verbose test flag to true since we are not using the regular go test CLI.
+	flag.Lookup("test.v").Value.Set("true")
+
 	os.Exit(testing.MainStart(&testDeps{}, []testing.InternalTest{
 		{
 			Name: testName,


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Improve logs outputted by the kudo test harness:

* Always use verbose test logging.
* Log the envtest startup time.
* Log resources created/updated by CreateOrUpdate

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```