### PR TITLE
In test harness, stop KUDO first then stop the control plane.

### DIFF
--- a/pkg/test/harness.go
+++ b/pkg/test/harness.go
@@ -238,13 +238,13 @@ func (h *Harness) Run() {
 
 // Stop the test environment and KUDO, clean up the harness.
 func (h *Harness) Stop() {
-	if h.env != nil {
-		h.env.Stop()
-		h.env = nil
-	}
-
 	if h.managerStopCh != nil {
 		close(h.managerStopCh)
 		h.managerStopCh = nil
+	}
+
+	if h.env != nil {
+		h.env.Stop()
+		h.env = nil
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This prevents errors with KUDO trying to communicate with a control plane that has been shutdown.

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```