### PR TITLE
Support running a single test with the `--test` flag.

### DIFF
--- a/pkg/kudoctl/cmd/test.go
+++ b/pkg/kudoctl/cmd/test.go
@@ -36,6 +36,8 @@ var (
 // newTestCmd creates the test command for the CLI
 func newTestCmd() *cobra.Command {
 	configPath := ""
+	testToRun := ""
+
 	options := kudo.TestSuite{}
 	defaults := kudo.TestSuite{
 		TestDirs: []string{},
@@ -93,7 +95,7 @@ For more detailed documentation, visit: https://kudo.dev/docs/testing`,
 			return nil
 		},
 		Run: func(cmd *cobra.Command, args []string) {
-			testutils.RunTests("kudo", func(t *testing.T) {
+			testutils.RunTests("kudo", testToRun, func(t *testing.T) {
 				harness := test.Harness{
 					TestSuite: options,
 					T:         t,
@@ -107,6 +109,7 @@ For more detailed documentation, visit: https://kudo.dev/docs/testing`,
 	testCmd.Flags().StringVar(&configPath, "config", "", "Path to file to load test settings from (must not be set with any other arguments).")
 	testCmd.Flags().StringVar(&options.CRDDir, "crd-dir", "", "Directory to load CustomResourceDefinitions from prior to running the tests.")
 	testCmd.Flags().StringVar(&options.ManifestsDir, "manifests-dir", "", "A directory containing manifests to apply before running the tests.")
+	testCmd.Flags().StringVar(&testToRun, "test", "", "If set, the specific test case to run.")
 	testCmd.Flags().BoolVar(&options.StartControlPlane, "start-control-plane", false, "Start a local Kubernetes control plane for the tests (requires etcd and kube-apiserver binaries, implies --start-kudo).")
 	testCmd.Flags().BoolVar(&options.StartKUDO, "start-kudo", false, "Start KUDO during the test run.")
 

--- a/pkg/test/utils/testing.go
+++ b/pkg/test/utils/testing.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"flag"
+	"fmt"
 	"io"
 	"os"
 	"regexp"
@@ -11,9 +12,14 @@ import (
 
 // RunTests runs a Go test method without requiring the Go compiler.
 // This does not currently support test caching.
-func RunTests(testName string, testFunc func(*testing.T)) {
+// If testToRun is set to a non-empty string, it is passed as a `-run` argument to the go test harness.
+func RunTests(testName string, testToRun string, testFunc func(*testing.T)) {
 	// Set the verbose test flag to true since we are not using the regular go test CLI.
 	flag.Lookup("test.v").Value.Set("true")
+
+	if testToRun != "" {
+		flag.Lookup("test.run").Value.Set(fmt.Sprintf("//%s", testToRun))
+	}
 
 	os.Exit(testing.MainStart(&testDeps{}, []testing.InternalTest{
 		{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kudo/blob/master/CONTRIBUTING.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kudobuilder/kudo/blob/master/RELEASE.md
3. Ensure you have added or ran the appropriate tests for your PR
4. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What type of PR is this?**

/component kudoctl
/kind feature

**What this PR does / why we need it**:

Adds the ability to run only a single test using the `--test` flag instead of an entire suite.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #376 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Test harness now supports running a single test with the `--test` flag.
```