### PR TITLE
Adding Ability to MergePatch CRDs properly

### DIFF
--- a/pkg/controller/planexecution/planexecution_controller.go
+++ b/pkg/controller/planexecution/planexecution_controller.go
@@ -513,22 +513,19 @@ func (r *ReconcilePlanExecution) Reconcile(request reconcile.Request) (reconcile
 							//			application/json-patch+json, application/merge-patch+json
 							//
 							// 		Reason: "UnsupportedMediaType" Code: 415
-							switch e := err.(type) {
-							case *errors.StatusError:
-								if e.Status().Reason == "UnsupportedMediaType" {
-									err = r.Client.Patch(context.TODO(), truth, client.ConstantPatch(types.MergePatchType, rawObj))
-									if err != nil {
-										log.Printf("PlanExecutionController: CreateOrUpdate MergePatch: %v", err)
-									}
+							if errors.IsUnsupportedMediaType(err) {
+								err = r.Client.Patch(context.TODO(), truth, client.ConstantPatch(types.MergePatchType, rawObj))
+								if err != nil {
+									log.Printf("PlanExecutionController: CreateOrUpdate MergePatch: %v", err)
 								}
-							default:
+							} else {
 								log.Printf("PlanExecutionController: CreateOrUpdate StrategicMergePatch: Unknown Error:", err)
 							}
 						}
 					}
 				} else {
 					//create
-					log.Printf("PlanExecutionController: CreateOrUpdate Object not present")
+					log.Println("PlanExecutionController: CreateOrUpdate Object not present")
 					err = r.Client.Create(context.TODO(), obj)
 					log.Printf("PlanExecutionController: CreateOrUpdate Create: %v", err)
 				}

--- a/pkg/controller/planexecution/planexecution_controller.go
+++ b/pkg/controller/planexecution/planexecution_controller.go
@@ -519,7 +519,7 @@ func (r *ReconcilePlanExecution) Reconcile(request reconcile.Request) (reconcile
 									log.Printf("PlanExecutionController: CreateOrUpdate MergePatch: %v", err)
 								}
 							} else {
-								log.Printf("PlanExecutionController: CreateOrUpdate StrategicMergePatch: Unknown Error:", err)
+								log.Printf("PlanExecutionController: CreateOrUpdate StrategicMergePatch: Unknown Error: %v", err)
 							}
 						}
 					}

--- a/pkg/controller/planexecution/planexecution_controller.go
+++ b/pkg/controller/planexecution/planexecution_controller.go
@@ -499,7 +499,12 @@ func (r *ReconcilePlanExecution) Reconcile(request reconcile.Request) (reconcile
 						log.Printf("Error getting patch between truth and obj: %v\n", err)
 					} else {
 						err = r.Client.Patch(context.TODO(), truth, client.ConstantPatch(types.StrategicMergePatchType, rawObj))
-						log.Printf("PlanExecutionController: CreateOrUpdate Patch: %v", err)
+						if err != nil {
+							err = r.Client.Patch(context.TODO(), truth, client.ConstantPatch(types.MergePatchType, rawObj))
+							if err != nil {
+								log.Printf("PlanExecutionController: CreateOrUpdate Patch: %v", err)
+							}
+						}
 					}
 				} else {
 					//create

--- a/test/integration/create-operator-in-operator/00-dream.yaml
+++ b/test/integration/create-operator-in-operator/00-dream.yaml
@@ -1,0 +1,50 @@
+## Dream is the umbrella operator that tests the creation of instances within an operator
+apiVersion: kudo.k8s.io/v1alpha1
+kind: Operator
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: dream
+---
+apiVersion: kudo.k8s.io/v1alpha1
+kind: OperatorVersion
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: dream-v1
+spec:
+  version: "1.0.0"
+  connectionString: ""
+  operator:
+    name: dream
+    kind: Operator
+  templates:
+    operator.yaml: |
+      apiVersion: kudo.k8s.io/v1alpha1
+      kind: Instance
+      metadata:
+        name: operator
+      spec:
+        operatorVersion:
+          kind: OperatorVersion
+          name: test-operator-1.0
+          namespace: default
+        parameters:
+          REPLICAS: "0"
+  tasks:
+    operator:
+      resources:
+        - operator.yaml
+  parameters:
+    - name: Param
+      description: "Sample parameter"
+      default: "dream-in-a-dream"
+  plans:
+    deploy:
+      strategy: serial
+      phases:
+        - name: dependencies
+          steps:
+            - name: operator
+              tasks:
+                - operator

--- a/test/integration/create-operator-in-operator/01-assert.yaml
+++ b/test/integration/create-operator-in-operator/01-assert.yaml
@@ -1,0 +1,20 @@
+apiVersion: kudo.k8s.io/v1alpha1
+kind: Instance
+metadata:
+  name: dream1
+status:
+  status: COMPLETE
+---
+apiVersion: kudo.k8s.io/v1alpha1
+kind: Instance
+metadata:
+  name: dream1-operator
+status:
+  status: COMPLETE
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dream1-operator-nginx
+spec:
+  replicas: 0

--- a/test/integration/create-operator-in-operator/01-install.yaml
+++ b/test/integration/create-operator-in-operator/01-install.yaml
@@ -1,0 +1,11 @@
+apiVersion: kudo.k8s.io/v1alpha1
+kind: Instance
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+    operator: dream
+  name: dream1
+spec:
+  operatorVersion:
+    name: dream-v1
+    kind: OperatorVersion


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kudo/blob/master/CONTRIBUTING.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kudobuilder/kudo/blob/master/RELEASE.md
3. Ensure you have added or ran the appropriate tests for your PR
4. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:

/component operator
/kind bug

**What this PR does / why we need it**:

In https://github.com/kudobuilder/kudo/pull/447 we've added StrategicMergePatchs, however custom resources apparently don't work currently with SMPs. With this patch, CustomResources can behave properly without throwing:

```
PlanExecutionController: CreateOrUpdate Patch: the body of the request was in an unknown format - accepted media types include: application/json-patch+json, application/merge-patch+json
```
It works by being more verbose and catching the error of a failed StrategicMergePatch and applying an old MergePatch before throwing an error. When testing this worked with Zookeeper, Kafka and Flink.

Without this, a more complex "extension", e.g. like in the Flink demo in which we require instantiation of e.g. other Operators first wasn't working. Having for example https://github.com/kudobuilder/operators/blob/master/repository/flink/docs/demo/financial-fraud/demo-operator/templates/zookeeper.yaml as an `Instance` to be applied in a Phase would throw the above error.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

First, this needs further testing. In particular for the scenario like in the [flink financial fraud demo](https://github.com/kudobuilder/operators/tree/master/repository/flink/docs/demo/financial-fraud).
To try it out run in the `kudobuilder/operators` repo: `kudo install flink/docs/demo/financial-fraud/demo-operator`

The expected output should be:

```
NAME                                          READY   STATUS        RESTARTS   AGE
flink-demo-qx2x66-zk-flink-demo-qx2x66-zk-0   0/1     Pending       0          2d21h
flink-demo-qx2x66-zk-flink-demo-qx2x66-zk-0   0/1     Pending       0          2d21h
flink-demo-qx2x66-zk-flink-demo-qx2x66-zk-1   0/1     Pending       0          2d21h
flink-demo-qx2x66-zk-flink-demo-qx2x66-zk-1   0/1     Pending       0          2d21h
flink-demo-qx2x66-zk-flink-demo-qx2x66-zk-2   0/1     Pending       0          2d21h
flink-demo-qx2x66-zk-flink-demo-qx2x66-zk-2   0/1     Pending       0          2d21h
flink-demo-qx2x66-zk-flink-demo-qx2x66-zk-0   0/1     Pending       0          2d21h
flink-demo-qx2x66-zk-flink-demo-qx2x66-zk-1   0/1     Pending       0          2d21h
flink-demo-qx2x66-zk-flink-demo-qx2x66-zk-0   0/1     ContainerCreating   0          2d21h
flink-demo-qx2x66-zk-flink-demo-qx2x66-zk-1   0/1     ContainerCreating   0          2d21h
flink-demo-qx2x66-zk-flink-demo-qx2x66-zk-0   0/1     Running             0          2d21h
flink-demo-qx2x66-zk-flink-demo-qx2x66-zk-1   0/1     Running             0          2d21h
flink-demo-qx2x66-zk-flink-demo-qx2x66-zk-2   0/1     Pending             0          2d21h
flink-demo-qx2x66-zk-flink-demo-qx2x66-zk-2   0/1     ContainerCreating   0          2d21h
flink-demo-qx2x66-zk-flink-demo-qx2x66-zk-2   0/1     Running             0          2d21h
flink-demo-qx2x66-zk-flink-demo-qx2x66-zk-0   1/1     Running             0          2d21h
flink-demo-qx2x66-zk-flink-demo-qx2x66-zk-1   1/1     Running             0          2d21h
flink-demo-qx2x66-zk-flink-demo-qx2x66-zk-2   1/1     Running             0          2d21h
flink-demo-jzhct2-zk-flink-demo-jzhct2-zk-0   0/1     Pending             0          2d21h
flink-demo-jzhct2-zk-flink-demo-jzhct2-zk-0   0/1     Pending             0          2d21h
flink-demo-jzhct2-zk-flink-demo-jzhct2-zk-1   0/1     Pending             0          2d21h
flink-demo-jzhct2-zk-flink-demo-jzhct2-zk-1   0/1     Pending             0          2d21h
flink-demo-jzhct2-zk-flink-demo-jzhct2-zk-2   0/1     Pending             0          2d21h
flink-demo-jzhct2-zk-flink-demo-jzhct2-zk-2   0/1     Pending             0          2d21h
flink-demo-jzhct2-zk-flink-demo-jzhct2-zk-2   0/1     Pending             0          2d21h
flink-demo-jzhct2-zk-flink-demo-jzhct2-zk-2   0/1     ContainerCreating   0          2d21h
flink-demo-jzhct2-zk-flink-demo-jzhct2-zk-2   0/1     Running             0          2d21h
flink-demo-jzhct2-zk-flink-demo-jzhct2-zk-1   0/1     Pending             0          2d21h
flink-demo-jzhct2-zk-flink-demo-jzhct2-zk-0   0/1     Pending             0          2d21h
flink-demo-jzhct2-zk-flink-demo-jzhct2-zk-1   0/1     ContainerCreating   0          2d21h
flink-demo-jzhct2-zk-flink-demo-jzhct2-zk-0   0/1     ContainerCreating   0          2d21h
flink-demo-jzhct2-zk-flink-demo-jzhct2-zk-0   0/1     Running             0          2d21h
flink-demo-jzhct2-zk-flink-demo-jzhct2-zk-1   0/1     Running             0          2d21h
flink-demo-jzhct2-zk-flink-demo-jzhct2-zk-1   1/1     Running             0          2d21h
flink-demo-jzhct2-zk-flink-demo-jzhct2-zk-0   1/1     Running             0          2d21h
flink-demo-jzhct2-zk-flink-demo-jzhct2-zk-2   1/1     Running             0          2d21h
flink-demo-4mqrmq-zk-flink-demo-4mqrmq-zk-0   0/1     Pending             0          2d21h
flink-demo-4mqrmq-zk-flink-demo-4mqrmq-zk-0   0/1     Pending             0          2d21h
flink-demo-4mqrmq-zk-flink-demo-4mqrmq-zk-1   0/1     Pending             0          2d21h
flink-demo-4mqrmq-zk-flink-demo-4mqrmq-zk-1   0/1     Pending             0          2d21h
flink-demo-4mqrmq-zk-flink-demo-4mqrmq-zk-2   0/1     Pending             0          2d21h
flink-demo-4mqrmq-zk-flink-demo-4mqrmq-zk-2   0/1     Pending             0          2d21h
flink-demo-4mqrmq-zk-flink-demo-4mqrmq-zk-1   0/1     Pending             0          2d21h
flink-demo-4mqrmq-zk-flink-demo-4mqrmq-zk-0   0/1     Pending             0          2d21h
flink-demo-4mqrmq-zk-flink-demo-4mqrmq-zk-1   0/1     ContainerCreating   0          2d21h
flink-demo-4mqrmq-zk-flink-demo-4mqrmq-zk-0   0/1     ContainerCreating   0          2d21h
flink-demo-4mqrmq-zk-flink-demo-4mqrmq-zk-0   0/1     Running             0          2d21h
flink-demo-4mqrmq-zk-flink-demo-4mqrmq-zk-2   0/1     Pending             0          2d21h
flink-demo-4mqrmq-zk-flink-demo-4mqrmq-zk-2   0/1     ContainerCreating   0          2d21h
flink-demo-4mqrmq-zk-flink-demo-4mqrmq-zk-1   0/1     Running             0          2d21h
flink-demo-4mqrmq-zk-flink-demo-4mqrmq-zk-2   0/1     Running             0          2d21h
flink-demo-4mqrmq-zk-flink-demo-4mqrmq-zk-0   1/1     Running             0          2d21h
flink-demo-4mqrmq-zk-flink-demo-4mqrmq-zk-1   1/1     Running             0          2d21h
flink-demo-4mqrmq-zk-flink-demo-4mqrmq-zk-2   1/1     Running             0          2d21h
flink-demo-4mqrmq-kafka-kafka-0               0/1     Pending             0          2d21h
flink-demo-4mqrmq-kafka-kafka-0               0/1     Pending             0          2d21h
flink-demo-4mqrmq-kafka-kafka-0               0/1     Pending             0          2d21h
flink-demo-4mqrmq-kafka-kafka-0               0/1     ContainerCreating   0          2d21h
flink-demo-4mqrmq-kafka-kafka-0               0/1     Running             0          2d21h
flink-demo-4mqrmq-kafka-kafka-0               1/1     Running             0          2d21h
flink-demo-4mqrmq-kafka-kafka-1               0/1     Pending             0          2d21h
flink-demo-4mqrmq-kafka-kafka-1               0/1     Pending             0          2d21h
flink-demo-4mqrmq-kafka-kafka-1               0/1     Pending             0          2d21h
flink-demo-4mqrmq-kafka-kafka-1               0/1     ContainerCreating   0          2d21h
flink-demo-4mqrmq-kafka-kafka-1               0/1     Running             0          2d21h
flink-demo-4mqrmq-kafka-kafka-1               1/1     Running             0          2d21h
flink-demo-4mqrmq-kafka-kafka-2               0/1     Pending             0          2d21h
flink-demo-4mqrmq-kafka-kafka-2               0/1     Pending             0          2d21h
flink-demo-4mqrmq-kafka-kafka-2               0/1     Pending             0          2d21h
flink-demo-4mqrmq-kafka-kafka-2               0/1     ContainerCreating   0          2d21h
flink-demo-4mqrmq-kafka-kafka-2               0/1     Running             0          2d21h
flink-demo-4mqrmq-kafka-kafka-2               1/1     Running             0          2d21h
flink-demo-4mqrmq-flink-jobmanager-0          0/1     Pending             0          2d21h
flink-demo-4mqrmq-flink-jobmanager-0          0/1     Pending             0          2d21h
flink-demo-4mqrmq-flink-taskmanager-7b5b955d59-9dq45   0/1     Pending             0          2d21h
flink-demo-4mqrmq-flink-taskmanager-7b5b955d59-9dq45   0/1     Pending             0          2d21h
flink-demo-4mqrmq-flink-taskmanager-7b5b955d59-47d97   0/1     Pending             0          2d21h
flink-demo-4mqrmq-flink-taskmanager-7b5b955d59-47d97   0/1     Pending             0          2d21h
flink-demo-4mqrmq-flink-jobmanager-0                   0/1     Pending             0          2d21h
flink-demo-4mqrmq-flink-taskmanager-7b5b955d59-9dq45   0/1     ContainerCreating   0          2d21h
flink-demo-4mqrmq-flink-taskmanager-7b5b955d59-47d97   0/1     ContainerCreating   0          2d21h
flink-demo-4mqrmq-flink-jobmanager-0                   0/1     ContainerCreating   0          2d21h
flink-demo-4mqrmq-flink-taskmanager-7b5b955d59-9dq45   1/1     Running             0          2d21h
flink-demo-4mqrmq-flink-jobmanager-0                   1/1     Running             0          2d21h
flink-demo-4mqrmq-generator-7dddcf978f-t8nnb           0/1     Pending             0          2d21h
flink-demo-4mqrmq-generator-7dddcf978f-t8nnb           0/1     Pending             0          2d21h
flink-demo-4mqrmq-actor-54656b546-qw6z5                0/1     Pending             0          2d21h
flink-demo-4mqrmq-actor-54656b546-qw6z5                0/1     Pending             0          2d21h
flink-demo-4mqrmq-generator-7dddcf978f-t8nnb           0/1     ContainerCreating   0          2d21h
flink-demo-4mqrmq-flink-taskmanager-7b5b955d59-47d97   1/1     Running             0          2d21h
flink-demo-4mqrmq-actor-54656b546-qw6z5                0/1     ContainerCreating   0          2d21h
flink-demo-4mqrmq-generator-7dddcf978f-t8nnb           1/1     Running             0          2d21h
flink-demo-4mqrmq-actor-54656b546-qw6z5                1/1     Running             0          2d21h
```

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```