### PR TITLE
Fix matching objects when listing in test harness

### DIFF
--- a/pkg/test/step.go
+++ b/pkg/test/step.go
@@ -122,8 +122,8 @@ func (s *Step) CheckResource(expected runtime.Object, namespace string) []error 
 
 		err = s.Client.List(context.TODO(), actual, listOptions...)
 
-		for _, item := range actual.Items {
-			actuals = append(actuals, &item)
+		for index := range actual.Items {
+			actuals = append(actuals, &actual.Items[index])
 		}
 	}
 	if err != nil {

--- a/pkg/test/step_integration_test.go
+++ b/pkg/test/step_integration_test.go
@@ -40,9 +40,19 @@ func TestCheckResourceIntegration(t *testing.T) {
 		shouldError bool
 	}{
 		{
-			testName: "match object by labels",
+			testName: "match object by labels, first in list matches",
 			actual: []runtime.Object{
-				testutils.WithSpec(testutils.WithLabels(testutils.NewPod("hello", ""), map[string]string{
+				testutils.WithSpec(testutils.WithLabels(testutils.NewPod("aa", ""), map[string]string{
+					"app": "nginx",
+				}), map[string]interface{}{
+					"containers": []interface{}{
+						map[string]interface{}{
+							"image": "nginx:1.7.9",
+							"name":  "nginx",
+						},
+					},
+				}),
+				testutils.WithSpec(testutils.WithLabels(testutils.NewPod("bb", ""), map[string]string{
 					"app": "not-match",
 				}), map[string]interface{}{
 					"containers": []interface{}{
@@ -52,7 +62,41 @@ func TestCheckResourceIntegration(t *testing.T) {
 						},
 					},
 				}),
-				testutils.WithSpec(testutils.WithLabels(testutils.NewPod("hello1", ""), map[string]string{
+			},
+			expected: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "Pod",
+					"metadata": map[string]interface{}{
+						"labels": map[string]interface{}{
+							"app": "nginx",
+						},
+					},
+					"spec": map[string]interface{}{
+						"containers": []interface{}{
+							map[string]interface{}{
+								"image": "nginx:1.7.9",
+								"name":  "nginx",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			testName: "match object by labels, last in list matches",
+			actual: []runtime.Object{
+				testutils.WithSpec(testutils.WithLabels(testutils.NewPod("aa", ""), map[string]string{
+					"app": "not-match",
+				}), map[string]interface{}{
+					"containers": []interface{}{
+						map[string]interface{}{
+							"image": "nginx:1.7.9",
+							"name":  "nginx",
+						},
+					},
+				}),
+				testutils.WithSpec(testutils.WithLabels(testutils.NewPod("bb", ""), map[string]string{
 					"app": "nginx",
 				}), map[string]interface{}{
 					"containers": []interface{}{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kudo/blob/master/CONTRIBUTING.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kudobuilder/kudo/blob/master/RELEASE.md
3. Ensure you have added or ran the appropriate tests for your PR
4. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

When listing objects in the test harness, there was a bug where the for loop variable was appended to the list of objects to compare causing only the last object (alphabetically) in the namespace to be compared when checking if any objects match the assert.

This fixes it by indexing the list instead of taking the address of the loop variable.

Found by @gkleiman :)

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```