### PR TITLE
kafka: update cli.md reference to kafka parameters

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -95,7 +95,7 @@ Both of these options will install new instance of that operator into your clust
 Use `--instance` and `--parameter`/`-p` for setting an Instance name and Parameters, respectively:
 
 ```bash
-$ kubectl kudo install kafka --instance=my-kafka-name --parameter KAFKA_ZOOKEEPER_URI=zk-zk-0.zk-hs:2181,zk-zk-1.zk-hs:2181,zk-zk-2.zk-hs:2181 --parameter KAFKA_ZOOKEEPER_PATH=/small -p BROKERS_COUNTER=3
+$ kubectl kudo install kafka --instance=my-kafka-name --parameter ZOOKEEPER_URI=zk-zk-0.zk-hs:2181,zk-zk-1.zk-hs:2181,zk-zk-2.zk-hs:2181 --parameter ZOOKEEPER_PATH=/small -p BROKERS_COUNTER=3
 operator.kudo.k8s.io/kafka unchanged
 operatorversion.kudo.k8s.io/kafka unchanged
 No instance named 'my-kafka-name' tied to this "kafka" version has been found. Do you want to create one? (Yes/no)


### PR DESCRIPTION
small PR to fix documentation around kafka parameters
 https://github.com/kudobuilder/operators/pull/40 is merged now

**What type of PR is this?**
 /kind documentation

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
The PR goes along with changes in https://github.com/kudobuilder/operators/pull/40 so users don't face issues when following the docs and installing the `kafka` operator 
In KUDO examples we use ` --parameter KAFKA_ZOOKEEPER_URI` that would be now ` --parameter ZOOKEEPER_URI` etc

This PR should be merged once we have merged https://github.com/kudobuilder/operators/pull/40
