### PR TITLE
Clean up integration tests that use controller-runtime envtest.

### DIFF
--- a/pkg/test/harness.go
+++ b/pkg/test/harness.go
@@ -65,18 +65,17 @@ func (h *Harness) LoadTests(dir string) ([]*Case, error) {
 // RunTestEnv starts a Kubernetes API server and etcd server for use in the
 // tests and returns the Kubernetes configuration.
 func (h *Harness) RunTestEnv() (*rest.Config, error) {
-	h.env = &envtest.Environment{}
-
 	started := time.Now()
 
-	config, err := h.env.Start()
+	testenv, err := testutils.StartTestEnvironment()
 	if err != nil {
 		return nil, err
 	}
 
 	h.T.Log("started test environment (kube-apiserver and etcd) in", time.Since(started))
+	h.env = testenv.Environment
 
-	return config, nil
+	return testenv.Config, nil
 }
 
 // Config returns the current Kubernetes configuration - either from the environment

--- a/pkg/test/step_integration_test.go
+++ b/pkg/test/step_integration_test.go
@@ -5,6 +5,8 @@ package test
 import (
 	"context"
 	"fmt"
+	"log"
+	"os"
 	"testing"
 
 	petname "github.com/dustinkirkland/golang-petname"
@@ -16,26 +18,24 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/discovery"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/envtest"
 )
 
+var testenv testutils.TestEnvironment
+
+func TestMain(m *testing.M) {
+	var err error
+
+	testenv, err = testutils.StartTestEnvironment()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	exitCode := m.Run()
+	testenv.Environment.Stop()
+	os.Exit(exitCode)
+}
+
 func TestCheckResourceIntegration(t *testing.T) {
-	env := &envtest.Environment{}
-
-	config, err := env.Start()
-	assert.Nil(t, err)
-
-	defer env.Stop()
-
-	cl, err := client.New(config, client.Options{
-		Scheme: testutils.Scheme(),
-	})
-	assert.Nil(t, err)
-	dClient, err := discovery.NewDiscoveryClientForConfig(config)
-	assert.Nil(t, err)
-
 	for _, test := range []struct {
 		testName    string
 		actual      []runtime.Object
@@ -228,19 +228,19 @@ func TestCheckResourceIntegration(t *testing.T) {
 		t.Run(test.testName, func(t *testing.T) {
 			namespace := fmt.Sprintf("kudo-test-%s", petname.Generate(2, "-"))
 
-			assert.Nil(t, cl.Create(context.TODO(), testutils.NewResource("v1", "Namespace", namespace, "")))
+			assert.Nil(t, testenv.Client.Create(context.TODO(), testutils.NewResource("v1", "Namespace", namespace, "")))
 
 			for _, actual := range test.actual {
-				_, _, err := testutils.Namespaced(dClient, actual, namespace)
+				_, _, err := testutils.Namespaced(testenv.DiscoveryClient, actual, namespace)
 				assert.Nil(t, err)
 
-				assert.Nil(t, cl.Create(context.TODO(), actual))
+				assert.Nil(t, testenv.Client.Create(context.TODO(), actual))
 			}
 
 			step := Step{
 				Logger:          testutils.NewTestLogger(t, ""),
-				Client:          cl,
-				DiscoveryClient: dClient,
+				Client:          testenv.Client,
+				DiscoveryClient: testenv.DiscoveryClient,
 			}
 
 			errors := step.CheckResource(test.expected, namespace)
@@ -256,20 +256,6 @@ func TestCheckResourceIntegration(t *testing.T) {
 
 // Verify that the DeleteExisting method properly cleans up resources that are matched on labels during a test step.
 func TestStepDeleteExistingLabelMatch(t *testing.T) {
-	env := &envtest.Environment{}
-
-	config, err := env.Start()
-	assert.Nil(t, err)
-
-	defer env.Stop()
-
-	cl, err := client.New(config, client.Options{
-		Scheme: testutils.Scheme(),
-	})
-	assert.Nil(t, err)
-	dClient, err := discovery.NewDiscoveryClientForConfig(config)
-	assert.Nil(t, err)
-
 	namespace := "world"
 
 	podSpec := map[string]interface{}{
@@ -308,8 +294,8 @@ func TestStepDeleteExistingLabelMatch(t *testing.T) {
 				},
 			},
 		},
-		Client:          cl,
-		DiscoveryClient: dClient,
+		Client:          testenv.Client,
+		DiscoveryClient: testenv.DiscoveryClient,
 	}
 
 	assert.Nil(t, step.Client.Create(context.TODO(), podToKeep))

--- a/pkg/test/utils/kubernetes.go
+++ b/pkg/test/utils/kubernetes.go
@@ -33,8 +33,10 @@ import (
 	"k8s.io/client-go/discovery"
 	fakediscovery "k8s.io/client-go/discovery/fake"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
 	coretesting "k8s.io/client-go/testing"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
 )
 
 // IsJSONSyntaxError returns true if the error is a JSON syntax error.
@@ -535,4 +537,38 @@ func WaitForCRDs(dClient discovery.DiscoveryInterface, crds []runtime.Object) er
 
 		return true, nil
 	})
+}
+
+// TestEnvironment is a struct containing the envtest environment, Kubernetes config and clients.
+type TestEnvironment struct {
+	Environment     *envtest.Environment
+	Config          *rest.Config
+	Client          client.Client
+	DiscoveryClient discovery.DiscoveryInterface
+}
+
+// StartTestEnvironment is a wrapper for controller-runtime's envtest that creates a Kubernetes API server and etcd
+// suitable for use in tests.
+func StartTestEnvironment() (env TestEnvironment, err error) {
+	env.Environment = &envtest.Environment{}
+
+	// Retry up to three times for the test environment to start up in case there is a port collision (#510).
+	for i := 0; i < 3; i++ {
+		env.Config, err = env.Environment.Start()
+		if err == nil {
+			break
+		}
+	}
+
+	if err != nil {
+		return
+	}
+
+	env.Client, err = client.New(env.Config, client.Options{})
+	if err != nil {
+		return
+	}
+
+	env.DiscoveryClient, err = discovery.NewDiscoveryClientForConfig(env.Config)
+	return
 }

--- a/pkg/test/utils/kubernetes_integration_test.go
+++ b/pkg/test/utils/kubernetes_integration_test.go
@@ -5,27 +5,32 @@ package utils
 import (
 	"context"
 	"fmt"
+	"log"
+	"os"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/api/meta"
-	"k8s.io/client-go/discovery"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/envtest"
 )
 
+var testenv TestEnvironment
+
+func TestMain(m *testing.M) {
+	var err error
+
+	testenv, err = StartTestEnvironment()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	exitCode := m.Run()
+	testenv.Environment.Stop()
+	os.Exit(exitCode)
+}
+
 func TestCreateOrUpdate(t *testing.T) {
-	env := &envtest.Environment{}
-
-	config, err := env.Start()
-	assert.Nil(t, err)
-
-	defer env.Stop()
-
-	client, err := client.New(config, client.Options{})
-	assert.Nil(t, err)
-
 	// Run the test a bunch of times to try to trigger a conflict and ensure that it handles conflicts properly.
 	for i := 0; i < 10; i++ {
 		depToUpdate := WithSpec(NewPod("update-me", fmt.Sprintf("default-%d", i)), map[string]interface{}{
@@ -37,7 +42,7 @@ func TestCreateOrUpdate(t *testing.T) {
 			},
 		})
 
-		_, err = CreateOrUpdate(context.TODO(), client, SetAnnotation(depToUpdate, "test", "hi"), true)
+		_, err := CreateOrUpdate(context.TODO(), testenv.Client, SetAnnotation(depToUpdate, "test", "hi"), true)
 		assert.Nil(t, err)
 
 		quit := make(chan bool)
@@ -48,7 +53,7 @@ func TestCreateOrUpdate(t *testing.T) {
 				case <-quit:
 					return
 				default:
-					CreateOrUpdate(context.TODO(), client, SetAnnotation(depToUpdate, "test", fmt.Sprintf("%d", i)), false)
+					CreateOrUpdate(context.TODO(), testenv.Client, SetAnnotation(depToUpdate, "test", fmt.Sprintf("%d", i)), false)
 					time.Sleep(time.Millisecond * 75)
 				}
 			}
@@ -56,7 +61,7 @@ func TestCreateOrUpdate(t *testing.T) {
 
 		time.Sleep(time.Millisecond * 50)
 
-		_, err = CreateOrUpdate(context.TODO(), client, SetAnnotation(depToUpdate, "test", "hello"), true)
+		_, err = CreateOrUpdate(context.TODO(), testenv.Client, SetAnnotation(depToUpdate, "test", "hello"), true)
 		assert.Nil(t, err)
 
 		quit <- true
@@ -64,38 +69,30 @@ func TestCreateOrUpdate(t *testing.T) {
 }
 
 func TestWaitForCRDs(t *testing.T) {
-	env := &envtest.Environment{}
-
-	config, err := env.Start()
-	assert.Nil(t, err)
-
-	defer env.Stop()
-
-	cl, err := client.New(config, client.Options{
+	// Kubernetes client caches the types, se we need to re-initialize it.
+	testClient, err := client.New(testenv.Config, client.Options{
 		Scheme: Scheme(),
 	})
-	assert.Nil(t, err)
-	dClient, err := discovery.NewDiscoveryClientForConfig(config)
 	assert.Nil(t, err)
 
 	instance := NewResource("kudo.k8s.io/v1alpha1", "Instance", "zk", "ns")
 
 	// Verify that we cannot create the instance, because the test environment is empty.
-	assert.IsType(t, &meta.NoKindMatchError{}, cl.Create(context.TODO(), instance))
+	assert.IsType(t, &meta.NoKindMatchError{}, testClient.Create(context.TODO(), instance))
 
 	// Install all of the CRDs.
-	crds, err := InstallManifests(context.TODO(), cl, dClient, "../../../config/crds/")
+	crds, err := InstallManifests(context.TODO(), testClient, testenv.DiscoveryClient, "../../../config/crds/")
 	assert.Nil(t, err)
 
 	// WaitForCRDs to be created.
-	assert.Nil(t, WaitForCRDs(dClient, crds))
+	assert.Nil(t, WaitForCRDs(testenv.DiscoveryClient, crds))
 
 	// Kubernetes client caches the types, se we need to re-initialize it.
-	cl, err = client.New(config, client.Options{
+	testClient, err = client.New(testenv.Config, client.Options{
 		Scheme: Scheme(),
 	})
 	assert.Nil(t, err)
 
 	// make sure that we can create an object of this type now
-	assert.Nil(t, cl.Create(context.TODO(), instance))
+	assert.Nil(t, testClient.Create(context.TODO(), instance))
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kudo/blob/master/CONTRIBUTING.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kudobuilder/kudo/blob/master/RELEASE.md
3. Ensure you have added or ran the appropriate tests for your PR
4. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

envtest can race when choosing the Kubernetes API port if multiple envtests are created simultaneously.

Instead of starting envtest within each test, we start envtest in a TestMain for the module. This means we do not
need to start as many envtests, as well as reducing our likelihood of racing over a Kubernetes API port.

We also retry creating envtest. If the API server does not come up, we will try twice to try to prevent any potential races.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #510

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```