### PR TITLE
Set the --advertise-address when starting Kubernetes API server in tests.

### DIFF
--- a/pkg/test/utils/kubernetes.go
+++ b/pkg/test/utils/kubernetes.go
@@ -550,7 +550,9 @@ type TestEnvironment struct {
 // StartTestEnvironment is a wrapper for controller-runtime's envtest that creates a Kubernetes API server and etcd
 // suitable for use in tests.
 func StartTestEnvironment() (env TestEnvironment, err error) {
-	env.Environment = &envtest.Environment{}
+	env.Environment = &envtest.Environment{
+		KubeAPIServerFlags: append(envtest.DefaultKubeAPIServerFlags, "--advertise-address={{ if .URL }}{{ .URL.Hostname }}{{ end }}"),
+	}
 
 	// Retry up to three times for the test environment to start up in case there is a port collision (#510).
 	for i := 0; i < 3; i++ {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

If the user has no default route when running the tests, the Kubernetes API server will refuse to start as the --advertise-address argument is missing which makes Kubernetes look up the default address.

This appends a specific --advertise-address to the Kubernetes API server flags in integration tests.

**Which issue(s) this PR fixes**:

Fixes #509 

**Special notes for your reviewer**:

Air plane mode :)

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```