### PR TITLE
Increase Docker RAM allocation to 4 gigabytes.

### DIFF
--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -3,7 +3,7 @@
 docker build -f test/Dockerfile -t kudo-test .
 if [ $? -eq 0 ]
 then
-   docker run -it -m 2g --rm kudo-test
+   docker run -it -m 4g --rm kudo-test
 else
     echo "Error when building test docker image, cannot run tests."
     exit 1


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Increase the RAM limit for the test Docker container to 4 gigabytes. I saw a timeout with 2 gigabyte, so suspect that it did not have enough headroom.

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```