### PR TITLE
Do not requeue when instance or OV is missing

### DIFF
--- a/pkg/controller/planexecution/planexecution_controller.go
+++ b/pkg/controller/planexecution/planexecution_controller.go
@@ -305,10 +305,11 @@ func (r *ReconcilePlanExecution) Reconcile(request reconcile.Request) (reconcile
 		if !ok {
 			// Not specified in params
 			if param.Required {
+				planExecution.Status.State = kudov1alpha1.PhaseStateError
 				err = fmt.Errorf("parameter %v was required but not provided by instance %v", param.Name, instance.Name)
 				log.Printf("PlanExecutionController: %v", err)
 				r.recorder.Event(planExecution, "Warning", "MissingParameter", fmt.Sprintf("Could not find required parameter (%v)", param.Name))
-				return reconcile.Result{}, err
+				return reconcile.Result{}, nil
 			}
 			params[param.Name] = param.Default
 		}

--- a/pkg/controller/planexecution/planexecution_controller.go
+++ b/pkg/controller/planexecution/planexecution_controller.go
@@ -231,14 +231,14 @@ func (r *ReconcilePlanExecution) Reconcile(request reconcile.Request) (reconcile
 			planExecution.Spec.Instance.Name,
 			planExecution.Spec.Instance.Namespace,
 			err)
-		return reconcile.Result{}, err
+		return reconcile.Result{}, nil
 	}
 
 	// Check for Suspend set.
 	if planExecution.Spec.Suspend != nil && *planExecution.Spec.Suspend {
 		planExecution.Status.State = kudov1alpha1.PhaseStateSuspend
 		err = r.Update(context.TODO(), planExecution)
-		r.recorder.Event(instance, "Normal", "PlanSuspend", fmt.Sprintf("PlanExecution %v suspended", planExecution.Name))
+		r.recorder.Event(instance, "Normal", "PlanSuspend", fmt.Sprintf("PlanExecution %v on instance %v suspended", planExecution.Name, planExecution.Spec.Instance.Name))
 		return reconcile.Result{}, err
 	}
 
@@ -281,7 +281,7 @@ func (r *ReconcilePlanExecution) Reconcile(request reconcile.Request) (reconcile
 			instance.Spec.OperatorVersion.Name,
 			instance.GetOperatorVersionNamespace(),
 			err)
-		return reconcile.Result{}, err
+		return reconcile.Result{}, nil
 	}
 
 	// Load parameters:

--- a/pkg/controller/planexecution/planexecution_controller.go
+++ b/pkg/controller/planexecution/planexecution_controller.go
@@ -328,7 +328,7 @@ func (r *ReconcilePlanExecution) Reconcile(request reconcile.Request) (reconcile
 		r.recorder.Event(planExecution, "Warning", "InvalidPlan", fmt.Sprintf("Could not find required plan (%v)", planExecution.Spec.PlanName))
 		err = fmt.Errorf("could not find required plan (%v)", planExecution.Spec.PlanName)
 		planExecution.Status.State = kudov1alpha1.PhaseStateError
-		return reconcile.Result{}, err
+		return reconcile.Result{}, nil
 	}
 
 	planExecution.Status.Name = planExecution.Spec.PlanName

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -3,7 +3,7 @@
 docker build -f test/Dockerfile -t kudo-test .
 if [ $? -eq 0 ]
 then
-   docker run kudo-test
+   docker run -it -m 2g --rm kudo-test
 else
     echo "Error when building test docker image, cannot run tests."
     exit 1


### PR DESCRIPTION
Just by reading the code it appears to me that we should not return err from cases when OV or I is missing. I guess we don't expect those objects to come back, right? And if they disappeared, we would be putting back to queue already failed plan execution all the time (returning non-nil error cause the request to be requeued).

Please correct me if I am wrong :-)