### PR TITLE
Adding Test for Parameter Parsing within Operators

### DIFF
--- a/test/integration/parse-param-operator-in-operator/00-dream.yaml
+++ b/test/integration/parse-param-operator-in-operator/00-dream.yaml
@@ -31,6 +31,7 @@ spec:
           namespace: default
         parameters:
           REPLICAS: "{{ .Params.REPLICAS }}"
+          PARAM: "after"
   tasks:
     operator:
       resources:

--- a/test/integration/parse-param-operator-in-operator/00-dream.yaml
+++ b/test/integration/parse-param-operator-in-operator/00-dream.yaml
@@ -1,0 +1,50 @@
+## Dream is the umbrella operator that tests the creation of instances within an operator
+apiVersion: kudo.k8s.io/v1alpha1
+kind: Operator
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: dream
+---
+apiVersion: kudo.k8s.io/v1alpha1
+kind: OperatorVersion
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: dream-v1
+spec:
+  version: "1.0.0"
+  connectionString: ""
+  operator:
+    name: dream
+    kind: Operator
+  templates:
+    operator.yaml: |
+      apiVersion: kudo.k8s.io/v1alpha1
+      kind: Instance
+      metadata:
+        name: operator
+      spec:
+        operatorVersion:
+          kind: OperatorVersion
+          name: test-operator-1.0
+          namespace: default
+        parameters:
+          REPLICAS: "{{ .Params.REPLICAS }}"
+  tasks:
+    operator:
+      resources:
+        - operator.yaml
+  parameters:
+    - name: Param
+      description: "Sample parameter"
+      default: "dream-in-a-dream"
+  plans:
+    deploy:
+      strategy: serial
+      phases:
+        - name: dependencies
+          steps:
+            - name: operator
+              tasks:
+                - operator

--- a/test/integration/parse-param-operator-in-operator/01-assert.yaml
+++ b/test/integration/parse-param-operator-in-operator/01-assert.yaml
@@ -1,0 +1,20 @@
+apiVersion: kudo.k8s.io/v1alpha1
+kind: Instance
+metadata:
+  name: dream1
+status:
+  status: IN_PROGRESS
+---
+apiVersion: kudo.k8s.io/v1alpha1
+kind: Instance
+metadata:
+  name: dream1-operator
+status:
+  status: IN_PROGRESS
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dream1-operator-nginx
+spec:
+  replicas: 2

--- a/test/integration/parse-param-operator-in-operator/01-assert.yaml
+++ b/test/integration/parse-param-operator-in-operator/01-assert.yaml
@@ -18,3 +18,9 @@ metadata:
   name: dream1-operator-nginx
 spec:
   replicas: 2
+  template:
+    spec:
+      containers:
+        - env:
+          - name: PARAM_ENV
+            value: "after"

--- a/test/integration/parse-param-operator-in-operator/01-install.yaml
+++ b/test/integration/parse-param-operator-in-operator/01-install.yaml
@@ -1,0 +1,13 @@
+apiVersion: kudo.k8s.io/v1alpha1
+kind: Instance
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+    operator: dream
+  name: dream1
+spec:
+  operatorVersion:
+    name: dream-v1
+    kind: OperatorVersion
+  parameters:
+    REPLICAS: "2"

--- a/test/integration/parse-param-operator-in-operator/01-install.yaml
+++ b/test/integration/parse-param-operator-in-operator/01-install.yaml
@@ -11,3 +11,4 @@ spec:
     kind: OperatorVersion
   parameters:
     REPLICAS: "2"
+    PARAM: "after"

--- a/test/manifests/test-operator.yaml
+++ b/test/manifests/test-operator.yaml
@@ -19,6 +19,9 @@ spec:
     description: "Number of nginx replicas"
     default: "3"
     displayName: "Replica count"
+  - name: PARAM
+    description: "Sample parameter"
+    default: "before"
   templates:
     deploy.yaml: |
       apiVersion: apps/v1
@@ -40,6 +43,9 @@ spec:
               image: nginx:1.7.9
               ports:
               - containerPort: 80
+              env:
+              - name: PARAM_ENV
+                value: {{ .Params.PARAM }}
   tasks:
     deploy:
       resources:


### PR DESCRIPTION
**What type of PR is this?**

/kind infrastructure

**What this PR does / why we need it**:

This test is for parsing parameters into operators that run operators. We test if the parsed parameters are applied successfully.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:

To run locally:
```
$ go run ./cmd/kubectl-kudo test --test=parse-param-operator-in-operator
```

Output will look like:
```
...
--- PASS: kudo (10.52s)
    harness.go:85: started test environment (kube-apiserver and etcd) in 7.116559804s
    --- PASS: kudo/harness (0.01s)
        --- PASS: kudo/harness/parse-param-operator-in-operator (3.11s)
            logger.go:37: 13:07:25 | parse-param-operator-in-operator | Creating namespace: kudo-test-big-tetra
            logger.go:37: 13:07:25 | parse-param-operator-in-operator/0-dream | starting test step 0-dream
            logger.go:37: 13:07:25 | parse-param-operator-in-operator/0-dream | Operator:kudo-test-big-tetra/dream created
            logger.go:37: 13:07:25 | parse-param-operator-in-operator/0-dream | OperatorVersion:kudo-test-big-tetra/dream-v1 created
            logger.go:37: 13:07:25 | parse-param-operator-in-operator/0-dream | test step completed 0-dream
            logger.go:37: 13:07:25 | parse-param-operator-in-operator/1-install | starting test step 1-install
            logger.go:37: 13:07:25 | parse-param-operator-in-operator/1-install | Instance:kudo-test-big-tetra/dream1 created
            logger.go:37: 13:07:28 | parse-param-operator-in-operator/1-install | test step completed 1-install
            logger.go:37: 13:07:28 | parse-param-operator-in-operator | Deleting namespace: kudo-test-big-tetra
PASS

```
**Does this PR introduce a user-facing change?**:

```release-note
NONE
```