### PR TITLE
Implement a new RetryClient that wraps the Kubernetes Client with retries

### DIFF
--- a/pkg/test/harness.go
+++ b/pkg/test/harness.go
@@ -145,7 +145,7 @@ func (h *Harness) Client(forceNew bool) (client.Client, error) {
 		return nil, err
 	}
 
-	h.client, err = client.New(config, client.Options{
+	h.client, err = testutils.NewRetryClient(config, client.Options{
 		Scheme: testutils.Scheme(),
 	})
 	return h.client, err

--- a/pkg/test/step.go
+++ b/pkg/test/step.go
@@ -79,28 +79,21 @@ func (s *Step) DeleteExisting(namespace string) error {
 		}
 
 		if ref.Labels != nil && len(ref.Labels) != 0 {
-			// If the reference has a label selector, List all objects that match
-			if err := testutils.Retry(context.TODO(), func(ctx context.Context) error {
-				u := &unstructured.UnstructuredList{}
-				u.SetGroupVersionKind(gvk)
+			u := &unstructured.UnstructuredList{}
+			u.SetGroupVersionKind(gvk)
 
-				listOptions := []client.ListOptionFunc{client.MatchingLabels(ref.Labels)}
-				if objNs != "" {
-					listOptions = append(listOptions, client.InNamespace(objNs))
-				}
+			listOptions := []client.ListOptionFunc{client.MatchingLabels(ref.Labels)}
+			if objNs != "" {
+				listOptions = append(listOptions, client.InNamespace(objNs))
+			}
 
-				err := s.Client.List(ctx, u, listOptions...)
-				if err != nil {
-					return errors.Wrap(err, "listing matching resources")
-				}
+			err := s.Client.List(context.TODO(), u, listOptions...)
+			if err != nil {
+				return errors.Wrap(err, "listing matching resources")
+			}
 
-				for index := range u.Items {
-					toDelete = append(toDelete, &u.Items[index])
-				}
-
-				return nil
-			}, testutils.IsJSONSyntaxError); err != nil {
-				return err
+			for index := range u.Items {
+				toDelete = append(toDelete, &u.Items[index])
 			}
 		} else {
 			// Otherwise just append the object specified.
@@ -109,13 +102,8 @@ func (s *Step) DeleteExisting(namespace string) error {
 	}
 
 	for _, obj := range toDelete {
-		if err := testutils.Retry(context.TODO(), func(ctx context.Context) error {
-			err := s.Client.Delete(context.TODO(), obj.DeepCopyObject())
-			if err != nil && k8serrors.IsNotFound(err) {
-				return nil
-			}
-			return err
-		}, testutils.IsJSONSyntaxError); err != nil {
+		err := s.Client.Delete(context.TODO(), obj.DeepCopyObject())
+		if err != nil && !k8serrors.IsNotFound(err) {
 			return err
 		}
 	}

--- a/pkg/test/utils/kubernetes_integration_test.go
+++ b/pkg/test/utils/kubernetes_integration_test.go
@@ -70,7 +70,7 @@ func TestCreateOrUpdate(t *testing.T) {
 
 func TestWaitForCRDs(t *testing.T) {
 	// Kubernetes client caches the types, se we need to re-initialize it.
-	testClient, err := client.New(testenv.Config, client.Options{
+	testClient, err := NewRetryClient(testenv.Config, client.Options{
 		Scheme: Scheme(),
 	})
 	assert.Nil(t, err)
@@ -88,7 +88,7 @@ func TestWaitForCRDs(t *testing.T) {
 	assert.Nil(t, WaitForCRDs(testenv.DiscoveryClient, crds))
 
 	// Kubernetes client caches the types, se we need to re-initialize it.
-	testClient, err = client.New(testenv.Config, client.Options{
+	testClient, err = NewRetryClient(testenv.Config, client.Options{
 		Scheme: Scheme(),
 	})
 	assert.Nil(t, err)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Implement a new RetryClient that wraps the Kubernetes Client with retries

This ensures that we properly retry on network failures in our integration tests to prevent an flaky tests.

**Which issue(s) this PR fixes**:

Fixes #526

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```