### PR TITLE
Fixed missed variable name changes from move to operator

### DIFF
--- a/pkg/controller/planexecution/planexecution_controller.go
+++ b/pkg/controller/planexecution/planexecution_controller.go
@@ -347,7 +347,7 @@ func (r *ReconcilePlanExecution) Reconcile(request reconcile.Request) (reconcile
 			// Fetch OperatorVersion:
 			//
 			//   - Get the task name from the step
-			//   - Get the task definition from the FV
+			//   - Get the task definition from the OV
 			//   - Create the kustomize templates
 			//   - Apply
 			configs["PlanName"] = planExecution.Spec.PlanName

--- a/pkg/kudoctl/cmd/install/install.go
+++ b/pkg/kudoctl/cmd/install/install.go
@@ -227,7 +227,7 @@ func versionExists(versions []string, currentVersion string) bool {
 // installSingleOperatorToCluster installs a given Operator to the cluster
 // TODO: needs testing
 func installSingleOperatorToCluster(name, namespace string, o *v1alpha1.Operator, kc *kudo.Client) error {
-	if _, err := kc.InstallOperatorObjToCluster(f, namespace); err != nil {
+	if _, err := kc.InstallOperatorObjToCluster(o, namespace); err != nil {
 		return errors.Wrapf(err, "installing %s-operator.yaml", name)
 	}
 	fmt.Printf("operator.%s/%s created\n", o.APIVersion, o.Name)

--- a/pkg/kudoctl/cmd/install/install.go
+++ b/pkg/kudoctl/cmd/install/install.go
@@ -226,21 +226,21 @@ func versionExists(versions []string, currentVersion string) bool {
 
 // installSingleOperatorToCluster installs a given Operator to the cluster
 // TODO: needs testing
-func installSingleOperatorToCluster(name, namespace string, f *v1alpha1.Operator, kc *kudo.Client) error {
+func installSingleOperatorToCluster(name, namespace string, o *v1alpha1.Operator, kc *kudo.Client) error {
 	if _, err := kc.InstallOperatorObjToCluster(f, namespace); err != nil {
 		return errors.Wrapf(err, "installing %s-operator.yaml", name)
 	}
-	fmt.Printf("operator.%s/%s created\n", f.APIVersion, f.Name)
+	fmt.Printf("operator.%s/%s created\n", o.APIVersion, o.Name)
 	return nil
 }
 
 // installSingleOperatorVersionToCluster installs a given OperatorVersion to the cluster
 // TODO: needs testing
-func installSingleOperatorVersionToCluster(name, namespace string, kc *kudo.Client, fv *v1alpha1.OperatorVersion) error {
-	if _, err := kc.InstallOperatorVersionObjToCluster(fv, namespace); err != nil {
+func installSingleOperatorVersionToCluster(name, namespace string, kc *kudo.Client, ov *v1alpha1.OperatorVersion) error {
+	if _, err := kc.InstallOperatorVersionObjToCluster(ov, namespace); err != nil {
 		return errors.Wrapf(err, "installing %s-operatorversion.yaml", name)
 	}
-	fmt.Printf("operatorversion.%s/%s created\n", fv.APIVersion, fv.Name)
+	fmt.Printf("operatorversion.%s/%s created\n", ov.APIVersion, ov.Name)
 	return nil
 }
 

--- a/pkg/kudoctl/util/kudo/kudo.go
+++ b/pkg/kudoctl/util/kudo/kudo.go
@@ -106,7 +106,7 @@ func (c *Client) InstanceExistsInCluster(name, namespace, version, instanceName 
 		}
 	}
 
-	// No instance exist with this name and FV exists
+	// No instance exist with this name and OV exists
 	if i == 0 {
 		return false, nil
 	}
@@ -115,13 +115,13 @@ func (c *Client) InstanceExistsInCluster(name, namespace, version, instanceName 
 
 // OperatorVersionsInstalled lists all the versions of given operator installed in the cluster in given ns
 func (c *Client) OperatorVersionsInstalled(operatorName, namespace string) ([]string, error) {
-	fv, err := c.clientset.KudoV1alpha1().OperatorVersions(namespace).List(v1.ListOptions{})
+	ov, err := c.clientset.KudoV1alpha1().OperatorVersions(namespace).List(v1.ListOptions{})
 	if err != nil {
 		return nil, err
 	}
 	existingVersions := []string{}
 
-	for _, v := range fv.Items {
+	for _, v := range ov.Items {
 		if strings.HasPrefix(v.Name, operatorName) {
 			existingVersions = append(existingVersions, v.Spec.Version)
 		}

--- a/pkg/kudoctl/util/repo/repo_operator.go
+++ b/pkg/kudoctl/util/repo/repo_operator.go
@@ -115,10 +115,10 @@ func (r *OperatorRepository) GetBundle(name string, version string) (bundle.Bund
 
 // GetOperatorVersionDependencies helper method returns a slice of strings that contains the names of all
 // dependency Operators
-func GetOperatorVersionDependencies(fv *v1alpha1.OperatorVersion) ([]string, error) {
+func GetOperatorVersionDependencies(ov *v1alpha1.OperatorVersion) ([]string, error) {
 	var dependencyOperators []string
-	if fv.Spec.Dependencies != nil {
-		for _, v := range fv.Spec.Dependencies {
+	if ov.Spec.Dependencies != nil {
+		for _, v := range ov.Spec.Dependencies {
 			dependencyOperators = append(dependencyOperators, v.Name)
 		}
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Clean up of variable names `f` and `fv` which referred to Framework and FrameworkVersion to `o` and `ov` for Operator and OperatorVersion.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```