### PR TITLE
Fix configuring kudo test assert timeouts via configuration file

### DIFF
--- a/pkg/test/harness.go
+++ b/pkg/test/harness.go
@@ -72,7 +72,7 @@ func (h *Harness) LoadTests(dir string) ([]*Case, error) {
 func (h *Harness) GetTimeout() int {
 	timeout := 30
 	if h.TestSuite.Timeout != 0 {
-		timeout = 30
+		timeout = h.TestSuite.Timeout
 	}
 	return timeout
 }

--- a/pkg/test/harness_test.go
+++ b/pkg/test/harness_test.go
@@ -1,0 +1,15 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetTimeout(t *testing.T) {
+	h := Harness{}
+	assert.Equal(t, 30, h.GetTimeout())
+
+	h.TestSuite.Timeout = 45
+	assert.Equal(t, 45, h.GetTimeout())
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Fix configuring kudo test assert timeouts via the kudo-test.yaml configuration file.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Bug fixed related to configuring Kudo test timeout via TestSuite or CLI.
```