### PR TITLE
Switch CRD version reference to the next release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
       - run: |
           git config user.name "Circle CI"
           git config user.email "ci@mesosphere.com"
-          git merge -m "Merge Commit" origin/master
+          git merge -m "Merge Commit" origin/releases/0.3
       - run: ./test/run_tests.sh
   release:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
       - run: |
           git config user.name "Circle CI"
           git config user.email "ci@mesosphere.com"
-          git merge -m "Merge Commit" origin/master
+          git merge -m "Merge Commit" origin/releases/0.3
       - run: make check-formatting
       - save_cache:
           key: go-mod-v1-{{ checksum "go.sum" }}

--- a/docs/deployment/20-deployment.yaml
+++ b/docs/deployment/20-deployment.yaml
@@ -44,7 +44,7 @@ spec:
               fieldPath: metadata.namespace
         - name: SECRET_NAME
           value: kudo-webhook-server-secret
-        image: kudobuilder/controller:v0.2.0
+        image: kudobuilder/controller:v0.3.2
         imagePullPolicy: Always
         name: manager
         ports:


### PR DESCRIPTION

**What type of PR is this?**
 /kind cleanup

**What this PR does / why we need it**:
This PR is against `releases/0.3` branch and is in preparation for the `v0.3.2` release.   It makes our CRDs useable for the release they are tagged in.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```