### PR TITLE
fix planexecution controller to check parameter default also

### DIFF
--- a/pkg/controller/planexecution/planexecution_controller.go
+++ b/pkg/controller/planexecution/planexecution_controller.go
@@ -306,7 +306,7 @@ func (r *ReconcilePlanExecution) Reconcile(request reconcile.Request) (reconcile
 		_, ok := params[param.Name]
 		if !ok {
 			// Not specified in params
-			if param.Required {
+			if param.Required && param.Default == nil {
 				err = fmt.Errorf("parameter %v was required but not provided by instance %v", param.Name, instance.Name)
 				log.Printf("PlanExecutionController: %v", err)
 				r.recorder.Event(planExecution, "Warning", "MissingParameter", fmt.Sprintf("Could not find required parameter (%v)", param.Name))


### PR DESCRIPTION


**What type of PR is this?**
 /kind bug

**What this PR does / why we need it**:
This PR fixes the issues of planexecution not passing the correct default params 
and showing in logs: 
```
PlanExecutionController: parameter cpus was required but not provided by instance zk
```
```
PlanExecutionController: parameter LOG_CLEANER_IO_BUFFER_LOAD_FACTOR was required but not provided by instance kafka
```
**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```