### PR TITLE
Add Build IDs to gorelease Release Builds

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,6 +11,7 @@ before:
     - go generate ./...
 builds:
 -
+  id: "manager"
   binary: manager
   main: cmd/manager/main.go
   ldflags:
@@ -24,6 +25,7 @@ builds:
     - amd64
     - arm
 -
+  id: "kubectl-kudo"
   binary: kubectl-kudo
   main: cmd/kubectl-kudo/main.go
   ldflags:


### PR DESCRIPTION

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
We discovered in the process of releasing `v0.3.2` that the latest goreleaser uses the project folder as the default name of the build id.  Since we have 2 builds, they both had the same build id.   We needed to provide proper discreet build ids.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```