### PR TITLE
Fix operator upgrades

### DIFF
--- a/pkg/controller/planexecution/planexecution_controller.go
+++ b/pkg/controller/planexecution/planexecution_controller.go
@@ -398,6 +398,7 @@ func (r *ReconcilePlanExecution) Reconcile(request reconcile.Request) (reconcile
 							"plan":          planExecution.Spec.PlanName,
 							"phase":         phase.Name,
 							"step":          step.Name,
+							"version":       operatorVersion.Spec.Version,
 						},
 						GeneratorOptions: &ktypes.GeneratorOptions{
 							DisableNameSuffixHash: true,

--- a/pkg/controller/planexecution/planexecution_controller.go
+++ b/pkg/controller/planexecution/planexecution_controller.go
@@ -391,7 +391,6 @@ func (r *ReconcilePlanExecution) Reconcile(request reconcile.Request) (reconcile
 						CommonLabels: map[string]string{
 							"heritage": "kudo",
 							"app":      operatorVersion.Spec.Operator.Name,
-							"version":  operatorVersion.Spec.Version,
 							"instance": instance.Name,
 						},
 						CommonAnnotations: map[string]string{

--- a/test/integration/patch/00-assert.yaml
+++ b/test/integration/patch/00-assert.yaml
@@ -4,7 +4,6 @@ metadata:
   name: toy1-my-service
   labels:
     app: "toy"
-    version: "1.0.0"
     instance: "toy1"
   annotations:
     plan: "deploy"

--- a/test/integration/patch/01-assert.yaml
+++ b/test/integration/patch/01-assert.yaml
@@ -4,7 +4,6 @@ metadata:
   name: toy1-my-service
   labels:
     app: "toy"
-    version: "1.0.0"
     instance: "toy1"
   annotations:
     plan: "scale"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kudo/blob/master/CONTRIBUTING.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kudobuilder/kudo/blob/master/RELEASE.md
3. Ensure you have added or ran the appropriate tests for your PR
4. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
controller was adding version labels with every patch of an object. This is fine for all objects except statefulsets.

```
"volumeClaimTemplates": [
      {
        "metadata": {
          ...
          "labels": {
           ....
            "version": "0.1.0"
          }
```

that was causing the same error as helm was dealing with here https://github.com/helm/charts/issues/7803

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #557 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fixes upgrades for operators using statefulsets - it was not possible to upgrade those to another version of template.
```