### PR TITLE
Support installing a CRD in a test step and using it in a later test step.

### DIFF
--- a/pkg/test/case.go
+++ b/pkg/test/case.go
@@ -30,15 +30,22 @@ type Case struct {
 	SkipDelete bool
 	Timeout    int
 
-	Client          client.Client
-	DiscoveryClient discovery.DiscoveryInterface
-	Logger          testutils.Logger
+	Client          func(forceNew bool) (client.Client, error)
+	DiscoveryClient func() (discovery.DiscoveryInterface, error)
+
+	Logger testutils.Logger
 }
 
 // DeleteNamespace deletes a namespace in Kubernetes after we are done using it.
 func (t *Case) DeleteNamespace(namespace string) error {
 	t.Logger.Log("Deleting namespace:", namespace)
-	return t.Client.Delete(context.TODO(), &corev1.Namespace{
+
+	cl, err := t.Client(false)
+	if err != nil {
+		return err
+	}
+
+	return cl.Delete(context.TODO(), &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: namespace,
 		},
@@ -51,7 +58,13 @@ func (t *Case) DeleteNamespace(namespace string) error {
 // CreateNamespace creates a namespace in Kubernetes to use for a test.
 func (t *Case) CreateNamespace(namespace string) error {
 	t.Logger.Log("Creating namespace:", namespace)
-	return t.Client.Create(context.TODO(), &corev1.Namespace{
+
+	cl, err := t.Client(false)
+	if err != nil {
+		return err
+	}
+
+	return cl.Create(context.TODO(), &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: namespace,
 		},

--- a/pkg/test/case_test.go
+++ b/pkg/test/case_test.go
@@ -65,8 +65,9 @@ func TestLoadTestSteps(t *testing.T) {
 						Delete: []kudo.ObjectReference{
 							{
 								ObjectReference: corev1.ObjectReference{
-									Kind: "Pod",
-									Name: "test",
+									APIVersion: "v1",
+									Kind:       "Pod",
+									Name:       "test",
 								},
 							},
 						},

--- a/pkg/test/harness_integration_test.go
+++ b/pkg/test/harness_integration_test.go
@@ -1,0 +1,24 @@
+// +build integration
+
+package test
+
+import (
+	"testing"
+
+	kudo "github.com/kudobuilder/kudo/pkg/apis/kudo/v1alpha1"
+)
+
+func TestHarnessRunIntegration(t *testing.T) {
+	harness := Harness{
+		TestSuite: kudo.TestSuite{
+			CRDDir: "../../config/crds/",
+			TestDirs: []string{
+				"./test_data/",
+			},
+			StartKUDO:         false,
+			StartControlPlane: true,
+		},
+		T: t,
+	}
+	harness.Run()
+}

--- a/pkg/test/step.go
+++ b/pkg/test/step.go
@@ -33,21 +33,33 @@ type Step struct {
 	Apply   []runtime.Object
 	Errors  []runtime.Object
 
-	Timeout         int
-	DiscoveryClient discovery.DiscoveryInterface
-	Client          client.Client
-	Logger          testutils.Logger
+	Timeout int
+
+	Client          func(forceNew bool) (client.Client, error)
+	DiscoveryClient func() (discovery.DiscoveryInterface, error)
+
+	Logger testutils.Logger
 }
 
 // Clean deletes all resources defined in the Apply list.
 func (s *Step) Clean(namespace string) error {
+	cl, err := s.Client(false)
+	if err != nil {
+		return err
+	}
+
+	dClient, err := s.DiscoveryClient()
+	if err != nil {
+		return err
+	}
+
 	for _, obj := range s.Apply {
-		_, _, err := testutils.Namespaced(s.DiscoveryClient, obj, namespace)
+		_, _, err := testutils.Namespaced(dClient, obj, namespace)
 		if err != nil {
 			return err
 		}
 
-		if err := s.Client.Delete(context.TODO(), obj); err != nil && !k8serrors.IsNotFound(err) {
+		if err := cl.Delete(context.TODO(), obj); err != nil && !k8serrors.IsNotFound(err) {
 			return err
 		}
 	}
@@ -57,6 +69,16 @@ func (s *Step) Clean(namespace string) error {
 
 // DeleteExisting deletes any resources in the TestStep.Delete list prior to running the tests.
 func (s *Step) DeleteExisting(namespace string) error {
+	cl, err := s.Client(false)
+	if err != nil {
+		return err
+	}
+
+	dClient, err := s.DiscoveryClient()
+	if err != nil {
+		return err
+	}
+
 	toDelete := []runtime.Object{}
 
 	if s.Step == nil {
@@ -73,7 +95,7 @@ func (s *Step) DeleteExisting(namespace string) error {
 			objNs = ref.Namespace
 		}
 
-		_, objNs, err := testutils.Namespaced(s.DiscoveryClient, obj, objNs)
+		_, objNs, err := testutils.Namespaced(dClient, obj, objNs)
 		if err != nil {
 			return err
 		}
@@ -87,7 +109,7 @@ func (s *Step) DeleteExisting(namespace string) error {
 				listOptions = append(listOptions, client.InNamespace(objNs))
 			}
 
-			err := s.Client.List(context.TODO(), u, listOptions...)
+			err := cl.List(context.TODO(), u, listOptions...)
 			if err != nil {
 				return errors.Wrap(err, "listing matching resources")
 			}
@@ -102,7 +124,7 @@ func (s *Step) DeleteExisting(namespace string) error {
 	}
 
 	for _, obj := range toDelete {
-		err := s.Client.Delete(context.TODO(), obj.DeepCopyObject())
+		err := cl.Delete(context.TODO(), obj.DeepCopyObject())
 		if err != nil && !k8serrors.IsNotFound(err) {
 			return err
 		}
@@ -111,7 +133,7 @@ func (s *Step) DeleteExisting(namespace string) error {
 	// Wait for resources to be deleted.
 	return wait.PollImmediate(100*time.Millisecond, 10*time.Second, func() (done bool, err error) {
 		for _, obj := range toDelete {
-			err = s.Client.Get(context.TODO(), testutils.ObjectKey(obj), obj.DeepCopyObject())
+			err = cl.Get(context.TODO(), testutils.ObjectKey(obj), obj.DeepCopyObject())
 			if err == nil || !k8serrors.IsNotFound(err) {
 				return false, err
 			}
@@ -123,16 +145,26 @@ func (s *Step) DeleteExisting(namespace string) error {
 
 // Create applies all resources defined in the Apply list.
 func (s *Step) Create(namespace string) []error {
+	cl, err := s.Client(true)
+	if err != nil {
+		return []error{err}
+	}
+
+	dClient, err := s.DiscoveryClient()
+	if err != nil {
+		return []error{err}
+	}
+
 	errors := []error{}
 
 	for _, obj := range s.Apply {
-		_, _, err := testutils.Namespaced(s.DiscoveryClient, obj, namespace)
+		_, _, err := testutils.Namespaced(dClient, obj, namespace)
 		if err != nil {
 			errors = append(errors, err)
 			continue
 		}
 
-		if updated, err := testutils.CreateOrUpdate(context.TODO(), s.Client, obj, true); err != nil {
+		if updated, err := testutils.CreateOrUpdate(context.TODO(), cl, obj, true); err != nil {
 			errors = append(errors, err)
 		} else {
 			action := "created"
@@ -157,9 +189,19 @@ func (s *Step) GetTimeout() int {
 
 // CheckResource checks if the expected resource's state in Kubernetes is correct.
 func (s *Step) CheckResource(expected runtime.Object, namespace string) []error {
+	cl, err := s.Client(false)
+	if err != nil {
+		return []error{err}
+	}
+
+	dClient, err := s.DiscoveryClient()
+	if err != nil {
+		return []error{err}
+	}
+
 	testErrors := []error{}
 
-	name, namespace, err := testutils.Namespaced(s.DiscoveryClient, expected, namespace)
+	name, namespace, err := testutils.Namespaced(dClient, expected, namespace)
 	if err != nil {
 		return append(testErrors, err)
 	}
@@ -172,7 +214,7 @@ func (s *Step) CheckResource(expected runtime.Object, namespace string) []error 
 		actual := &unstructured.Unstructured{}
 		actual.SetGroupVersionKind(gvk)
 
-		err = s.Client.Get(context.TODO(), client.ObjectKey{
+		err = cl.Get(context.TODO(), client.ObjectKey{
 			Namespace: namespace,
 			Name:      name,
 		}, actual)
@@ -188,7 +230,7 @@ func (s *Step) CheckResource(expected runtime.Object, namespace string) []error 
 			listOptions = append(listOptions, client.InNamespace(namespace))
 		}
 
-		err = s.Client.List(context.TODO(), actual, listOptions...)
+		err = cl.List(context.TODO(), actual, listOptions...)
 
 		for index := range actual.Items {
 			actuals = append(actuals, &actual.Items[index])

--- a/pkg/test/step_test.go
+++ b/pkg/test/step_test.go
@@ -11,6 +11,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/discovery"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -26,19 +27,21 @@ func TestStepClean(t *testing.T) {
 	pod2WithNamespace := testutils.NewPod("hello2", namespace)
 	pod2WithDiffNamespace := testutils.NewPod("hello2", "different-namespace")
 
+	cl := fake.NewFakeClient(pod, pod2WithNamespace, pod2WithDiffNamespace)
+
 	step := Step{
 		Apply: []runtime.Object{
 			pod.DeepCopyObject(), pod2WithDiffNamespace.DeepCopyObject(), testutils.NewPod("does-not-exist", ""),
 		},
-		Client:          fake.NewFakeClient(pod, pod2WithNamespace, pod2WithDiffNamespace),
-		DiscoveryClient: testutils.FakeDiscoveryClient(),
+		Client:          func(bool) (client.Client, error) { return cl, nil },
+		DiscoveryClient: func() (discovery.DiscoveryInterface, error) { return testutils.FakeDiscoveryClient(), nil },
 	}
 
 	assert.Nil(t, step.Clean(namespace))
 
-	assert.True(t, k8serrors.IsNotFound(step.Client.Get(context.TODO(), testutils.ObjectKey(podWithNamespace), podWithNamespace)))
-	assert.True(t, k8serrors.IsNotFound(step.Client.Get(context.TODO(), testutils.ObjectKey(pod2WithNamespace), pod2WithNamespace)))
-	assert.Nil(t, step.Client.Get(context.TODO(), testutils.ObjectKey(pod2WithDiffNamespace), pod2WithDiffNamespace))
+	assert.True(t, k8serrors.IsNotFound(cl.Get(context.TODO(), testutils.ObjectKey(podWithNamespace), podWithNamespace)))
+	assert.True(t, k8serrors.IsNotFound(cl.Get(context.TODO(), testutils.ObjectKey(pod2WithNamespace), pod2WithNamespace)))
+	assert.Nil(t, cl.Get(context.TODO(), testutils.ObjectKey(pod2WithDiffNamespace), pod2WithDiffNamespace))
 }
 
 // Verify the test state as loaded from disk.
@@ -54,26 +57,28 @@ func TestStepCreate(t *testing.T) {
 		"replicas": 2,
 	})
 
+	cl := fake.NewFakeClient(testutils.WithNamespace(podToUpdate, "world"))
+
 	step := Step{
 		Logger: testutils.NewTestLogger(t, ""),
 		Apply: []runtime.Object{
 			pod.DeepCopyObject(), podWithNamespace.DeepCopyObject(), clusterScopedResource, updateToApply,
 		},
-		Client:          fake.NewFakeClient(testutils.WithNamespace(podToUpdate, "world")),
-		DiscoveryClient: testutils.FakeDiscoveryClient(),
+		Client:          func(bool) (client.Client, error) { return cl, nil },
+		DiscoveryClient: func() (discovery.DiscoveryInterface, error) { return testutils.FakeDiscoveryClient(), nil },
 	}
 
 	assert.Equal(t, []error{}, step.Create(namespace))
 
-	assert.Nil(t, step.Client.Get(context.TODO(), testutils.ObjectKey(pod), pod))
-	assert.Nil(t, step.Client.Get(context.TODO(), testutils.ObjectKey(clusterScopedResource), clusterScopedResource))
+	assert.Nil(t, cl.Get(context.TODO(), testutils.ObjectKey(pod), pod))
+	assert.Nil(t, cl.Get(context.TODO(), testutils.ObjectKey(clusterScopedResource), clusterScopedResource))
 
-	assert.Nil(t, step.Client.Get(context.TODO(), testutils.ObjectKey(podToUpdate), podToUpdate))
+	assert.Nil(t, cl.Get(context.TODO(), testutils.ObjectKey(podToUpdate), podToUpdate))
 	assert.Equal(t, updateToApply, podToUpdate)
 
-	assert.True(t, k8serrors.IsNotFound(step.Client.Get(context.TODO(), testutils.ObjectKey(podWithNamespace), podWithNamespace)))
+	assert.True(t, k8serrors.IsNotFound(cl.Get(context.TODO(), testutils.ObjectKey(podWithNamespace), podWithNamespace)))
 	actual := testutils.NewPod("hello2", namespace)
-	assert.Nil(t, step.Client.Get(context.TODO(), testutils.ObjectKey(actual), actual))
+	assert.Nil(t, cl.Get(context.TODO(), testutils.ObjectKey(actual), actual))
 }
 
 // Verify that the DeleteExisting method properly cleans up resources during a test step.
@@ -83,6 +88,8 @@ func TestStepDeleteExisting(t *testing.T) {
 	podToDelete := testutils.NewPod("delete-me", "world")
 	podToDeleteDefaultNS := testutils.NewPod("also-delete-me", "default")
 	podToKeep := testutils.NewPod("keep-me", "world")
+
+	cl := fake.NewFakeClient(podToDelete, podToKeep, podToDeleteDefaultNS)
 
 	step := Step{
 		Logger: testutils.NewTestLogger(t, ""),
@@ -105,19 +112,19 @@ func TestStepDeleteExisting(t *testing.T) {
 				},
 			},
 		},
-		Client:          fake.NewFakeClient(podToDelete, podToKeep, podToDeleteDefaultNS),
-		DiscoveryClient: testutils.FakeDiscoveryClient(),
+		Client:          func(bool) (client.Client, error) { return cl, nil },
+		DiscoveryClient: func() (discovery.DiscoveryInterface, error) { return testutils.FakeDiscoveryClient(), nil },
 	}
 
-	assert.Nil(t, step.Client.Get(context.TODO(), testutils.ObjectKey(podToKeep), podToKeep))
-	assert.Nil(t, step.Client.Get(context.TODO(), testutils.ObjectKey(podToDelete), podToDelete))
-	assert.Nil(t, step.Client.Get(context.TODO(), testutils.ObjectKey(podToDeleteDefaultNS), podToDeleteDefaultNS))
+	assert.Nil(t, cl.Get(context.TODO(), testutils.ObjectKey(podToKeep), podToKeep))
+	assert.Nil(t, cl.Get(context.TODO(), testutils.ObjectKey(podToDelete), podToDelete))
+	assert.Nil(t, cl.Get(context.TODO(), testutils.ObjectKey(podToDeleteDefaultNS), podToDeleteDefaultNS))
 
 	assert.Nil(t, step.DeleteExisting(namespace))
 
-	assert.Nil(t, step.Client.Get(context.TODO(), testutils.ObjectKey(podToKeep), podToKeep))
-	assert.True(t, k8serrors.IsNotFound(step.Client.Get(context.TODO(), testutils.ObjectKey(podToDelete), podToDelete)))
-	assert.True(t, k8serrors.IsNotFound(step.Client.Get(context.TODO(), testutils.ObjectKey(podToDeleteDefaultNS), podToDeleteDefaultNS)))
+	assert.Nil(t, cl.Get(context.TODO(), testutils.ObjectKey(podToKeep), podToKeep))
+	assert.True(t, k8serrors.IsNotFound(cl.Get(context.TODO(), testutils.ObjectKey(podToDelete), podToDelete)))
+	assert.True(t, k8serrors.IsNotFound(cl.Get(context.TODO(), testutils.ObjectKey(podToDeleteDefaultNS), podToDeleteDefaultNS)))
 }
 
 func TestCheckResource(t *testing.T) {
@@ -164,8 +171,8 @@ func TestCheckResource(t *testing.T) {
 
 			step := Step{
 				Logger:          testutils.NewTestLogger(t, ""),
-				Client:          fake.NewFakeClient(test.actual),
-				DiscoveryClient: fakeDiscovery,
+				Client:          func(bool) (client.Client, error) { return fake.NewFakeClient(test.actual), nil },
+				DiscoveryClient: func() (discovery.DiscoveryInterface, error) { return fakeDiscovery, nil },
 			}
 
 			errors := step.CheckResource(test.expected, namespace)
@@ -231,8 +238,10 @@ func TestRun(t *testing.T) {
 				Timeout: 1,
 			}
 
-			test.Step.Client = fake.NewFakeClient()
-			test.Step.DiscoveryClient = testutils.FakeDiscoveryClient()
+			cl := fake.NewFakeClient()
+
+			test.Step.Client = func(bool) (client.Client, error) { return cl, nil }
+			test.Step.DiscoveryClient = func() (discovery.DiscoveryInterface, error) { return testutils.FakeDiscoveryClient(), nil }
 			test.Step.Logger = testutils.NewTestLogger(t, "")
 
 			if test.updateMethod != nil {
@@ -240,7 +249,7 @@ func TestRun(t *testing.T) {
 
 				go func() {
 					time.Sleep(time.Second * 2)
-					test.updateMethod(t, test.Step.Client)
+					test.updateMethod(t, cl)
 				}()
 			}
 

--- a/pkg/test/test_data/create-or-update/00-assert.yaml
+++ b/pkg/test/test_data/create-or-update/00-assert.yaml
@@ -1,0 +1,13 @@
+# Wait for CRD to be ready.
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: prowjobs.prow.k8s.io
+status:
+  acceptedNames:
+    kind: ProwJob
+    listKind: ProwJobList
+    plural: prowjobs
+    singular: prowjob
+  storedVersions:
+  - v1

--- a/pkg/test/test_data/create-or-update/00-crd.yaml
+++ b/pkg/test/test_data/create-or-update/00-crd.yaml
@@ -1,0 +1,88 @@
+# Create the CRD needed for the "unknown-crd" step.
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: prowjobs.prow.k8s.io
+spec:
+  group: prow.k8s.io
+  version: v1
+  names:
+    kind: ProwJob
+    singular: prowjob
+    plural: prowjobs
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          properties:
+            max_concurrency:
+              type: integer
+              minimum: 0
+            type:
+              type: string
+              enum:
+              - "presubmit"
+              - "postsubmit"
+              - "periodic"
+              - "batch"
+        status:
+          properties:
+            state:
+              type: string
+              enum:
+              - "triggered"
+              - "pending"
+              - "success"
+              - "failure"
+              - "aborted"
+              - "error"
+          anyOf:
+          - not:
+              properties:
+                state:
+                  type: string
+                  enum:
+                  - "success"
+                  - "failure"
+                  - "error"
+                  - "aborted"
+          - required:
+            - completionTime
+  additionalPrinterColumns:
+  - name: Job
+    type: string
+    description: The name of the job being run.
+    JSONPath: .spec.job
+  - name: BuildId
+    type: string
+    description: The ID of the job being run.
+    JSONPath: .status.build_id
+  - name: Type
+    type: string
+    description: The type of job being run.
+    JSONPath: .spec.type
+  - name: Org
+    type: string
+    description: The org for which the job is running.
+    JSONPath: .spec.refs.org
+  - name: Repo
+    type: string
+    description: The repo for which the job is running.
+    JSONPath: .spec.refs.repo
+  - name: Pulls
+    type: string
+    description: The pulls for which the job is running.
+    JSONPath: ".spec.refs.pulls[*].number"
+  - name: StartTime
+    type: date
+    description: When the job started running.
+    JSONPath: .status.startTime
+  - name: CompletionTime
+    type: date
+    description: When the job finished running.
+    JSONPath: .status.completionTime
+  - name: State
+    description: The state of the job.
+    type: string
+    JSONPath: .status.state

--- a/pkg/test/test_data/create-or-update/02-assert.yaml
+++ b/pkg/test/test_data/create-or-update/02-assert.yaml
@@ -1,0 +1,58 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  labels:
+    app: nginx
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1234
+        ports:
+        - containerPort: 80
+---
+apiVersion: kudo.k8s.io/v1alpha1
+kind: Instance
+metadata:
+  name: my-instance
+spec:
+  parameters:
+    PARAM: "abcdef"
+  operatorVersion:
+    name: job-operator
+    kind: OperatorVersion
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: svc
+spec:
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  type: ClusterIP
+---
+apiVersion: prow.k8s.io/v1
+kind: ProwJob
+metadata:
+  name: my-job
+spec:
+  agent: kubernetes
+  cluster: default
+  pod_spec:
+    containers:
+    - command:
+      - test
+      image: alpine:1234
+      imagePullPolicy: Always

--- a/pkg/test/test_data/create-or-update/02-update-deployment.yaml
+++ b/pkg/test/test_data/create-or-update/02-update-deployment.yaml
@@ -1,0 +1,13 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  replicas: 2
+  template:
+    spec:
+      containers:
+      - image: nginx:1234
+        name: nginx
+        ports:
+        - containerPort: 80

--- a/pkg/test/test_data/create-or-update/02-update-deployment.yaml
+++ b/pkg/test/test_data/create-or-update/02-update-deployment.yaml
@@ -2,9 +2,17 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: nginx-deployment
+  labels:
+    app: nginx
 spec:
   replicas: 2
+  selector:
+    matchLabels:
+      app: nginx
   template:
+    metadata:
+      labels:
+        app: nginx
     spec:
       containers:
       - image: nginx:1234

--- a/pkg/test/test_data/with-overrides/01-test-assert.yaml
+++ b/pkg/test/test_data/with-overrides/01-test-assert.yaml
@@ -11,5 +11,6 @@ spec:
 apiVersion: kudo.k8s.io/v1alpha1
 kind: TestStep
 delete:
-- kind: Pod
+- apiVersion: v1
+  kind: Pod
   name: test

--- a/pkg/test/utils/kubernetes.go
+++ b/pkg/test/utils/kubernetes.go
@@ -272,8 +272,6 @@ func ConvertUnstructured(in runtime.Object) (runtime.Object, error) {
 		converted = &kudo.TestAssert{}
 	} else if group == "kudo.k8s.io" && kind == "TestSuite" {
 		converted = &kudo.TestSuite{}
-	} else if group == "apiextensions.k8s.io" && kind == "CustomResourceDefinition" {
-		converted = &apiextensions.CustomResourceDefinition{}
 	} else if group == "kind.sigs.k8s.io" && kind == "Cluster" {
 		converted = &kindConfig.Cluster{}
 	} else {
@@ -305,15 +303,13 @@ func PatchObject(actual, expected runtime.Object) error {
 	return nil
 }
 
-// MarshalObject marshals a Kubernetes object to a YAML string.
-func MarshalObject(o runtime.Object, w io.Writer) error {
-	encoder := json.NewYAMLSerializer(json.DefaultMetaFactory, nil, nil)
-
+// CleanObjectForMarshalling removes unnecessary object metadata that should not be included in serialization and diffs.
+func CleanObjectForMarshalling(o runtime.Object) (runtime.Object, error) {
 	copied := o.DeepCopyObject()
 
 	meta, err := meta.Accessor(copied)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	meta.SetResourceVersion("")
@@ -331,7 +327,27 @@ func MarshalObject(o runtime.Object, w io.Writer) error {
 		meta.SetAnnotations(nil)
 	}
 
-	return encoder.Encode(copied, w)
+	return copied, nil
+}
+
+// MarshalObject marshals a Kubernetes object to a YAML string.
+func MarshalObject(o runtime.Object, w io.Writer) error {
+	copied, err := CleanObjectForMarshalling(o)
+	if err != nil {
+		return err
+	}
+
+	return json.NewYAMLSerializer(json.DefaultMetaFactory, nil, nil).Encode(copied, w)
+}
+
+// MarshalObjectJSON marshals a Kubernetes object to a JSON string.
+func MarshalObjectJSON(o runtime.Object, w io.Writer) error {
+	copied, err := CleanObjectForMarshalling(o)
+	if err != nil {
+		return err
+	}
+
+	return json.NewSerializer(json.DefaultMetaFactory, nil, nil, false).Encode(copied, w)
 }
 
 // LoadYAML loads all objects from a YAML file.
@@ -371,6 +387,19 @@ func LoadYAML(path string) ([]runtime.Object, error) {
 	}
 
 	return objects, nil
+}
+
+// MatchesKind returns true if the Kubernetes kind of obj matches any of kinds.
+func MatchesKind(obj runtime.Object, kinds ...runtime.Object) bool {
+	gvk := obj.GetObjectKind().GroupVersionKind()
+
+	for _, kind := range kinds {
+		if kind.GetObjectKind().GroupVersionKind() == gvk {
+			return true
+		}
+	}
+
+	return false
 }
 
 // InstallManifests recurses over ManifestsDir to install all resources defined in YAML manifests.
@@ -605,8 +634,13 @@ func GetAPIResource(dClient discovery.DiscoveryInterface, gvk schema.GroupVersio
 // WaitForCRDs waits for the provided CRD types to be available in the Kubernetes API.
 func WaitForCRDs(dClient discovery.DiscoveryInterface, crds []runtime.Object) error {
 	waitingFor := []schema.GroupVersionKind{}
+	crdKind := NewResource("apiextensions.k8s.io/v1beta1", "CustomResourceDefinition", "", "")
 
 	for _, crdObj := range crds {
+		if !MatchesKind(crdObj, crdKind) {
+			continue
+		}
+
 		crd, ok := crdObj.(*apiextensions.CustomResourceDefinition)
 		if !ok {
 			continue

--- a/pkg/test/utils/kubernetes_test.go
+++ b/pkg/test/utils/kubernetes_test.go
@@ -183,3 +183,44 @@ spec:
 		},
 	}, objs[1])
 }
+
+func TestMatchesKind(t *testing.T) {
+	tmpfile, err := ioutil.TempFile("", "test.yaml")
+	assert.Nil(t, err)
+	defer tmpfile.Close()
+
+	ioutil.WriteFile(tmpfile.Name(), []byte(`
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hello
+spec:
+  containers:
+  - name: nginx
+    image: nginx:1.7.9
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: hello
+`), 0644)
+
+	objs, err := LoadYAML(tmpfile.Name())
+	assert.Nil(t, err)
+
+	crd := NewResource("apiextensions.k8s.io/v1beta1", "CustomResourceDefinition", "", "")
+	pod := NewResource("v1", "Pod", "", "")
+	svc := NewResource("v1", "Service", "", "")
+
+	assert.False(t, MatchesKind(objs[0], crd))
+	assert.True(t, MatchesKind(objs[0], pod))
+	assert.True(t, MatchesKind(objs[0], pod, crd))
+	assert.True(t, MatchesKind(objs[0], crd, pod))
+	assert.False(t, MatchesKind(objs[0], crd, svc))
+
+	assert.True(t, MatchesKind(objs[1], crd))
+	assert.False(t, MatchesKind(objs[1], pod))
+	assert.True(t, MatchesKind(objs[1], pod, crd))
+	assert.True(t, MatchesKind(objs[1], crd, pod))
+	assert.False(t, MatchesKind(objs[1], svc, pod))
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kudo/blob/master/CONTRIBUTING.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kudobuilder/kudo/blob/master/RELEASE.md
3. Ensure you have added or ran the appropriate tests for your PR
4. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What type of PR is this?**

/kind enhancement

**What this PR does / why we need it**:

This allows a user to include CRDs in test steps and use them in later test steps. Prior to this, all CRDs had to be included in the `crdDir`, which could be messy depending on the test case (e.g., I wanted to write a test for the harness for a CRD that is explicitly not included in the runtime scheme and don't want to pollute `config/crds`).

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
N/A but unblocks a test for a feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```