### PR TITLE
Respect namespaces if they are set in test harness.

### DIFF
--- a/keps/0008-operator-testing.md
+++ b/keps/0008-operator-testing.md
@@ -124,7 +124,7 @@ Test cases will be authored by defining Kubernetes objects to apply and Kubernet
 
 Tests will be invoked via a CLI tool that runs the test suite against the current Kubernetes context by default, or optionally against a mocked control plane or kind (kubernetes-in-docker) cluster. It will be packaged with the default set of test suites from the KUDO Operators repository using go-bindata, with the ability to provide alternative directories containing tests to use.
 
-The tool will enumerate each test case (group of test steps) and run them concurrently in batches. Each test case will run in its own namespace (care must be taken that cluster-level resources do not collide with other test cases [??? TODO: solvable?]) which will be deleted after the test case has been completed.
+The tool will enumerate each test case (group of test steps) and run them concurrently in batches. Each test case will run in its own namespace (care must be taken that cluster-level resources do not collide with other test cases [??? TODO: solvable?]) which will be deleted after the test case has been completed. Resources in test steps that are namespace-level will have their namespace set to the test case namespace if it is not present.
 
 Each test case consists of a directory containing test steps and their expected results ("assertions"). The test steps within a test case are run sequentially, waiting for the assertions to be true, a timeout to pass, or a failure condition to be met.
 

--- a/pkg/test/step_test.go
+++ b/pkg/test/step_test.go
@@ -37,8 +37,8 @@ func TestStepClean(t *testing.T) {
 	assert.Nil(t, step.Clean(namespace))
 
 	assert.True(t, k8serrors.IsNotFound(step.Client.Get(context.TODO(), testutils.ObjectKey(podWithNamespace), podWithNamespace)))
-	assert.True(t, k8serrors.IsNotFound(step.Client.Get(context.TODO(), testutils.ObjectKey(pod2WithNamespace), pod2WithNamespace)))
-	assert.Nil(t, step.Client.Get(context.TODO(), testutils.ObjectKey(pod2WithDiffNamespace), pod2WithDiffNamespace))
+	assert.Nil(t, step.Client.Get(context.TODO(), testutils.ObjectKey(pod2WithNamespace), pod2WithNamespace))
+	assert.True(t, k8serrors.IsNotFound(step.Client.Get(context.TODO(), testutils.ObjectKey(pod2WithDiffNamespace), pod2WithDiffNamespace)))
 }
 
 // Verify the test state as loaded from disk.
@@ -71,9 +71,9 @@ func TestStepCreate(t *testing.T) {
 	assert.Nil(t, step.Client.Get(context.TODO(), testutils.ObjectKey(podToUpdate), podToUpdate))
 	assert.Equal(t, updateToApply, podToUpdate)
 
-	assert.True(t, k8serrors.IsNotFound(step.Client.Get(context.TODO(), testutils.ObjectKey(podWithNamespace), podWithNamespace)))
+	assert.Nil(t, step.Client.Get(context.TODO(), testutils.ObjectKey(podWithNamespace), podWithNamespace))
 	actual := testutils.NewPod("hello2", namespace)
-	assert.Nil(t, step.Client.Get(context.TODO(), testutils.ObjectKey(actual), actual))
+	assert.True(t, k8serrors.IsNotFound(step.Client.Get(context.TODO(), testutils.ObjectKey(actual), actual)))
 }
 
 // Verify that the DeleteExisting method properly cleans up resources during a test step.

--- a/pkg/test/utils/kubernetes.go
+++ b/pkg/test/utils/kubernetes.go
@@ -210,10 +210,15 @@ func ResourceID(obj runtime.Object) string {
 
 // Namespaced sets the namespace on an object to namespace, if it is a namespace scoped resource.
 // If the resource is cluster scoped, then it is ignored and the namespace is not set.
+// If it is a namespaced resource and a namespace is already set, then the namespace is unchanged.
 func Namespaced(dClient discovery.DiscoveryInterface, obj runtime.Object, namespace string) (string, string, error) {
 	m, err := meta.Accessor(obj)
 	if err != nil {
 		return "", "", err
+	}
+
+	if m.GetNamespace() != "" {
+		return m.GetName(), m.GetNamespace(), nil
 	}
 
 	resource, err := GetAPIResource(dClient, obj.GetObjectKind().GroupVersionKind())

--- a/pkg/test/utils/kubernetes_test.go
+++ b/pkg/test/utils/kubernetes_test.go
@@ -18,22 +18,36 @@ func TestNamespaced(t *testing.T) {
 	fake := FakeDiscoveryClient()
 
 	for _, test := range []struct {
-		testName             string
-		resource             runtime.Object
-		namespaceShouldBeSet bool
-		shouldError          bool
+		testName    string
+		resource    runtime.Object
+		namespace   string
+		shouldError bool
 	}{
-		{"namespaced resource", NewPod("hello", ""), true, false},
-		{"namespace already set", NewPod("hello", "other"), true, false},
-		{"not-namespaced resource", NewResource("v1", "Namespace", "hello", ""), false, false},
-		{"non-existent resource", NewResource("v1", "Blah", "hello", ""), false, true},
+		{
+			testName:  "namespaced resource",
+			resource:  NewPod("hello", ""),
+			namespace: "set-the-namespace",
+		},
+		{
+			testName:  "namespace already set",
+			resource:  NewPod("hello", "other"),
+			namespace: "other",
+		},
+		{
+			testName:  "not-namespaced resource",
+			resource:  NewResource("v1", "Namespace", "hello", ""),
+			namespace: "",
+		},
+		{
+			testName:    "non-existent resource",
+			resource:    NewResource("v1", "Blah", "hello", ""),
+			shouldError: true,
+		},
 	} {
 		t.Run(test.testName, func(t *testing.T) {
-			namespace := "world"
-
 			m, _ := meta.Accessor(test.resource)
 
-			actualName, actualNamespace, err := Namespaced(fake, test.resource, namespace)
+			actualName, actualNamespace, err := Namespaced(fake, test.resource, "set-the-namespace")
 
 			if test.shouldError {
 				assert.NotNil(t, err)
@@ -43,12 +57,8 @@ func TestNamespaced(t *testing.T) {
 				assert.Equal(t, m.GetName(), actualName)
 			}
 
-			if !test.namespaceShouldBeSet {
-				namespace = ""
-			}
-
-			assert.Equal(t, namespace, actualNamespace)
-			assert.Equal(t, namespace, m.GetNamespace())
+			assert.Equal(t, test.namespace, actualNamespace)
+			assert.Equal(t, test.namespace, m.GetNamespace())
 		})
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kudo/blob/master/CONTRIBUTING.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kudobuilder/kudo/blob/master/RELEASE.md
3. Ensure you have added or ran the appropriate tests for your PR
4. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

This makes it so that if a namespace is set in a resource in a test step or assert that namespace is respected instead of being overwritten with the test case's namespace. This allows tests to be written that span multiple namespaces or test resources that exist in a specific namespace (e.g., check the status of `core-dns` in `kube-system`).

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
N/A

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Tests can now create and assert on resources in any namespace.
```