### PR TITLE
Support collecting cluster logs with kind.

### DIFF
--- a/pkg/apis/kudo/v1alpha1/test_types.go
+++ b/pkg/apis/kudo/v1alpha1/test_types.go
@@ -38,6 +38,8 @@ type TestSuite struct {
 	Timeout int `json:"timeout"`
 	// The maximum number of tests to run at once (default: 8).
 	Parallel int `json:"parallel"`
+	// The directory to output artifacts to (current working directory if not specified).
+	ArtifactsDir string `json:"artifactsDir"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/kudoctl/cmd/test.go
+++ b/pkg/kudoctl/cmd/test.go
@@ -47,6 +47,7 @@ func newTestCmd() *cobra.Command {
 	skipDelete := false
 	skipClusterDelete := false
 	parallel := 0
+	artifactsDir := ""
 
 	options := kudo.TestSuite{}
 
@@ -146,6 +147,10 @@ For more detailed documentation, visit: https://kudo.dev/docs/testing`,
 				options.Parallel = parallel
 			}
 
+			if isSet(flags, "artifacts-dir") {
+				options.ArtifactsDir = artifactsDir
+			}
+
 			if len(args) != 0 {
 				options.TestDirs = args
 			}
@@ -176,6 +181,7 @@ For more detailed documentation, visit: https://kudo.dev/docs/testing`,
 	testCmd.Flags().BoolVar(&startKIND, "start-kind", false, "Start a KIND cluster for the tests (cannot be used with --start-control-plane).")
 	testCmd.Flags().StringVar(&kindConfig, "kind-config", "", "Specify the KIND configuration file path (implies --start-kind, cannot be used with --start-control-plane).")
 	testCmd.Flags().StringVar(&kindContext, "kind-context", "", "Specify the KIND context name to use.")
+	testCmd.Flags().StringVar(&artifactsDir, "artifacts-dir", "", "Directory to output kind logs to (if not specified, the current working directory).")
 	testCmd.Flags().BoolVar(&startKUDO, "start-kudo", false, "Start KUDO during the test run.")
 	testCmd.Flags().BoolVar(&skipDelete, "skip-delete", false, "If set, do not delete resources created during tests (helpful for debugging test failures, implies --skip-cluster-delete).")
 	testCmd.Flags().BoolVar(&skipClusterDelete, "skip-cluster-delete", false, "If set, do not delete the mocked control plane or kind cluster.")

--- a/pkg/test/harness.go
+++ b/pkg/test/harness.go
@@ -310,6 +310,16 @@ func (h *Harness) Stop() {
 		h.managerStopCh = nil
 	}
 
+	if h.kind != nil {
+		logDir := filepath.Join(h.TestSuite.ArtifactsDir, fmt.Sprintf("kind-logs-%d", time.Now().Unix()))
+
+		h.T.Log("collecting cluster logs to", logDir)
+
+		if err := h.kind.CollectLogs(logDir); err != nil {
+			h.T.Log("error collecting kind cluster logs", err)
+		}
+	}
+
 	if h.TestSuite.SkipClusterDelete || h.TestSuite.SkipDelete {
 		// TODO: figure out how to write the Kubernetes client configuration to disk.
 		return


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kudo/blob/master/CONTRIBUTING.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kudobuilder/kudo/blob/master/RELEASE.md
3. Ensure you have added or ran the appropriate tests for your PR
4. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

If a KIND cluster is used for the tests, we collect its logs at the end of the test run into the configurable `--artifacts-dir` (or `.`, if not specified).

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
The test harness now collects logs from kind at the end of test runs.
```