### PR TITLE
Use merge patch instead of Update method in test harness.

### DIFF
--- a/pkg/test/test_data/create-or-update/00-assert.yaml
+++ b/pkg/test/test_data/create-or-update/00-assert.yaml
@@ -1,0 +1,7 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: prowjobs.prow.k8s.io
+status:
+  acceptedNames:
+    kind: ProwJob

--- a/pkg/test/test_data/create-or-update/00-assert.yaml
+++ b/pkg/test/test_data/create-or-update/00-assert.yaml
@@ -16,4 +16,4 @@ status:
     status: "True"
     type: Established
   storedVersions:
-  - v1alpha1
+  - v1

--- a/pkg/test/test_data/create-or-update/00-assert.yaml
+++ b/pkg/test/test_data/create-or-update/00-assert.yaml
@@ -5,3 +5,15 @@ metadata:
 status:
   acceptedNames:
     kind: ProwJob
+  # InitialNamesAccepted will change from False -> True once the CRD is ready.
+  conditions:
+  - message: no conflicts found
+    reason: NoConflicts
+    status: "True"
+    type: NamesAccepted
+  - message: the initial names have been accepted
+    reason: InitialNamesAccepted
+    status: "True"
+    type: Established
+  storedVersions:
+  - v1alpha1

--- a/pkg/test/test_data/create-or-update/00-crd.yaml
+++ b/pkg/test/test_data/create-or-update/00-crd.yaml
@@ -13,18 +13,18 @@ spec:
   validation:
     openAPIV3Schema:
       properties:
-#        spec:
-#          properties:
-#            max_concurrency:
-#              type: integer
-#              minimum: 0.0
-#            type:
-#              type: string
-#              enum:
-#              - "presubmit"
-#              - "postsubmit"
-#              - "periodic"
-#              - "batch"
+        spec:
+          properties:
+            max_concurrency:
+              type: integer
+              minimum: 0
+            type:
+              type: string
+              enum:
+              - "presubmit"
+              - "postsubmit"
+              - "periodic"
+              - "batch"
         status:
           properties:
             state:

--- a/pkg/test/test_data/create-or-update/00-crd.yaml
+++ b/pkg/test/test_data/create-or-update/00-crd.yaml
@@ -1,0 +1,87 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: prowjobs.prow.k8s.io
+spec:
+  group: prow.k8s.io
+  version: v1
+  names:
+    kind: ProwJob
+    singular: prowjob
+    plural: prowjobs
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+#        spec:
+#          properties:
+#            max_concurrency:
+#              type: integer
+#              minimum: 0.0
+#            type:
+#              type: string
+#              enum:
+#              - "presubmit"
+#              - "postsubmit"
+#              - "periodic"
+#              - "batch"
+        status:
+          properties:
+            state:
+              type: string
+              enum:
+              - "triggered"
+              - "pending"
+              - "success"
+              - "failure"
+              - "aborted"
+              - "error"
+          anyOf:
+          - not:
+              properties:
+                state:
+                  type: string
+                  enum:
+                  - "success"
+                  - "failure"
+                  - "error"
+                  - "aborted"
+          - required:
+            - completionTime
+  additionalPrinterColumns:
+  - name: Job
+    type: string
+    description: The name of the job being run.
+    JSONPath: .spec.job
+  - name: BuildId
+    type: string
+    description: The ID of the job being run.
+    JSONPath: .status.build_id
+  - name: Type
+    type: string
+    description: The type of job being run.
+    JSONPath: .spec.type
+  - name: Org
+    type: string
+    description: The org for which the job is running.
+    JSONPath: .spec.refs.org
+  - name: Repo
+    type: string
+    description: The repo for which the job is running.
+    JSONPath: .spec.refs.repo
+  - name: Pulls
+    type: string
+    description: The pulls for which the job is running.
+    JSONPath: ".spec.refs.pulls[*].number"
+  - name: StartTime
+    type: date
+    description: When the job started running.
+    JSONPath: .status.startTime
+  - name: CompletionTime
+    type: date
+    description: When the job finished running.
+    JSONPath: .status.completionTime
+  - name: State
+    description: The state of the job.
+    type: string
+    JSONPath: .status.state

--- a/pkg/test/test_data/create-or-update/01-assert.yaml
+++ b/pkg/test/test_data/create-or-update/01-assert.yaml
@@ -1,0 +1,56 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: svc
+spec:
+  ports:
+  - name: https
+    port: 443
+    protocol: TCP
+    targetPort: 443
+  type: ClusterIP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  labels:
+    app: nginx
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.7.9
+        ports:
+        - containerPort: 80
+---
+apiVersion: kudo.k8s.io/v1alpha1
+kind: Instance
+metadata:
+  name: my-instance
+spec:
+  operatorVersion:
+    name: job-operator
+    kind: OperatorVersion
+---
+apiVersion: prow.k8s.io/v1
+kind: ProwJob
+metadata:
+  name: my-job
+spec:
+  agent: kubernetes
+  cluster: default
+  pod_spec:
+    containers:
+    - command:
+      - test
+      image: alpine
+      imagePullPolicy: Always

--- a/pkg/test/test_data/create-or-update/01-create-deployment.yaml
+++ b/pkg/test/test_data/create-or-update/01-create-deployment.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  labels:
+    app: nginx
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.7.9
+        ports:
+        - containerPort: 80

--- a/pkg/test/test_data/create-or-update/01-create-known-crd.yaml
+++ b/pkg/test/test_data/create-or-update/01-create-known-crd.yaml
@@ -1,0 +1,8 @@
+apiVersion: kudo.k8s.io/v1alpha1
+kind: Instance
+metadata:
+  name: my-instance
+spec:
+  operatorVersion:
+    name: job-operator
+    kind: OperatorVersion

--- a/pkg/test/test_data/create-or-update/01-create-service.yaml
+++ b/pkg/test/test_data/create-or-update/01-create-service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: svc
+spec:
+  ports:
+  - name: https
+    port: 443
+    protocol: TCP
+    targetPort: 443
+  type: ClusterIP

--- a/pkg/test/test_data/create-or-update/01-create-unknown-crd.yaml
+++ b/pkg/test/test_data/create-or-update/01-create-unknown-crd.yaml
@@ -1,0 +1,13 @@
+apiVersion: prow.k8s.io/v1
+kind: ProwJob
+metadata:
+  name: my-job
+spec:
+  agent: kubernetes
+  cluster: default
+  pod_spec:
+    containers:
+    - command:
+      - test
+      image: alpine
+      imagePullPolicy: Always

--- a/pkg/test/test_data/create-or-update/02-assert.yaml
+++ b/pkg/test/test_data/create-or-update/02-assert.yaml
@@ -1,0 +1,58 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  labels:
+    app: nginx
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.7.9
+        ports:
+        - containerPort: 80
+---
+apiVersion: kudo.k8s.io/v1alpha1
+kind: Instance
+metadata:
+  name: my-instance
+spec:
+  parameters:
+    PARAM: "abcdef"
+  operatorVersion:
+    name: job-operator
+    kind: OperatorVersion
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: svc
+spec:
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  type: ClusterIP
+---
+apiVersion: prow.k8s.io/v1
+kind: ProwJob
+metadata:
+  name: my-job
+spec:
+  agent: kubernetes
+  cluster: default
+  pod_spec:
+    containers:
+    - command:
+      - test
+      image: alpine:1234
+      imagePullPolicy: Always

--- a/pkg/test/test_data/create-or-update/02-update-deployment.yaml
+++ b/pkg/test/test_data/create-or-update/02-update-deployment.yaml
@@ -1,0 +1,6 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  replicas: 2

--- a/pkg/test/test_data/create-or-update/02-update-known-crd.yaml
+++ b/pkg/test/test_data/create-or-update/02-update-known-crd.yaml
@@ -1,7 +1,7 @@
 apiVersion: kudo.k8s.io/v1alpha1
 kind: Instance
 metadata:
-  name: operator-test-instance
+  name: my-instance
 spec:
   parameters:
-    REPLICAS: "4"
+    PARAM: "abcdef"

--- a/pkg/test/test_data/create-or-update/02-update-service.yaml
+++ b/pkg/test/test_data/create-or-update/02-update-service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: svc
+spec:
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  type: ClusterIP

--- a/pkg/test/test_data/create-or-update/02-update-unknown-crd.yaml
+++ b/pkg/test/test_data/create-or-update/02-update-unknown-crd.yaml
@@ -1,0 +1,11 @@
+apiVersion: prow.k8s.io/v1
+kind: ProwJob
+metadata:
+  name: my-job
+spec:
+  pod_spec:
+    containers:
+    - image: alpine:1234
+      command:
+      - test
+      imagePullPolicy: Always

--- a/pkg/test/utils/kubernetes.go
+++ b/pkg/test/utils/kubernetes.go
@@ -648,12 +648,11 @@ func CreateOrUpdate(ctx context.Context, cl client.Client, obj runtime.Object, r
 				return err
 			}
 
-			expectedBytes, err := apijson.Marshal(expected)
+			var expectedBytes []byte
+			expectedBytes, err = apijson.Marshal(expected)
 			if err != nil {
 				return err
 			}
-
-			fmt.Println(string(expectedBytes))
 
 			err = cl.Patch(ctx, actual, client.ConstantPatch(types.MergePatchType, expectedBytes))
 			updated = true

--- a/test/integration/immutable-client-ip/01-upgrade.yaml
+++ b/test/integration/immutable-client-ip/01-upgrade.yaml
@@ -5,8 +5,5 @@ metadata:
   labels:
     operator: service-operator
 spec:
-  operatorVersion:
-    name: service-operator
-    kind: OperatorVersion
   parameters:
     LABEL: "hello"

--- a/test/integration/instance-controller-param-change-custom-trigger/01-update-instance.yaml
+++ b/test/integration/instance-controller-param-change-custom-trigger/01-update-instance.yaml
@@ -3,8 +3,5 @@ kind: Instance
 metadata:
   name: icto-custom-trigger
 spec:
-  operatorVersion:
-    name: icto-custom-trigger
-    kind: OperatorVersion
   parameters:
     foo: "new value"

--- a/test/integration/instance-controller-param-change-fallback-to-deploy/01-update-instance.yaml
+++ b/test/integration/instance-controller-param-change-fallback-to-deploy/01-update-instance.yaml
@@ -11,8 +11,5 @@ kind: Instance
 metadata:
   name: icto-fallback-to-deploy
 spec:
-  operatorVersion:
-    name: icto-fallback-to-deploy
-    kind: OperatorVersion
   parameters:
     foo: "new value"

--- a/test/integration/instance-controller-param-change-no-trigger/01-update-instance.yaml
+++ b/test/integration/instance-controller-param-change-no-trigger/01-update-instance.yaml
@@ -2,11 +2,6 @@ apiVersion: kudo.k8s.io/v1alpha1
 kind: Instance
 metadata:
   name: icto-no-trigger
-  labels:
-    operator: icto-no-trigger
 spec:
-  operatorVersion:
-    name: icto-no-trigger
-    kind: OperatorVersion
   parameters:
     foo: "new value"

--- a/test/integration/patch/01-plan-update.yaml
+++ b/test/integration/patch/01-plan-update.yaml
@@ -5,11 +5,6 @@ metadata:
     controller-tools.k8s.io: "1.0"
   name: toy1
 spec:
-  operatorVersion:
-    name: toy-v1
-    kind: OperatorVersion
-    namespace: default
-# Add fields here
+  # Add fields here
   parameters:
-    Param: "30"
     Replicas: "3"

--- a/test/integration/step-delete/01-upgrade.yaml
+++ b/test/integration/step-delete/01-upgrade.yaml
@@ -4,8 +4,5 @@ kind: Instance
 metadata:
   name: step-delete-instance
 spec:
-  operatorVersion:
-    name: job-operator
-    kind: OperatorVersion
   parameters:
     LABEL: "hello"


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This fixes the test harness to use a merge patch instead of `Update`. In our previous use of `Update`, we were replacing entire objects when updating them (e.g., if `status` is not defined in YAML it would get wiped out on update). Instead of using `Update`, we use the merge patching method.

We do *not* use strategic merge patch as it does not work with CRDs and my tests indicate the proper behavior that we want is achieved using only merge patch.

Additionally, as a side effect of this change, only minimal updates need to be defined in test steps.

If validated well, this can guide the implementation of `CreateOrUpdate` in KUDO (or be the implementation of `CreateOrUpdate`).

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
The test harness now uses merge patching to update objects.
```