### PR TITLE
Do not Get after Create/Patch in plan execution controller

### DIFF
--- a/pkg/controller/planexecution/planexecution_controller.go
+++ b/pkg/controller/planexecution/planexecution_controller.go
@@ -435,18 +435,17 @@ func (r *ReconcilePlanExecution) Reconcile(request reconcile.Request) (reconcile
 				}
 
 				//See if its present
-				key, _ := client.ObjectKeyFromObject(obj)
-				truth := obj.DeepCopyObject()
-				err := r.Client.Get(context.TODO(), key, truth)
 				rawObj, _ := apijson.Marshal(obj)
+				key, _ := client.ObjectKeyFromObject(obj)
+				err := r.Client.Get(context.TODO(), key, obj)
 				if err == nil {
 					log.Printf("PlanExecutionController: Object %v already exists for instance %v, going to apply patch", key, instance.Name)
 					//update
-					log.Printf("Going to apply patch\n%+v\n\n to object\n%s\n", string(rawObj), prettyPrint(truth))
+					log.Printf("Going to apply patch\n%+v\n\n to object\n%s\n", string(rawObj), prettyPrint(obj))
 					if err != nil {
 						log.Printf("Error getting patch between truth and obj: %v\n", err)
 					} else {
-						err = r.Client.Patch(context.TODO(), truth, client.ConstantPatch(types.StrategicMergePatchType, rawObj))
+						err = r.Client.Patch(context.TODO(), obj, client.ConstantPatch(types.StrategicMergePatchType, rawObj))
 						if err != nil {
 							// Right now applying a Strategic Merge Patch to custom resources does not work. There is
 							// certain metadata needed, which when missing, leads to an invalid Content-Type Header and
@@ -462,7 +461,7 @@ func (r *ReconcilePlanExecution) Reconcile(request reconcile.Request) (reconcile
 							//
 							// 		Reason: "UnsupportedMediaType" Code: 415
 							if errors.IsUnsupportedMediaType(err) {
-								err = r.Client.Patch(context.TODO(), truth, client.ConstantPatch(types.MergePatchType, rawObj))
+								err = r.Client.Patch(context.TODO(), obj, client.ConstantPatch(types.MergePatchType, rawObj))
 								if err != nil {
 									log.Printf("PlanExecutionController: Error when applying merge patch to object %v for instance %v: %v", key, instance.Name, err)
 								}
@@ -488,14 +487,6 @@ func (r *ReconcilePlanExecution) Reconcile(request reconcile.Request) (reconcile
 					return reconcile.Result{}, err
 				}
 
-				err = r.Client.Get(context.TODO(), key, obj)
-
-				if err != nil {
-					log.Printf("PlanExecutionController: Error getting new object in step \"%v\": %v", s.Name, err)
-					planExecution.Status.Phases[i].State = kudov1alpha1.PhaseStateError
-					planExecution.Status.Phases[i].Steps[j].State = kudov1alpha1.PhaseStateError
-					return reconcile.Result{}, err
-				}
 				err = health.IsHealthy(r.Client, obj)
 				if err != nil {
 					log.Printf("PlanExecutionController: Obj is NOT healthy: %s", prettyPrint(obj))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kudo/blob/master/CONTRIBUTING.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kudobuilder/kudo/blob/master/RELEASE.md
3. Ensure you have added or ran the appropriate tests for your PR
4. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Instead of issuing a Get after Create or Patch in the PlanExecution controller, we use the objects that were updated by the Create and Patch method to prevent read-after-write cache consistency issues.

We also save ourselves a Get because of this :)

**Fixes**:

Fixes #602 

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fixed cache consistency issue in PlanExecution controller.
```