### PR TITLE
Remove merge check from circle CI configuration.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,10 +7,6 @@ jobs:
     machine: true
     steps:
       - checkout
-      - run: |
-          git config user.name "Circle CI"
-          git config user.email "kudobuilder@gmail.com"
-          git merge -m "Merge Commit" origin/master
       - run: ./test/run_tests.sh
   release:
     docker:
@@ -33,10 +29,6 @@ jobs:
           keys:
             - go-mod-v1-{{ checksum "go.sum" }}
 
-      - run: |
-          git config user.name "Circle CI"
-          git config user.email "kudobuilder@gmail.com"
-          git merge -m "Merge Commit" origin/master
       - run: make check-formatting
       - save_cache:
           key: go-mod-v1-{{ checksum "go.sum" }}
@@ -45,7 +37,7 @@ jobs:
             - "/go/bin"
 workflows:
   version: 2
-  formatting:
+  test:
     jobs:
       - code-formatting
       - test


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This removes the merge before running tests in Circle CI. I believe this check provides no value as it runs at *commit time* and not at *merge time*, so there are no guarantees that this even tests the correct merge target and creates difficulty with PR branches. To enforce merge safety, we should use GitHub branch settings.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #568

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```