### PR TITLE
Add a Watch method to the RetryClient

### DIFF
--- a/pkg/test/utils/kubernetes.go
+++ b/pkg/test/utils/kubernetes.go
@@ -30,10 +30,13 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/discovery"
 	fakediscovery "k8s.io/client-go/discovery/fake"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/restmapper"
 	coretesting "k8s.io/client-go/testing"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
@@ -104,7 +107,9 @@ func Retry(ctx context.Context, fn func(context.Context) error, errValidationFun
 
 // RetryClient implements the Client interface, with retries built in.
 type RetryClient struct {
-	Client client.Client
+	Client    client.Client
+	dynamic   dynamic.Interface
+	discovery discovery.DiscoveryInterface
 }
 
 // RetryStatusWriter implements the StatusWriter interface, with retries built in.
@@ -114,8 +119,18 @@ type RetryStatusWriter struct {
 
 // NewRetryClient initializes a new Kubernetes client that automatically retries on network-related errors.
 func NewRetryClient(cfg *rest.Config, opts client.Options) (*RetryClient, error) {
+	dynamicClient, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	discovery, err := discovery.NewDiscoveryClientForConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+
 	client, err := client.New(cfg, opts)
-	return &RetryClient{Client: client}, err
+	return &RetryClient{Client: client, dynamic: dynamicClient, discovery: discovery}, err
 }
 
 // Create saves the object obj in the Kubernetes cluster.
@@ -164,6 +179,31 @@ func (r *RetryClient) List(ctx context.Context, list runtime.Object, opts ...cli
 	return Retry(ctx, func(ctx context.Context) error {
 		return r.Client.List(ctx, list, opts...)
 	}, IsJSONSyntaxError)
+}
+
+// Watch watches a specific object and returns all events for it.
+func (r *RetryClient) Watch(ctx context.Context, obj runtime.Object) (watch.Interface, error) {
+	meta, err := meta.Accessor(obj)
+	if err != nil {
+		return nil, err
+	}
+
+	gvk := obj.GetObjectKind().GroupVersionKind()
+
+	groupResources, err := restmapper.GetAPIGroupResources(r.discovery)
+	if err != nil {
+		return nil, err
+	}
+
+	mapping, err := restmapper.NewDiscoveryRESTMapper(groupResources).RESTMapping(gvk.GroupKind(), gvk.Version)
+	if err != nil {
+		return nil, err
+	}
+
+	return r.dynamic.Resource(mapping.Resource).Watch(metav1.SingleObject(metav1.ObjectMeta{
+		Name:      meta.GetName(),
+		Namespace: meta.GetNamespace(),
+	}))
 }
 
 // Status returns a client which can update status subresource for kubernetes objects.
@@ -636,11 +676,18 @@ func WaitForCRDs(dClient discovery.DiscoveryInterface, crds []runtime.Object) er
 	})
 }
 
+// Client is the controller-runtime Client interface with an added Watch method.
+type Client interface {
+	client.Client
+	// Watch watches a specific object and returns all events for it.
+	Watch(ctx context.Context, obj runtime.Object) (watch.Interface, error)
+}
+
 // TestEnvironment is a struct containing the envtest environment, Kubernetes config and clients.
 type TestEnvironment struct {
 	Environment     *envtest.Environment
 	Config          *rest.Config
-	Client          client.Client
+	Client          Client
 	DiscoveryClient discovery.DiscoveryInterface
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kudo/blob/master/CONTRIBUTING.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kudobuilder/kudo/blob/master/RELEASE.md
3. Ensure you have added or ran the appropriate tests for your PR
4. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

This adds a basic `Watch` method to the RetryClient which allows a user to Watch all events on a specific resource for use in integration tests.

This is needed to allow @fabianbaier to write a test for the step delete behavior in #599. Eventually, this will be used to implement #600 when we replace the test harness's polling with watching events.

**Special notes for your reviewer**:

This is probably not the most efficient way to implement the watches... I figured we would start here and optimize the internals of the method as necessary, but if anyone knows how to make it better we could do that here too.

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```