### PR TITLE
Fix race between OV and I creation in tests

### DIFF
--- a/pkg/controller/instance/instance_controller.go
+++ b/pkg/controller/instance/instance_controller.go
@@ -84,10 +84,11 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 			requests := make([]reconcile.Request, 0)
 			// We want to query and queue up operators Instances
 			instances := &kudov1alpha1.InstanceList{}
+			// we are listing all instances here, which could come with some performance penalty
+			// a possible optimization is to introduce filtering based on operatorversion (or operator)
 			err := mgr.GetClient().List(
 				context.TODO(),
 				instances,
-				client.MatchingLabels(map[string]string{kudo.OperatorLabel: a.Meta.GetName()}),
 			)
 
 			if err != nil {

--- a/test/integration/create-operator-in-operator/00-dream.yaml
+++ b/test/integration/create-operator-in-operator/00-dream.yaml
@@ -24,6 +24,8 @@ spec:
       kind: Instance
       metadata:
         name: operator
+        labels:
+          kudo.dev/operator: test-operator
       spec:
         operatorVersion:
           kind: OperatorVersion

--- a/test/integration/create-operator-in-operator/01-install.yaml
+++ b/test/integration/create-operator-in-operator/01-install.yaml
@@ -3,7 +3,7 @@ kind: Instance
 metadata:
   labels:
     controller-tools.k8s.io: "1.0"
-    operator: dream
+    kudo.dev/operator: dream
   name: dream1
 spec:
   operatorVersion:

--- a/test/integration/parse-param-operator-in-operator/00-dream.yaml
+++ b/test/integration/parse-param-operator-in-operator/00-dream.yaml
@@ -24,6 +24,8 @@ spec:
       kind: Instance
       metadata:
         name: operator
+        labels:
+          kudo.dev/operator: test-operator
       spec:
         operatorVersion:
           kind: OperatorVersion

--- a/test/integration/parse-param-operator-in-operator/01-install.yaml
+++ b/test/integration/parse-param-operator-in-operator/01-install.yaml
@@ -3,7 +3,7 @@ kind: Instance
 metadata:
   labels:
     controller-tools.k8s.io: "1.0"
-    operator: dream
+    kudo.dev/operator: dream
   name: dream1
 spec:
   operatorVersion:

--- a/test/integration/step-delete/00-install-instance.yaml
+++ b/test/integration/step-delete/00-install-instance.yaml
@@ -44,7 +44,8 @@ apiVersion: kudo.k8s.io/v1alpha1
 kind: Instance
 metadata:
   name: step-delete-instance
-  kudo.dev/operator: job-operator
+  labels:
+    kudo.dev/operator: job-operator
 spec:
   operatorVersion:
     name: job-operator

--- a/test/integration/step-delete/00-install-instance.yaml
+++ b/test/integration/step-delete/00-install-instance.yaml
@@ -44,6 +44,7 @@ apiVersion: kudo.k8s.io/v1alpha1
 kind: Instance
 metadata:
   name: step-delete-instance
+  kudo.dev/operator: job-operator
 spec:
   operatorVersion:
     name: job-operator


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
When OV is created AFTER instance, this is how we look for existing instances https://github.com/kudobuilder/kudo/blob/master/pkg/controller/instance/instance_controller.go#L87 so the labels have to be in place

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #626 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```