### PR TITLE
Change uses of .k8s.io to .kudo.dev

### DIFF
--- a/config/crds/kudo_v1alpha1_instance.yaml
+++ b/config/crds/kudo_v1alpha1_instance.yaml
@@ -4,9 +4,9 @@ metadata:
   creationTimestamp: null
   labels:
     controller-tools.k8s.io: "1.0"
-  name: instances.kudo.k8s.io
+  name: instances.kudo.dev
 spec:
-  group: kudo.k8s.io
+  group: kudo.dev
   names:
     kind: Instance
     plural: instances

--- a/config/crds/kudo_v1alpha1_operator.yaml
+++ b/config/crds/kudo_v1alpha1_operator.yaml
@@ -4,9 +4,9 @@ metadata:
   creationTimestamp: null
   labels:
     controller-tools.k8s.io: "1.0"
-  name: operators.kudo.k8s.io
+  name: operators.kudo.dev
 spec:
-  group: kudo.k8s.io
+  group: kudo.dev
   names:
     kind: Operator
     plural: operators

--- a/config/crds/kudo_v1alpha1_operatorversion.yaml
+++ b/config/crds/kudo_v1alpha1_operatorversion.yaml
@@ -4,9 +4,9 @@ metadata:
   creationTimestamp: null
   labels:
     controller-tools.k8s.io: "1.0"
-  name: operatorversions.kudo.k8s.io
+  name: operatorversions.kudo.dev
 spec:
-  group: kudo.k8s.io
+  group: kudo.dev
   names:
     kind: OperatorVersion
     plural: operatorversions

--- a/config/crds/kudo_v1alpha1_planexecution.yaml
+++ b/config/crds/kudo_v1alpha1_planexecution.yaml
@@ -4,9 +4,9 @@ metadata:
   creationTimestamp: null
   labels:
     controller-tools.k8s.io: "1.0"
-  name: planexecutions.kudo.k8s.io
+  name: planexecutions.kudo.dev
 spec:
-  group: kudo.k8s.io
+  group: kudo.dev
   names:
     kind: PlanExecution
     plural: planexecutions

--- a/config/crds/kudo_v1alpha1_teststep.yaml
+++ b/config/crds/kudo_v1alpha1_teststep.yaml
@@ -4,9 +4,9 @@ metadata:
   creationTimestamp: null
   labels:
     controller-tools.k8s.io: "1.0"
-  name: teststeps.kudo.k8s.io
+  name: teststeps.kudo.dev
 spec:
-  group: kudo.k8s.io
+  group: kudo.dev
   names:
     kind: TestStep
     plural: teststeps

--- a/config/crds/kudo_v1alpha1_testsuite.yaml
+++ b/config/crds/kudo_v1alpha1_testsuite.yaml
@@ -4,9 +4,9 @@ metadata:
   creationTimestamp: null
   labels:
     controller-tools.k8s.io: "1.0"
-  name: testsuites.kudo.k8s.io
+  name: testsuites.kudo.dev
 spec:
-  group: kudo.k8s.io
+  group: kudo.dev
   names:
     kind: TestSuite
     plural: testsuites

--- a/config/rbac/rbac_role.yaml
+++ b/config/rbac/rbac_role.yaml
@@ -17,7 +17,7 @@ rules:
   - patch
   - delete
 - apiGroups:
-  - kudo.k8s.io
+  - kudo.dev
   resources:
   - instances
   verbs:
@@ -41,7 +41,7 @@ rules:
   - patch
   - delete
 - apiGroups:
-  - kudo.k8s.io
+  - kudo.dev
   resources:
   - operators
   verbs:
@@ -65,7 +65,7 @@ rules:
   - patch
   - delete
 - apiGroups:
-  - kudo.k8s.io
+  - kudo.dev
   resources:
   - operatorversions
   verbs:
@@ -90,7 +90,7 @@ rules:
   - patch
   - delete
 - apiGroups:
-  - kudo.k8s.io
+  - kudo.dev
   resources:
   - planexecutions
   - instances

--- a/config/samples/canary.yaml
+++ b/config/samples/canary.yaml
@@ -1,12 +1,12 @@
-apiVersion: kudo.k8s.io/v1alpha1
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: Operator
 metadata:
   labels:
     controller-tools.k8s.io: "1.0"
   name: canary-app
 ---
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: OperatorVersion
 metadata:
   labels:
@@ -117,7 +117,7 @@ spec:
       phases:
         - name: deploy-canary
 ---
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: Instance
 metadata:
   labels:

--- a/config/samples/flink-demo.yaml
+++ b/config/samples/flink-demo.yaml
@@ -1,11 +1,11 @@
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: Operator
 metadata:
   labels:
     controller-tools.k8s.io: "1.0"
   name: flink-financial-demo
 ---
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: OperatorVersion
 metadata:
   labels:
@@ -23,7 +23,7 @@ spec:
     default: "https://downloads.mesosphere.com/dcos-demo/flink/flink-job-1.0.jar"
   templates:
     zookeeper.yaml: |
-      apiVersion: kudo.k8s.io/v1alpha1
+      apiVersion: kudo.dev/v1alpha1
       kind: Instance
       metadata:
         labels:
@@ -40,7 +40,7 @@ spec:
         parameters:
           ZOOKEEPER_CPUS: "0.3"
     kafka.yaml: |
-      apiVersion: kudo.k8s.io/v1alpha1
+      apiVersion: kudo.dev/v1alpha1
       kind: Instance
       metadata:
         labels:
@@ -58,7 +58,7 @@ spec:
           BROKER_COUNT: "3"
           KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true"
     flink.yaml: |
-      apiVersion: kudo.k8s.io/v1alpha1
+      apiVersion: kudo.dev/v1alpha1
       kind: Instance
       metadata:
         labels:
@@ -210,7 +210,7 @@ spec:
               tasks:
               - upload
 ---
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: Instance
 metadata:
   labels:

--- a/config/samples/flink.yaml
+++ b/config/samples/flink.yaml
@@ -1,11 +1,11 @@
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: Operator
 metadata:
   labels:
     controller-tools.k8s.io: "1.0"
   name: flink
 ---
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: OperatorVersion
 metadata:
   labels:

--- a/config/samples/kafka-instance.yaml
+++ b/config/samples/kafka-instance.yaml
@@ -1,4 +1,4 @@
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: Instance
 metadata:
   labels:

--- a/config/samples/kafka-operator.yaml
+++ b/config/samples/kafka-operator.yaml
@@ -1,4 +1,4 @@
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: Operator
 metadata:
   labels:

--- a/config/samples/kafka-operatorversion.yaml
+++ b/config/samples/kafka-operatorversion.yaml
@@ -1,4 +1,4 @@
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: OperatorVersion
 metadata:
   labels:

--- a/config/samples/kubectl-kudo
+++ b/config/samples/kubectl-kudo
@@ -429,7 +429,7 @@ function createFunction {
 EOF
     done
     cat <<EOF > "/tmp/kudo_instance"
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: Instance
 metadata:
     labels:

--- a/config/samples/mysql.yaml
+++ b/config/samples/mysql.yaml
@@ -1,11 +1,11 @@
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: Operator
 metadata:
   labels:
     controller-tools.k8s.io: "1.0"
   name: mysql
 ---
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: OperatorVersion
 metadata:
   labels:
@@ -255,7 +255,7 @@ spec:
               - restore
               delete: true
 ---
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: Instance
 metadata:
   labels:

--- a/config/samples/toy.yaml
+++ b/config/samples/toy.yaml
@@ -1,11 +1,11 @@
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: Operator
 metadata:
   labels:
     controller-tools.k8s.io: "1.0"
   name: toy
 ---
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: OperatorVersion
 metadata:
   labels:
@@ -100,7 +100,7 @@ spec:
               tasks:
               - serial
 ---
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: Instance
 metadata:
   labels:

--- a/config/samples/upgrade.yaml
+++ b/config/samples/upgrade.yaml
@@ -1,11 +1,11 @@
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: Operator
 metadata:
   labels:
     controller-tools.k8s.io: "1.0"
   name: upgrade
 ---
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: OperatorVersion
 metadata:
   labels:
@@ -78,7 +78,7 @@ spec:
             tasks:
             - run
 ---
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: OperatorVersion
 metadata:
   labels:
@@ -151,7 +151,7 @@ spec:
             tasks:
             - run
 ---
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: Instance
 metadata:
   labels:

--- a/config/samples/zookeeper-instance.yaml
+++ b/config/samples/zookeeper-instance.yaml
@@ -1,4 +1,4 @@
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: Instance
 metadata:
   labels:

--- a/config/samples/zookeeper-operator.yaml
+++ b/config/samples/zookeeper-operator.yaml
@@ -1,4 +1,4 @@
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: Operator
 metadata:
   labels:

--- a/config/samples/zookeeper-operatorversion.yaml
+++ b/config/samples/zookeeper-operatorversion.yaml
@@ -1,4 +1,4 @@
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: OperatorVersion
 metadata:
   labels:

--- a/config/scratch/mysql-backup.yaml
+++ b/config/scratch/mysql-backup.yaml
@@ -1,4 +1,4 @@
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: PlanExecution
 metadata:
   labels:

--- a/config/scratch/mysql-restore.yaml
+++ b/config/scratch/mysql-restore.yaml
@@ -1,4 +1,4 @@
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: PlanExecution
 metadata:
   labels:

--- a/config/scratch/validation.yaml
+++ b/config/scratch/validation.yaml
@@ -1,4 +1,4 @@
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: PlanExecution
 metadata:
   labels:
@@ -6,7 +6,7 @@ metadata:
   name: validation
   namespace: default
   ownerReferences:
-  - apiVersion: kudo.k8s.io/v1alpha1
+  - apiVersion: kudo.dev/v1alpha1
     blockOwnerDeletion: true
     controller: true
     kind: Instance

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -96,10 +96,10 @@ Use `--instance` and `--parameter`/`-p` for setting an Instance name and Paramet
 
 ```bash
 $ kubectl kudo install kafka --instance=my-kafka-name --parameter ZOOKEEPER_URI=zk-zk-0.zk-hs:2181,zk-zk-1.zk-hs:2181,zk-zk-2.zk-hs:2181 --parameter ZOOKEEPER_PATH=/small -p BROKERS_COUNTER=3
-operator.kudo.k8s.io/kafka unchanged
-operatorversion.kudo.k8s.io/kafka unchanged
+operator.kudo.dev/kafka unchanged
+operatorversion.kudo.dev/kafka unchanged
 No instance named 'my-kafka-name' tied to this "kafka" version has been found. Do you want to create one? (Yes/no)
-instance.kudo.k8s.io/v1alpha1/my-kafka-name created
+instance.kudo.dev/v1alpha1/my-kafka-name created
 $ kubectl get instances
 NAME            AGE
 my-kafka-name   6s
@@ -194,15 +194,15 @@ $ kubectl describe operatorversion upgrade-v1
 Name:         upgrade-v1
 Namespace:    default
 Labels:       controller-tools.k8s.io=1.0
-Annotations:  kubectl.kubernetes.io/last-applied-configuration={"apiVersion":"kudo.k8s.io/v1alpha1","kind":"OperatorVersion","metadata":{"annotations":{},"labels":{"controller-tools.k8s.io":"1.0"},"name":"upgra...
-API Version:  kudo.k8s.io/v1alpha1
+Annotations:  kubectl.kubernetes.io/last-applied-configuration={"apiVersion":"kudo.dev/v1alpha1","kind":"OperatorVersion","metadata":{"annotations":{},"labels":{"controller-tools.k8s.io":"1.0"},"name":"upgra...
+API Version:  kudo.dev/v1alpha1
 Kind:         OperatorVersion
 Metadata:
   Cluster Name:
   Creation Timestamp:  2018-12-14T19:26:44Z
   Generation:          1
   Resource Version:    63769
-  Self Link:           /apis/kudo.k8s.io/v1alpha1/namespaces/default/operatorversions/upgrade-v1
+  Self Link:           /apis/kudo.dev/v1alpha1/namespaces/default/operatorversions/upgrade-v1
   UID:                 30fe6209-ffd6-11e8-abd5-080027d506c7
 Spec:
   Connection String:
@@ -281,21 +281,21 @@ $ kubectl describe planexecution up-deploy-493146000
   Labels:       operator-version=upgrade-v1
                 instance=up
   Annotations:  <none>
-  API Version:  kudo.k8s.io/v1alpha1
+  API Version:  kudo.dev/v1alpha1
   Kind:         PlanExecution
   Metadata:
     Cluster Name:
     Creation Timestamp:  2018-12-14T19:26:44Z
     Generation:          1
     Owner References:
-      API Version:           kudo.k8s.io/v1alpha1
+      API Version:           kudo.dev/v1alpha1
       Block Owner Deletion:  true
       Controller:            true
       Kind:                  Instance
       Name:                  up
       UID:                   3101bbe5-ffd6-11e8-abd5-080027d506c7
     Resource Version:        63815
-    Self Link:               /apis/kudo.k8s.io/v1alpha1/namespaces/default/planexecutions/up-deploy-493146000
+    Self Link:               /apis/kudo.dev/v1alpha1/namespaces/default/planexecutions/up-deploy-493146000
     UID:                     31037dd0-ffd6-11e8-abd5-080027d506c7
   Spec:
     Instance:

--- a/docs/deployment/10-crds.yaml
+++ b/docs/deployment/10-crds.yaml
@@ -4,9 +4,9 @@ metadata:
   creationTimestamp: null
   labels:
     controller-tools.k8s.io: "1.0"
-  name: operators.kudo.k8s.io
+  name: operators.kudo.dev
 spec:
-  group: kudo.k8s.io
+  group: kudo.dev
   names:
     kind: Operator
     plural: operators
@@ -57,9 +57,9 @@ metadata:
   creationTimestamp: null
   labels:
     controller-tools.k8s.io: "1.0"
-  name: operatorversions.kudo.k8s.io
+  name: operatorversions.kudo.dev
 spec:
-  group: kudo.k8s.io
+  group: kudo.dev
   names:
     kind: OperatorVersion
     plural: operatorversions
@@ -167,9 +167,9 @@ metadata:
   creationTimestamp: null
   labels:
     controller-tools.k8s.io: "1.0"
-  name: instances.kudo.k8s.io
+  name: instances.kudo.dev
 spec:
-  group: kudo.k8s.io
+  group: kudo.dev
   names:
     kind: Instance
     plural: instances
@@ -237,9 +237,9 @@ metadata:
   creationTimestamp: null
   labels:
     controller-tools.k8s.io: "1.0"
-  name: planexecutions.kudo.k8s.io
+  name: planexecutions.kudo.dev
 spec:
-  group: kudo.k8s.io
+  group: kudo.dev
   names:
     kind: PlanExecution
     plural: planexecutions

--- a/docs/examples/apache-flink.md
+++ b/docs/examples/apache-flink.md
@@ -71,7 +71,7 @@ This phase deploys a `Flink` actor that mirrors the deployment [here](kubectl ap
 # Scratch
 ```bash
 cat <<EOF | kubectl apply -f -
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: PlanExecution
 metadata:
   name: upload

--- a/docs/examples/apache-kafka.md
+++ b/docs/examples/apache-kafka.md
@@ -14,21 +14,21 @@ Kafka depends on Zookeeper so we need to run it first. Follow the [Zookeeper exa
 Create a `Operator` object for Kafka
 ```bash
 $ kubectl apply -f config/samples/kafka-operator.yaml
-operator.kudo.k8s.io "kafka" created
+operator.kudo.dev "kafka" created
 ```
 
 Create a `OperatorVersion` for the Kafka  `Operator`
 
 ```bash
 $ kubectl apply -f config/samples/kafka-operatorversion.yaml
-operatorversion.kudo.k8s.io "kafka-2.11-2.4.0" created
+operatorversion.kudo.dev "kafka-2.11-2.4.0" created
 ```
 
 
 Create an Instance of Kafka
 ```
 $ kubectl apply -f config/samples/kafka-instance.yaml
-instance.kudo.k8s.io "kafka" created
+instance.kudo.dev "kafka" created
 ```
 
 When an instance is created, the default `deploy` plan is executed

--- a/docs/examples/apache-zookeeper.md
+++ b/docs/examples/apache-zookeeper.md
@@ -8,21 +8,21 @@ type: docs
 Create a `Operator` object for Zookeeper
 ```bash
 $ kubectl apply -f config/samples/zookeeper-operator.yaml
-operator.kudo.k8s.io "zookeeper" created
+operator.kudo.dev "zookeeper" created
 ```
 
 Create a `OperatorVersion` for the Zookeeper  `Operator`
 
 ```bash
 $ kubectl apply -f config/samples/zookeeper-operatorversion.yaml
-operatorversion.kudo.k8s.io "zookeeper-1.0" created
+operatorversion.kudo.dev "zookeeper-1.0" created
 ```
 
 
 Create an Instance of Zookeeper
 ```
 $ kubectl apply -f config/samples/zookeeper-instance.yaml
-instance.kudo.k8s.io "zk" created
+instance.kudo.dev "zk" created
 ```
 
 When an instance is created, the default `deploy` plan is executed

--- a/docs/examples/backups.md
+++ b/docs/examples/backups.md
@@ -17,9 +17,9 @@ Create an instance of MySQL using the provided sample Operator:
 
 ```bash
 $ kubectl apply -f config/samples/mysql.yaml
-operator.kudo.k8s.io/mysql created
-operatorversion.kudo.k8s.io/mysql-57 created
-instance.kudo.k8s.io/mysql created
+operator.kudo.dev/mysql created
+operatorversion.kudo.dev/mysql-57 created
+instance.kudo.dev/mysql created
 ```
 
 Query the database to show its schema:
@@ -45,7 +45,7 @@ Define and execute a custom plan in order to take a backup:
 
 ```bash
 cat <<EOF | kubectl apply -f -
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: PlanExecution
 metadata:
   labels:
@@ -75,7 +75,7 @@ Similar to the backup step, define and execute the restore:
 
 ```bash
 cat <<EOF | kubectl apply -f -
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: PlanExecution
 metadata:
   labels:

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -42,7 +42,7 @@ KUDO should be used any time you would use an Operator. It can provide an advanc
 
 Kafka Operator Example
 ```
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: Operator
 metadata:
   labels:
@@ -69,7 +69,7 @@ A `OperatorVersion` is the particular implementation of a `Operator` containing:
 An example for a `OperatorVersion` is the [kafka-operatorversion.yaml](https://github.com/kudobuilder/operators/blob/master/repo/stable/kafka/versions/0/kafka-operatorversion.yaml) that you find in the [kudobuilder/operators](https://github.com/kudobuilder/operators) repository.
 
 ```
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: OperatorVersion
 metadata:
   labels:

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -91,7 +91,7 @@ The test step files can contain any number of Kubernetes resources that should b
 Continuing with the upgrade-test example, create `00-instance.yaml`:
 
 ```
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: Instance
 metadata:
   name: zk
@@ -112,7 +112,7 @@ This test step will create a Zookeeper `Instance`. The namespace should not be s
 It is possible to delete existing resources at the beginning of a test step. Create a `TestStep` object in your step to configure it:
 
 ```
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: TestStep
 delete:
 - name: my-pod
@@ -135,7 +135,7 @@ Test assert files contain any number of Kubernetes resources that are expected t
 Continuing with the `upgrade-test` example, create `00-instance.yaml`:
 
 ```
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: Instance
 metadata:
   name: zk
@@ -182,7 +182,7 @@ This would verify that a pod with the `app=nginx` label is running.
 The test harness recognizes special `TestAssert` objects defined in the assert file. If present, they override default settings of the test assert.
 
 ```
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: TestAssert
 timeout: 120
 ```

--- a/docs/update-upgrade-plans.md
+++ b/docs/update-upgrade-plans.md
@@ -16,10 +16,10 @@ The deploy plan is automatically run for new instances:
 
 ```bash
 $ kubectl apply -f config/samples/upgrade.yaml
-operator.kudo.k8s.io/upgrade created
-operatorversion.kudo.k8s.io/upgrade-v1 created
-operatorversion.kudo.k8s.io/upgrade-v2 created
-instance.kudo.k8s.io/up created
+operator.kudo.dev/upgrade created
+operatorversion.kudo.dev/upgrade-v1 created
+operatorversion.kudo.dev/upgrade-v2 created
+instance.kudo.dev/up created
 ```
 
 The PlanExecution object that gets created gets suffixed with a timestamp for uniqueness.
@@ -44,7 +44,7 @@ An update of the instance is run when the Spec of the Instance is changed, but t
 
 ```
 kubectl patch instance up -p '{"spec":{"parameters":{"SLEEP":"60"}}}' --type=merge
-instance.kudo.k8s.io/up patched
+instance.kudo.dev/up patched
 ```
 
 ```bash
@@ -67,7 +67,7 @@ Upgrades occur when the `OperatorVersion` is changed.  The Upgrade from the NEW 
 
 ```bash
 $  kubectl patch instance up -p '{"spec":{"operatorVersion":{"name":"upgrade-v2"}}}' --type=merge
-instance.kudo.k8s.io/up patched
+instance.kudo.dev/up patched
 $ kubectl get planexecutions -l instance=up
 NAME                   AGE
 up-deploy-539794000    3m

--- a/keps/0008-operator-testing.md
+++ b/keps/0008-operator-testing.md
@@ -236,7 +236,7 @@ When searching a test step file, if a `TestStep` object is found, it includes se
 
 ```
 type TestStep struct {
-    // The type meta object, should always be a GVK of kudo.k8s.io/v1alpha1/TestStep.
+    // The type meta object, should always be a GVK of kudo.dev/v1alpha1/TestStep.
     TypeMeta
     // Override the default metadata. Set labels or override the test step name.
     ObjectMeta
@@ -306,7 +306,7 @@ When searching the assertion file for a test step, if a `TestAssert` object is f
 
 ```
 type TestAssert struct {
-    // The type meta object, should always be a GVK of kudo.k8s.io/v1alpha1/TestAssert.
+    // The type meta object, should always be a GVK of kudo.dev/v1alpha1/TestAssert.
     TypeMeta
     // Override the default timeout of 30 seconds (in seconds).
     Timeout int

--- a/kudo-test.yaml
+++ b/kudo-test.yaml
@@ -1,4 +1,4 @@
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: TestSuite
 crdDir: ./config/crds/
 manifestsDir: ./test/manifests/

--- a/pkg/apis/kudo/v1alpha1/doc.go
+++ b/pkg/apis/kudo/v1alpha1/doc.go
@@ -18,5 +18,5 @@ limitations under the License.
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/kudobuilder/kudo/pkg/apis/kudo
 // +k8s:defaulter-gen=TypeMeta
-// +groupName=kudo.k8s.io
+// +groupName=kudo.dev
 package v1alpha1

--- a/pkg/apis/kudo/v1alpha1/register.go
+++ b/pkg/apis/kudo/v1alpha1/register.go
@@ -20,7 +20,7 @@ limitations under the License.
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/kudobuilder/kudo/pkg/apis/kudo
 // +k8s:defaulter-gen=TypeMeta
-// +groupName=kudo.k8s.io
+// +groupName=kudo.dev
 package v1alpha1
 
 import (
@@ -30,7 +30,7 @@ import (
 
 var (
 	// SchemeGroupVersion is group version used to register these objects
-	SchemeGroupVersion = schema.GroupVersion{Group: "kudo.k8s.io", Version: "v1alpha1"}
+	SchemeGroupVersion = schema.GroupVersion{Group: "kudo.dev", Version: "v1alpha1"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
 	SchemeBuilder = &scheme.Builder{GroupVersion: SchemeGroupVersion}

--- a/pkg/apis/kudo/v1alpha1/test_types.go
+++ b/pkg/apis/kudo/v1alpha1/test_types.go
@@ -9,7 +9,7 @@ import (
 
 // TestSuite configures which tests should be loaded.
 type TestSuite struct {
-	// The type meta object, should always be a GVK of kudo.k8s.io/v1alpha1/TestSuite.
+	// The type meta object, should always be a GVK of kudo.dev/v1alpha1/TestSuite.
 	metav1.TypeMeta `json:",inline"`
 	// Set labels or the test suite name.
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -63,7 +63,7 @@ func (t TestSuite) GetManifestsDirs() []string {
 
 // TestStep settings to apply to a test step.
 type TestStep struct {
-	// The type meta object, should always be a GVK of kudo.k8s.io/v1alpha1/TestStep.
+	// The type meta object, should always be a GVK of kudo.dev/v1alpha1/TestStep.
 	metav1.TypeMeta `json:",inline"`
 	// Override the default metadata. Set labels or override the test step name.
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -83,7 +83,7 @@ type TestStep struct {
 
 // TestAssert represents the settings needed to verify the result of a test step.
 type TestAssert struct {
-	// The type meta object, should always be a GVK of kudo.k8s.io/v1alpha1/TestAssert.
+	// The type meta object, should always be a GVK of kudo.dev/v1alpha1/TestAssert.
 	metav1.TypeMeta `json:",inline"`
 	// Override the default timeout of 30 seconds (in seconds).
 	Timeout int `json:"timeout"`

--- a/pkg/client/clientset/versioned/typed/kudo/v1alpha1/fake/fake_instance.go
+++ b/pkg/client/clientset/versioned/typed/kudo/v1alpha1/fake/fake_instance.go
@@ -32,9 +32,9 @@ type FakeInstances struct {
 	ns   string
 }
 
-var instancesResource = schema.GroupVersionResource{Group: "kudo.k8s.io", Version: "v1alpha1", Resource: "instances"}
+var instancesResource = schema.GroupVersionResource{Group: "kudo.dev", Version: "v1alpha1", Resource: "instances"}
 
-var instancesKind = schema.GroupVersionKind{Group: "kudo.k8s.io", Version: "v1alpha1", Kind: "Instance"}
+var instancesKind = schema.GroupVersionKind{Group: "kudo.dev", Version: "v1alpha1", Kind: "Instance"}
 
 // Get takes name of the instance, and returns the corresponding instance object, and an error if there is any.
 func (c *FakeInstances) Get(name string, options v1.GetOptions) (result *v1alpha1.Instance, err error) {

--- a/pkg/client/clientset/versioned/typed/kudo/v1alpha1/fake/fake_operator.go
+++ b/pkg/client/clientset/versioned/typed/kudo/v1alpha1/fake/fake_operator.go
@@ -32,9 +32,9 @@ type FakeOperators struct {
 	ns   string
 }
 
-var operatorsResource = schema.GroupVersionResource{Group: "kudo.k8s.io", Version: "v1alpha1", Resource: "operators"}
+var operatorsResource = schema.GroupVersionResource{Group: "kudo.dev", Version: "v1alpha1", Resource: "operators"}
 
-var operatorsKind = schema.GroupVersionKind{Group: "kudo.k8s.io", Version: "v1alpha1", Kind: "Operator"}
+var operatorsKind = schema.GroupVersionKind{Group: "kudo.dev", Version: "v1alpha1", Kind: "Operator"}
 
 // Get takes name of the operator, and returns the corresponding operator object, and an error if there is any.
 func (c *FakeOperators) Get(name string, options v1.GetOptions) (result *v1alpha1.Operator, err error) {

--- a/pkg/client/clientset/versioned/typed/kudo/v1alpha1/fake/fake_operatorversion.go
+++ b/pkg/client/clientset/versioned/typed/kudo/v1alpha1/fake/fake_operatorversion.go
@@ -32,9 +32,9 @@ type FakeOperatorVersions struct {
 	ns   string
 }
 
-var operatorversionsResource = schema.GroupVersionResource{Group: "kudo.k8s.io", Version: "v1alpha1", Resource: "operatorversions"}
+var operatorversionsResource = schema.GroupVersionResource{Group: "kudo.dev", Version: "v1alpha1", Resource: "operatorversions"}
 
-var operatorversionsKind = schema.GroupVersionKind{Group: "kudo.k8s.io", Version: "v1alpha1", Kind: "OperatorVersion"}
+var operatorversionsKind = schema.GroupVersionKind{Group: "kudo.dev", Version: "v1alpha1", Kind: "OperatorVersion"}
 
 // Get takes name of the operatorVersion, and returns the corresponding operatorVersion object, and an error if there is any.
 func (c *FakeOperatorVersions) Get(name string, options v1.GetOptions) (result *v1alpha1.OperatorVersion, err error) {

--- a/pkg/client/clientset/versioned/typed/kudo/v1alpha1/fake/fake_planexecution.go
+++ b/pkg/client/clientset/versioned/typed/kudo/v1alpha1/fake/fake_planexecution.go
@@ -32,9 +32,9 @@ type FakePlanExecutions struct {
 	ns   string
 }
 
-var planexecutionsResource = schema.GroupVersionResource{Group: "kudo.k8s.io", Version: "v1alpha1", Resource: "planexecutions"}
+var planexecutionsResource = schema.GroupVersionResource{Group: "kudo.dev", Version: "v1alpha1", Resource: "planexecutions"}
 
-var planexecutionsKind = schema.GroupVersionKind{Group: "kudo.k8s.io", Version: "v1alpha1", Kind: "PlanExecution"}
+var planexecutionsKind = schema.GroupVersionKind{Group: "kudo.dev", Version: "v1alpha1", Kind: "PlanExecution"}
 
 // Get takes name of the planExecution, and returns the corresponding planExecution object, and an error if there is any.
 func (c *FakePlanExecutions) Get(name string, options v1.GetOptions) (result *v1alpha1.PlanExecution, err error) {

--- a/pkg/client/clientset/versioned/typed/kudo/v1alpha1/kudo_client.go
+++ b/pkg/client/clientset/versioned/typed/kudo/v1alpha1/kudo_client.go
@@ -31,7 +31,7 @@ type KudoV1alpha1Interface interface {
 	PlanExecutionsGetter
 }
 
-// KudoV1alpha1Client is used to interact with features provided by the kudo.k8s.io group.
+// KudoV1alpha1Client is used to interact with features provided by the kudo.dev group.
 type KudoV1alpha1Client struct {
 	restClient rest.Interface
 }

--- a/pkg/client/informers/externalversions/generic.go
+++ b/pkg/client/informers/externalversions/generic.go
@@ -50,7 +50,7 @@ func (f *genericInformer) Lister() cache.GenericLister {
 // TODO extend this to unknown resources with a client pool
 func (f *sharedInformerFactory) ForResource(resource schema.GroupVersionResource) (GenericInformer, error) {
 	switch resource {
-	// Group=kudo.k8s.io, Version=v1alpha1
+	// Group=kudo.dev, Version=v1alpha1
 	case v1alpha1.SchemeGroupVersion.WithResource("instances"):
 		return &genericInformer{resource: resource.GroupResource(), informer: f.Kudo().V1alpha1().Instances().Informer()}, nil
 	case v1alpha1.SchemeGroupVersion.WithResource("operators"):

--- a/pkg/controller/instance/instance_controller.go
+++ b/pkg/controller/instance/instance_controller.go
@@ -373,7 +373,7 @@ type ReconcileInstance struct {
 //
 // Automatically generate RBAC rules to allow the Controller to read and write Deployments
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=kudo.k8s.io,resources=instances,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=kudo.dev,resources=instances,verbs=get;list;watch;create;update;patch;delete
 func (r *ReconcileInstance) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	// Fetch the Instance instance
 	instance := &kudov1alpha1.Instance{}

--- a/pkg/controller/operator/operator_controller.go
+++ b/pkg/controller/operator/operator_controller.go
@@ -75,7 +75,7 @@ type ReconcileOperator struct {
 // and what is in the Operator.Spec
 // Automatically generate RBAC rules to allow the Controller to read and write Deployments
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=kudo.k8s.io,resources=operators,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=kudo.dev,resources=operators,verbs=get;list;watch;create;update;patch;delete
 func (r *ReconcileOperator) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	// Fetch the operator
 	operator := &kudov1alpha1.Operator{}

--- a/pkg/controller/operatorversion/operatorversion_controller.go
+++ b/pkg/controller/operatorversion/operatorversion_controller.go
@@ -72,7 +72,7 @@ type ReconcileOperatorVersion struct {
 //
 // Automatically generate RBAC rules to allow the Controller to read and write Deployments
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=kudo.k8s.io,resources=operatorversions,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=kudo.dev,resources=operatorversions,verbs=get;list;watch;create;update;patch;delete
 func (r *ReconcileOperatorVersion) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	// Fetch the operator version
 	operatorVersion := &kudov1alpha1.OperatorVersion{}

--- a/pkg/controller/planexecution/planexecution_controller.go
+++ b/pkg/controller/planexecution/planexecution_controller.go
@@ -186,7 +186,7 @@ type ReconcilePlanExecution struct {
 //
 // Automatically generate RBAC rules to allow the Controller to read and write Deployments
 // +kubebuilder:rbac:groups=apps,resources=deployments;statefulsets,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=kudo.k8s.io,resources=planexecutions;instances,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=kudo.dev,resources=planexecutions;instances,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=events;configmaps,verbs=get;list;watch;create;patch
 // +kubebuilder:rbac:groups=policy,resources=poddisruptionbudgets;poddisruptionbudgets.policy,verbs=get;list;watch;create;update;patch;delete

--- a/pkg/kudoctl/bundle/package.go
+++ b/pkg/kudoctl/bundle/package.go
@@ -24,7 +24,7 @@ const (
 	paramsFileName        = "params.yaml"
 )
 
-const apiVersion = "kudo.k8s.io/v1alpha1"
+const apiVersion = "kudo.dev/v1alpha1"
 
 // PackageCRDs is collection of CRDs that are used when installing operator
 // during installation, package format is converted to this structure

--- a/pkg/kudoctl/bundle/testdata/zk-crd-golden1/instance.golden
+++ b/pkg/kudoctl/bundle/testdata/zk-crd-golden1/instance.golden
@@ -1,4 +1,4 @@
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: Instance
 metadata:
   labels:

--- a/pkg/kudoctl/bundle/testdata/zk-crd-golden1/operator.golden
+++ b/pkg/kudoctl/bundle/testdata/zk-crd-golden1/operator.golden
@@ -1,4 +1,4 @@
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: Operator
 metadata:
   labels:

--- a/pkg/kudoctl/bundle/testdata/zk-crd-golden1/operatorversion.golden
+++ b/pkg/kudoctl/bundle/testdata/zk-crd-golden1/operatorversion.golden
@@ -1,4 +1,4 @@
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: OperatorVersion
 metadata:
   labels:

--- a/pkg/kudoctl/bundle/testdata/zk-crd-golden2/instance.golden
+++ b/pkg/kudoctl/bundle/testdata/zk-crd-golden2/instance.golden
@@ -1,4 +1,4 @@
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: Instance
 metadata:
   labels:

--- a/pkg/kudoctl/bundle/testdata/zk-crd-golden2/operator.golden
+++ b/pkg/kudoctl/bundle/testdata/zk-crd-golden2/operator.golden
@@ -1,4 +1,4 @@
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: Operator
 metadata:
   labels:

--- a/pkg/kudoctl/bundle/testdata/zk-crd-golden2/operatorversion.golden
+++ b/pkg/kudoctl/bundle/testdata/zk-crd-golden2/operatorversion.golden
@@ -1,4 +1,4 @@
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: OperatorVersion
 metadata:
   labels:

--- a/pkg/kudoctl/cmd/get/get_test.go
+++ b/pkg/kudoctl/cmd/get/get_test.go
@@ -39,7 +39,7 @@ func newTestClient() *kudo.Client {
 func TestGetInstances(t *testing.T) {
 	testInstance := &v1alpha1.Instance{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "kudo.k8s.io/v1alpha1",
+			APIVersion: "kudo.dev/v1alpha1",
 			Kind:       "Instance",
 		},
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/kudoctl/cmd/install/install_test.go
+++ b/pkg/kudoctl/cmd/install/install_test.go
@@ -43,7 +43,7 @@ func TestParameterValidation_InstallCrds(t *testing.T) {
 	crds := bundle.PackageCRDs{
 		Operator: &v1alpha1.Operator{
 			TypeMeta: metav1.TypeMeta{
-				APIVersion: "kudo.k8s.io/v1alpha1",
+				APIVersion: "kudo.dev/v1alpha1",
 				Kind:       "Operator",
 			},
 			ObjectMeta: metav1.ObjectMeta{
@@ -55,7 +55,7 @@ func TestParameterValidation_InstallCrds(t *testing.T) {
 		},
 		Instance: &v1alpha1.Instance{
 			TypeMeta: metav1.TypeMeta{
-				APIVersion: "kudo.k8s.io/v1alpha1",
+				APIVersion: "kudo.dev/v1alpha1",
 				Kind:       "Instance",
 			},
 			ObjectMeta: metav1.ObjectMeta{
@@ -73,7 +73,7 @@ func TestParameterValidation_InstallCrds(t *testing.T) {
 		},
 		OperatorVersion: &v1alpha1.OperatorVersion{
 			TypeMeta: metav1.TypeMeta{
-				APIVersion: "kudo.k8s.io/v1alpha1",
+				APIVersion: "kudo.dev/v1alpha1",
 				Kind:       "OperatorVersion",
 			},
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/kudoctl/cmd/plan/plan_history.go
+++ b/pkg/kudoctl/cmd/plan/plan_history.go
@@ -72,7 +72,7 @@ func planHistory(args []string, options *historyOptions) error {
 	}
 
 	planExecutionsGVR := schema.GroupVersionResource{
-		Group:    "kudo.k8s.io",
+		Group:    "kudo.dev",
 		Version:  "v1alpha1",
 		Resource: "planexecutions",
 	}

--- a/pkg/kudoctl/cmd/plan/plan_status.go
+++ b/pkg/kudoctl/cmd/plan/plan_status.go
@@ -72,7 +72,7 @@ func planStatus(options *statusOptions) error {
 	}
 
 	instancesGVR := schema.GroupVersionResource{
-		Group:    "kudo.k8s.io",
+		Group:    "kudo.dev",
 		Version:  "v1alpha1",
 		Resource: "instances",
 	}
@@ -97,7 +97,7 @@ func planStatus(options *statusOptions) error {
 	operatorVersionNameOfInstance := instance.Spec.OperatorVersion.Name
 
 	operatorGVR := schema.GroupVersionResource{
-		Group:    "kudo.k8s.io",
+		Group:    "kudo.dev",
 		Version:  "v1alpha1",
 		Resource: "operatorversions",
 	}
@@ -121,7 +121,7 @@ func planStatus(options *statusOptions) error {
 	}
 
 	planExecutionsGVR := schema.GroupVersionResource{
-		Group:    "kudo.k8s.io",
+		Group:    "kudo.dev",
 		Version:  "v1alpha1",
 		Resource: "planexecutions",
 	}

--- a/pkg/kudoctl/util/kudo/kudo.go
+++ b/pkg/kudoctl/util/kudo/kudo.go
@@ -70,7 +70,7 @@ func (c *Client) OperatorExistsInCluster(name, namespace string) bool {
 	if err != nil {
 		return false
 	}
-	fmt.Printf("operator.kudo.k8s.io/%s unchanged\n", operator.Name)
+	fmt.Printf("operator.kudo.dev/%s unchanged\n", operator.Name)
 	return true
 }
 

--- a/pkg/kudoctl/util/kudo/kudo_test.go
+++ b/pkg/kudoctl/util/kudo/kudo_test.go
@@ -35,7 +35,7 @@ func TestK2oClient_OperatorExistsInCluster(t *testing.T) {
 
 	obj := v1alpha1.Operator{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "kudo.k8s.io/v1alpha1",
+			APIVersion: "kudo.dev/v1alpha1",
 			Kind:       "Operator",
 		},
 		ObjectMeta: metav1.ObjectMeta{
@@ -84,7 +84,7 @@ func TestK2oClient_OperatorExistsInCluster(t *testing.T) {
 func TestK2oClient_InstanceExistsInCluster(t *testing.T) {
 	obj := v1alpha1.Instance{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "kudo.k8s.io/v1alpha1",
+			APIVersion: "kudo.dev/v1alpha1",
 			Kind:       "Instance",
 		},
 		ObjectMeta: metav1.ObjectMeta{
@@ -103,7 +103,7 @@ func TestK2oClient_InstanceExistsInCluster(t *testing.T) {
 
 	wrongObj := v1alpha1.Instance{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "kudo.k8s.io/v1alpha1",
+			APIVersion: "kudo.dev/v1alpha1",
 			Kind:       "Instance",
 		},
 		ObjectMeta: metav1.ObjectMeta{
@@ -158,7 +158,7 @@ func TestK2oClient_InstanceExistsInCluster(t *testing.T) {
 func TestK2oClient_ListInstances(t *testing.T) {
 	obj := v1alpha1.Instance{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "kudo.k8s.io/v1alpha1",
+			APIVersion: "kudo.dev/v1alpha1",
 			Kind:       "Instance",
 		},
 		ObjectMeta: metav1.ObjectMeta{
@@ -209,7 +209,7 @@ func TestK2oClient_OperatorVersionsInstalled(t *testing.T) {
 	operatorName := "test"
 	obj := v1alpha1.OperatorVersion{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "kudo.k8s.io/v1alpha1",
+			APIVersion: "kudo.dev/v1alpha1",
 			Kind:       "OperatorVersion",
 		},
 		ObjectMeta: metav1.ObjectMeta{
@@ -257,7 +257,7 @@ func TestK2oClient_OperatorVersionsInstalled(t *testing.T) {
 func TestK2oClient_InstallOperatorObjToCluster(t *testing.T) {
 	obj := v1alpha1.Operator{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "kudo.k8s.io/v1alpha1",
+			APIVersion: "kudo.dev/v1alpha1",
 			Kind:       "Operator",
 		},
 		ObjectMeta: metav1.ObjectMeta{
@@ -274,11 +274,11 @@ func TestK2oClient_InstallOperatorObjToCluster(t *testing.T) {
 		createns string
 		obj      *v1alpha1.Operator
 	}{
-		{"", "operators.kudo.k8s.io \"\" not found", "", nil},                // 1
-		{"", "operators.kudo.k8s.io \"\" not found", "default", nil},         // 2
-		{"", "operators.kudo.k8s.io \"\" not found", "kudo", nil},            // 3
-		{"test2", "operators.kudo.k8s.io \"test2\" not found", "kudo", &obj}, // 4
-		{"test", "", "kudo", &obj},                                           // 5
+		{"", "operators.kudo.dev \"\" not found", "", nil},                // 1
+		{"", "operators.kudo.dev \"\" not found", "default", nil},         // 2
+		{"", "operators.kudo.dev \"\" not found", "kudo", nil},            // 3
+		{"test2", "operators.kudo.dev \"test2\" not found", "kudo", &obj}, // 4
+		{"test", "", "kudo", &obj},                                        // 5
 	}
 
 	for i, tt := range tests {
@@ -303,7 +303,7 @@ func TestK2oClient_InstallOperatorObjToCluster(t *testing.T) {
 func TestK2oClient_InstallOperatorVersionObjToCluster(t *testing.T) {
 	obj := v1alpha1.OperatorVersion{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "kudo.k8s.io/v1alpha1",
+			APIVersion: "kudo.dev/v1alpha1",
 			Kind:       "OperatorVersion",
 		},
 		ObjectMeta: metav1.ObjectMeta{
@@ -320,11 +320,11 @@ func TestK2oClient_InstallOperatorVersionObjToCluster(t *testing.T) {
 		createns string
 		obj      *v1alpha1.OperatorVersion
 	}{
-		{"", "operatorversions.kudo.k8s.io \"\" not found", "", nil},                // 1
-		{"", "operatorversions.kudo.k8s.io \"\" not found", "default", nil},         // 2
-		{"", "operatorversions.kudo.k8s.io \"\" not found", "kudo", nil},            // 3
-		{"test2", "operatorversions.kudo.k8s.io \"test2\" not found", "kudo", &obj}, // 4
-		{"test", "", "kudo", &obj}, // 5
+		{"", "operatorversions.kudo.dev \"\" not found", "", nil},                // 1
+		{"", "operatorversions.kudo.dev \"\" not found", "default", nil},         // 2
+		{"", "operatorversions.kudo.dev \"\" not found", "kudo", nil},            // 3
+		{"test2", "operatorversions.kudo.dev \"test2\" not found", "kudo", &obj}, // 4
+		{"test", "", "kudo", &obj},                                               // 5
 	}
 
 	for i, tt := range tests {
@@ -349,7 +349,7 @@ func TestK2oClient_InstallOperatorVersionObjToCluster(t *testing.T) {
 func TestK2oClient_InstallInstanceObjToCluster(t *testing.T) {
 	obj := v1alpha1.Instance{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "kudo.k8s.io/v1alpha1",
+			APIVersion: "kudo.dev/v1alpha1",
 			Kind:       "OperatorVersion",
 		},
 		ObjectMeta: metav1.ObjectMeta{
@@ -366,11 +366,11 @@ func TestK2oClient_InstallInstanceObjToCluster(t *testing.T) {
 		createns string
 		obj      *v1alpha1.Instance
 	}{
-		{"", "instances.kudo.k8s.io \"\" not found", "", nil},                // 1
-		{"", "instances.kudo.k8s.io \"\" not found", "default", nil},         // 2
-		{"", "instances.kudo.k8s.io \"\" not found", "kudo", nil},            // 3
-		{"test2", "instances.kudo.k8s.io \"test2\" not found", "kudo", &obj}, // 4
-		{"test", "", "kudo", &obj},                                           // 5
+		{"", "instances.kudo.dev \"\" not found", "", nil},                // 1
+		{"", "instances.kudo.dev \"\" not found", "default", nil},         // 2
+		{"", "instances.kudo.dev \"\" not found", "kudo", nil},            // 3
+		{"test2", "instances.kudo.dev \"test2\" not found", "kudo", &obj}, // 4
+		{"test", "", "kudo", &obj},                                        // 5
 	}
 
 	for i, tt := range tests {

--- a/pkg/test/case_test.go
+++ b/pkg/test/case_test.go
@@ -31,7 +31,7 @@ func TestLoadTestSteps(t *testing.T) {
 						},
 						TypeMeta: metav1.TypeMeta{
 							Kind:       "TestStep",
-							APIVersion: "kudo.k8s.io/v1alpha1",
+							APIVersion: "kudo.dev/v1alpha1",
 						},
 						Index: 0,
 					},
@@ -59,7 +59,7 @@ func TestLoadTestSteps(t *testing.T) {
 					Step: &kudo.TestStep{
 						TypeMeta: metav1.TypeMeta{
 							Kind:       "TestStep",
-							APIVersion: "kudo.k8s.io/v1alpha1",
+							APIVersion: "kudo.dev/v1alpha1",
 						},
 						Index: 1,
 						Delete: []kudo.ObjectReference{
@@ -75,7 +75,7 @@ func TestLoadTestSteps(t *testing.T) {
 					Assert: &kudo.TestAssert{
 						TypeMeta: metav1.TypeMeta{
 							Kind:       "TestAssert",
-							APIVersion: "kudo.k8s.io/v1alpha1",
+							APIVersion: "kudo.dev/v1alpha1",
 						},
 						Timeout: 20,
 					},
@@ -134,7 +134,7 @@ func TestLoadTestSteps(t *testing.T) {
 						},
 						TypeMeta: metav1.TypeMeta{
 							Kind:       "TestStep",
-							APIVersion: "kudo.k8s.io/v1alpha1",
+							APIVersion: "kudo.dev/v1alpha1",
 						},
 						Index: 3,
 					},

--- a/pkg/test/test_data/create-or-update/01-assert.yaml
+++ b/pkg/test/test_data/create-or-update/01-assert.yaml
@@ -32,7 +32,7 @@ spec:
         ports:
         - containerPort: 80
 ---
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: Instance
 metadata:
   name: my-instance

--- a/pkg/test/test_data/create-or-update/01-create-known-crd.yaml
+++ b/pkg/test/test_data/create-or-update/01-create-known-crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: Instance
 metadata:
   name: my-instance

--- a/pkg/test/test_data/create-or-update/02-assert.yaml
+++ b/pkg/test/test_data/create-or-update/02-assert.yaml
@@ -20,7 +20,7 @@ spec:
         ports:
         - containerPort: 80
 ---
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: Instance
 metadata:
   name: my-instance

--- a/pkg/test/test_data/create-or-update/02-update-known-crd.yaml
+++ b/pkg/test/test_data/create-or-update/02-update-known-crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: Instance
 metadata:
   name: my-instance

--- a/pkg/test/test_data/delete-in-step/01-create.yaml
+++ b/pkg/test/test_data/delete-in-step/01-create.yaml
@@ -1,6 +1,6 @@
 # Delete all pods and then make sure that we can make pods with the same name but different specs (this would fail if they were
 # not deleted).
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: TestStep
 delete:
 - apiVersion: v1

--- a/pkg/test/test_data/with-overrides/00-test-step.yaml
+++ b/pkg/test/test_data/with-overrides/00-test-step.yaml
@@ -8,7 +8,7 @@ spec:
   - name: nginx
     image: nginx:1.7.9
 ---
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: TestStep
 metadata:
   name: with-test-step-name-override

--- a/pkg/test/test_data/with-overrides/01-assert.yaml
+++ b/pkg/test/test_data/with-overrides/01-assert.yaml
@@ -1,4 +1,4 @@
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: TestAssert
 timeout: 20
 ---

--- a/pkg/test/test_data/with-overrides/01-test-assert.yaml
+++ b/pkg/test/test_data/with-overrides/01-test-assert.yaml
@@ -8,7 +8,7 @@ spec:
   - name: nginx
     image: nginx:1.7.9
 ---
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: TestStep
 delete:
 - apiVersion: v1

--- a/pkg/test/test_data/with-overrides/03-pod.yaml
+++ b/pkg/test/test_data/with-overrides/03-pod.yaml
@@ -1,4 +1,4 @@
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: TestStep
 metadata:
   name: name-overriden

--- a/pkg/test/utils/kubernetes.go
+++ b/pkg/test/utils/kubernetes.go
@@ -322,11 +322,11 @@ func ConvertUnstructured(in runtime.Object) (runtime.Object, error) {
 	kind := in.GetObjectKind().GroupVersionKind().Kind
 	group := in.GetObjectKind().GroupVersionKind().Group
 
-	if group == "kudo.k8s.io" && kind == "TestStep" {
+	if group == "kudo.dev" && kind == "TestStep" {
 		converted = &kudo.TestStep{}
-	} else if group == "kudo.k8s.io" && kind == "TestAssert" {
+	} else if group == "kudo.dev" && kind == "TestAssert" {
 		converted = &kudo.TestAssert{}
-	} else if group == "kudo.k8s.io" && kind == "TestSuite" {
+	} else if group == "kudo.dev" && kind == "TestSuite" {
 		converted = &kudo.TestSuite{}
 	} else if group == "kind.sigs.k8s.io" && kind == "Cluster" {
 		converted = &kindConfig.Cluster{}

--- a/pkg/test/utils/kubernetes_integration_test.go
+++ b/pkg/test/utils/kubernetes_integration_test.go
@@ -76,7 +76,7 @@ func TestWaitForCRDs(t *testing.T) {
 	})
 	assert.Nil(t, err)
 
-	instance := NewResource("kudo.k8s.io/v1alpha1", "Instance", "zk", "ns")
+	instance := NewResource("kudo.dev/v1alpha1", "Instance", "zk", "ns")
 
 	// Verify that we cannot create the instance, because the test environment is empty.
 	assert.IsType(t, &meta.NoKindMatchError{}, testClient.Create(context.TODO(), instance))

--- a/test/integration/create-operator-in-operator/00-dream.yaml
+++ b/test/integration/create-operator-in-operator/00-dream.yaml
@@ -1,12 +1,12 @@
 ## Dream is the umbrella operator that tests the creation of instances within an operator
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: Operator
 metadata:
   labels:
     controller-tools.k8s.io: "1.0"
   name: dream
 ---
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: OperatorVersion
 metadata:
   labels:
@@ -20,7 +20,7 @@ spec:
     kind: Operator
   templates:
     operator.yaml: |
-      apiVersion: kudo.k8s.io/v1alpha1
+      apiVersion: kudo.dev/v1alpha1
       kind: Instance
       metadata:
         name: operator

--- a/test/integration/create-operator-in-operator/01-assert.yaml
+++ b/test/integration/create-operator-in-operator/01-assert.yaml
@@ -1,11 +1,11 @@
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: Instance
 metadata:
   name: dream1
 status:
   status: COMPLETE
 ---
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: Instance
 metadata:
   name: dream1-operator

--- a/test/integration/create-operator-in-operator/01-install.yaml
+++ b/test/integration/create-operator-in-operator/01-install.yaml
@@ -1,4 +1,4 @@
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: Instance
 metadata:
   labels:

--- a/test/integration/immutable-client-ip/00-assert.yaml
+++ b/test/integration/immutable-client-ip/00-assert.yaml
@@ -1,4 +1,4 @@
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: Instance
 metadata:
   name: immutable-client-ip-instance

--- a/test/integration/immutable-client-ip/00-install-instance.yaml
+++ b/test/integration/immutable-client-ip/00-install-instance.yaml
@@ -1,4 +1,4 @@
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: Instance
 metadata:
   name: immutable-client-ip-instance
@@ -9,7 +9,7 @@ spec:
     name: service-operator
     kind: OperatorVersion
 ---
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: OperatorVersion
 metadata:
   name: service-operator

--- a/test/integration/immutable-client-ip/01-assert.yaml
+++ b/test/integration/immutable-client-ip/01-assert.yaml
@@ -1,4 +1,4 @@
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: Instance
 metadata:
   name: immutable-client-ip-instance

--- a/test/integration/immutable-client-ip/01-upgrade.yaml
+++ b/test/integration/immutable-client-ip/01-upgrade.yaml
@@ -1,4 +1,4 @@
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: Instance
 metadata:
   name: immutable-client-ip-instance

--- a/test/integration/instance-controller-param-change-custom-trigger/00-assert.yaml
+++ b/test/integration/instance-controller-param-change-custom-trigger/00-assert.yaml
@@ -1,11 +1,11 @@
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: Instance
 metadata:
   name: icto-custom-trigger
 status:
   status: COMPLETE
 ---
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: PlanExecution
 metadata:
   labels:

--- a/test/integration/instance-controller-param-change-custom-trigger/00-setup.yaml
+++ b/test/integration/instance-controller-param-change-custom-trigger/00-setup.yaml
@@ -2,7 +2,7 @@
 #
 # The next step will update the parameter and verify that it triggers the
 # creation of a `PlanExecution` for the plan defined as a trigger.
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: OperatorVersion
 metadata:
   name: icto-custom-trigger
@@ -16,7 +16,7 @@ spec:
     update:
     foo-changed:
 ---
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: Instance
 metadata:
   name: icto-custom-trigger

--- a/test/integration/instance-controller-param-change-custom-trigger/01-assert.yaml
+++ b/test/integration/instance-controller-param-change-custom-trigger/01-assert.yaml
@@ -1,4 +1,4 @@
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: PlanExecution
 metadata:
   labels:

--- a/test/integration/instance-controller-param-change-custom-trigger/01-update-instance.yaml
+++ b/test/integration/instance-controller-param-change-custom-trigger/01-update-instance.yaml
@@ -1,4 +1,4 @@
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: Instance
 metadata:
   name: icto-custom-trigger

--- a/test/integration/instance-controller-param-change-fallback-to-deploy/00-assert.yaml
+++ b/test/integration/instance-controller-param-change-fallback-to-deploy/00-assert.yaml
@@ -1,11 +1,11 @@
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: Instance
 metadata:
   name: icto-fallback-to-deploy
 status:
   status: COMPLETE
 ---
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: PlanExecution
 metadata:
   labels:

--- a/test/integration/instance-controller-param-change-fallback-to-deploy/00-setup.yaml
+++ b/test/integration/instance-controller-param-change-fallback-to-deploy/00-setup.yaml
@@ -3,7 +3,7 @@
 #
 # The next step will update the parameter and verify that it triggers the creation
 # of a `PlanExecution` for the `deploy` plan.
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: OperatorVersion
 metadata:
   name: icto-fallback-to-deploy
@@ -17,7 +17,7 @@ spec:
   plans:
     deploy:
 ---
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: Instance
 metadata:
   name: icto-fallback-to-deploy

--- a/test/integration/instance-controller-param-change-fallback-to-deploy/01-assert.yaml
+++ b/test/integration/instance-controller-param-change-fallback-to-deploy/01-assert.yaml
@@ -1,4 +1,4 @@
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: PlanExecution
 metadata:
   labels:

--- a/test/integration/instance-controller-param-change-fallback-to-deploy/01-update-instance.yaml
+++ b/test/integration/instance-controller-param-change-fallback-to-deploy/01-update-instance.yaml
@@ -1,12 +1,12 @@
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: TestStep
 delete:
-  - apiVersion: kudo.k8s.io/v1alpha1
+  - apiVersion: kudo.dev/v1alpha1
     kind: PlanExecution
     labels:
       kudo.dev/instance: icto-fallback-to-deploy
 ---
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: Instance
 metadata:
   name: icto-fallback-to-deploy

--- a/test/integration/instance-controller-param-change-no-trigger/00-assert.yaml
+++ b/test/integration/instance-controller-param-change-no-trigger/00-assert.yaml
@@ -1,11 +1,11 @@
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: Instance
 metadata:
   name: icto-no-trigger
 status:
   status: COMPLETE
 ---
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: PlanExecution
 metadata:
   labels:

--- a/test/integration/instance-controller-param-change-no-trigger/00-setup.yaml
+++ b/test/integration/instance-controller-param-change-no-trigger/00-setup.yaml
@@ -3,7 +3,7 @@
 #
 # The next step will update the parameter and verify that it triggers the creation
 # of a `PlanExecution` for the `update` plan.
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: OperatorVersion
 metadata:
   name: icto-no-trigger
@@ -15,7 +15,7 @@ spec:
     deploy:
     update:
 ---
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: Instance
 metadata:
   name: icto-no-trigger

--- a/test/integration/instance-controller-param-change-no-trigger/01-assert.yaml
+++ b/test/integration/instance-controller-param-change-no-trigger/01-assert.yaml
@@ -1,4 +1,4 @@
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: PlanExecution
 metadata:
   labels:

--- a/test/integration/instance-controller-param-change-no-trigger/01-update-instance.yaml
+++ b/test/integration/instance-controller-param-change-no-trigger/01-update-instance.yaml
@@ -1,4 +1,4 @@
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: Instance
 metadata:
   name: icto-no-trigger

--- a/test/integration/instance-controller-upgrade-fallback-to-deploy/00-assert.yaml
+++ b/test/integration/instance-controller-upgrade-fallback-to-deploy/00-assert.yaml
@@ -1,11 +1,11 @@
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: Instance
 metadata:
   name: icto-upgrade-fallback-to-deploy
 status:
   status: COMPLETE
 ---
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: PlanExecution
 metadata:
   labels:

--- a/test/integration/instance-controller-upgrade-fallback-to-deploy/00-setup.yaml
+++ b/test/integration/instance-controller-upgrade-fallback-to-deploy/00-setup.yaml
@@ -12,12 +12,12 @@
 #   2. Create a new operator version with just a "deploy" plan.
 #   3. Trigger an upgrading by updating the operator version used by the instance.
 #   4. Verify that KUDO creates a new "deploy" plan execution.
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: Operator
 metadata:
   name: icto-upgrade
 ---
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: OperatorVersion
 metadata:
   name: icto-upgrade
@@ -30,7 +30,7 @@ spec:
     deploy:
     upgrade:
 ---
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: Instance
 metadata:
   name: icto-upgrade-fallback-to-deploy

--- a/test/integration/instance-controller-upgrade-fallback-to-deploy/01-assert.yaml
+++ b/test/integration/instance-controller-upgrade-fallback-to-deploy/01-assert.yaml
@@ -1,4 +1,4 @@
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: PlanExecution
 metadata:
   labels:

--- a/test/integration/instance-controller-upgrade-fallback-to-deploy/01-upgrade-instance.yaml
+++ b/test/integration/instance-controller-upgrade-fallback-to-deploy/01-upgrade-instance.yaml
@@ -1,13 +1,13 @@
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: TestStep
 delete:
-  - apiVersion: kudo.k8s.io/v1alpha1
+  - apiVersion: kudo.dev/v1alpha1
     kind: PlanExecution
     labels:
       kudo.dev/instance: icto-upgrade-fallback-to-deploy
       kudo.dev/operator-version: icto-upgrade-fallback-to-deploy
 ---
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: OperatorVersion
 metadata:
   name: icto-upgrade-fallback-to-deploy
@@ -19,7 +19,7 @@ spec:
   plans:
     deploy:
 ---
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: Instance
 metadata:
   name: icto-upgrade-fallback-to-deploy

--- a/test/integration/instance-controller-upgrade-fallback-to-update/00-assert.yaml
+++ b/test/integration/instance-controller-upgrade-fallback-to-update/00-assert.yaml
@@ -1,11 +1,11 @@
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: Instance
 metadata:
   name: icto-upgrade-fallback-to-update
 status:
   status: COMPLETE
 ---
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: PlanExecution
 metadata:
   labels:

--- a/test/integration/instance-controller-upgrade-fallback-to-update/00-setup.yaml
+++ b/test/integration/instance-controller-upgrade-fallback-to-update/00-setup.yaml
@@ -8,12 +8,12 @@
 # The next step will then create new OperatorVersion which will include
 # "update" and "deploy" plans, update the instance, and finally verify that the
 # right PlanExecution was created.
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: Operator
 metadata:
   name: icto-upgrade
 ---
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: OperatorVersion
 metadata:
   name: icto-upgrade
@@ -27,7 +27,7 @@ spec:
     upgrade:
     update:
 ---
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: Instance
 metadata:
   name: icto-upgrade-fallback-to-update

--- a/test/integration/instance-controller-upgrade-fallback-to-update/01-assert.yaml
+++ b/test/integration/instance-controller-upgrade-fallback-to-update/01-assert.yaml
@@ -1,4 +1,4 @@
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: PlanExecution
 metadata:
   labels:

--- a/test/integration/instance-controller-upgrade-fallback-to-update/01-upgrade-instance.yaml
+++ b/test/integration/instance-controller-upgrade-fallback-to-update/01-upgrade-instance.yaml
@@ -1,4 +1,4 @@
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: OperatorVersion
 metadata:
   name: icto-upgrade-fallback-to-update
@@ -11,7 +11,7 @@ spec:
     deploy:
     update:
 ---
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: Instance
 metadata:
   name: icto-upgrade-fallback-to-update

--- a/test/integration/instance-controller-upgrade/00-assert.yaml
+++ b/test/integration/instance-controller-upgrade/00-assert.yaml
@@ -1,11 +1,11 @@
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: Instance
 metadata:
   name: icto-upgrade
 status:
   status: COMPLETE
 ---
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: PlanExecution
 metadata:
   labels:

--- a/test/integration/instance-controller-upgrade/00-setup.yaml
+++ b/test/integration/instance-controller-upgrade/00-setup.yaml
@@ -7,12 +7,12 @@
 # The next step will then create new OperatorVersion which will include an
 # "upgrade" plan, update the instance, and finally verify that the right
 # PlanExecution was created.
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: Operator
 metadata:
   name: icto-upgrade
 ---
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: OperatorVersion
 metadata:
   name: icto-upgrade
@@ -25,7 +25,7 @@ spec:
     deploy:
     upgrade:
 ---
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: Instance
 metadata:
   name: icto-upgrade

--- a/test/integration/instance-controller-upgrade/01-assert.yaml
+++ b/test/integration/instance-controller-upgrade/01-assert.yaml
@@ -1,4 +1,4 @@
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: PlanExecution
 metadata:
   labels:

--- a/test/integration/instance-controller-upgrade/01-upgrade-instance.yaml
+++ b/test/integration/instance-controller-upgrade/01-upgrade-instance.yaml
@@ -1,4 +1,4 @@
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: OperatorVersion
 metadata:
   name: icto-upgrade-v2
@@ -12,7 +12,7 @@ spec:
     update:
     upgrade:
 ---
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: Instance
 metadata:
   name: icto-upgrade

--- a/test/integration/operator-test/00-install.yaml
+++ b/test/integration/operator-test/00-install.yaml
@@ -1,4 +1,4 @@
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: Instance
 metadata:
   name: operator-test-instance

--- a/test/integration/operator-test/01-upgrade.yaml
+++ b/test/integration/operator-test/01-upgrade.yaml
@@ -1,4 +1,4 @@
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: Instance
 metadata:
   name: operator-test-instance

--- a/test/integration/parse-param-operator-in-operator/00-dream.yaml
+++ b/test/integration/parse-param-operator-in-operator/00-dream.yaml
@@ -1,12 +1,12 @@
 ## Dream is the umbrella operator that tests the creation of instances within an operator
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: Operator
 metadata:
   labels:
     controller-tools.k8s.io: "1.0"
   name: dream
 ---
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: OperatorVersion
 metadata:
   labels:
@@ -20,7 +20,7 @@ spec:
     kind: Operator
   templates:
     operator.yaml: |
-      apiVersion: kudo.k8s.io/v1alpha1
+      apiVersion: kudo.dev/v1alpha1
       kind: Instance
       metadata:
         name: operator

--- a/test/integration/parse-param-operator-in-operator/01-assert.yaml
+++ b/test/integration/parse-param-operator-in-operator/01-assert.yaml
@@ -1,11 +1,11 @@
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: Instance
 metadata:
   name: dream1
 status:
   status: IN_PROGRESS
 ---
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: Instance
 metadata:
   name: dream1-operator

--- a/test/integration/parse-param-operator-in-operator/01-install.yaml
+++ b/test/integration/parse-param-operator-in-operator/01-install.yaml
@@ -1,4 +1,4 @@
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: Instance
 metadata:
   labels:

--- a/test/integration/patch/00-assert.yaml
+++ b/test/integration/patch/00-assert.yaml
@@ -7,24 +7,24 @@ spec:
     replicas: "1"
     param: "30"
 ---
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: Instance
 metadata:
   name: toy1
 status:
   status: COMPLETE
   activePlan:
-    apiVersion: kudo.k8s.io/v1alpha1
+    apiVersion: kudo.dev/v1alpha1
     kind: PlanExecution
 ---
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: PlanExecution
 metadata:
   labels:
     kudo.dev/instance: toy1
     kudo.dev/operator-version: toy-v1
   ownerReferences:
-  - apiVersion: kudo.k8s.io/v1alpha1
+  - apiVersion: kudo.dev/v1alpha1
     blockOwnerDeletion: true
     controller: true
     kind: Instance

--- a/test/integration/patch/00-install.yaml
+++ b/test/integration/patch/00-install.yaml
@@ -1,4 +1,4 @@
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: Instance
 metadata:
   labels:

--- a/test/integration/patch/01-assert.yaml
+++ b/test/integration/patch/01-assert.yaml
@@ -7,24 +7,24 @@ spec:
     replicas: "3"
     param: "30"
 ---
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: Instance
 metadata:
   name: toy1
 status:
   status: COMPLETE
   activePlan:
-    apiVersion: kudo.k8s.io/v1alpha1
+    apiVersion: kudo.dev/v1alpha1
     kind: PlanExecution
 ---
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: PlanExecution
 metadata:
   labels:
     kudo.dev/instance: toy1
     kudo.dev/operator-version: toy-v1
   ownerReferences:
-  - apiVersion: kudo.k8s.io/v1alpha1
+  - apiVersion: kudo.dev/v1alpha1
     blockOwnerDeletion: true
     controller: true
     kind: Instance

--- a/test/integration/patch/01-plan-update.yaml
+++ b/test/integration/patch/01-plan-update.yaml
@@ -1,4 +1,4 @@
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: Instance
 metadata:
   labels:

--- a/test/integration/racy-reconcile/00-install-instance.yaml
+++ b/test/integration/racy-reconcile/00-install-instance.yaml
@@ -1,4 +1,4 @@
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: Instance
 metadata:
   name: racy-instance

--- a/test/integration/racy-reconcile/01-assert.yaml
+++ b/test/integration/racy-reconcile/01-assert.yaml
@@ -1,18 +1,18 @@
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: Instance
 metadata:
   name: racy-instance
 status:
   status: COMPLETE
 ---
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: PlanExecution
 metadata:
   labels:
     kudo.dev/operator-version: racy-operator
     kudo.dev/instance: racy-instance
   ownerReferences:
-  - apiVersion: kudo.k8s.io/v1alpha1
+  - apiVersion: kudo.dev/v1alpha1
     kind: Instance
     name: racy-instance
 status:

--- a/test/integration/racy-reconcile/01-install-operatorversion.yaml
+++ b/test/integration/racy-reconcile/01-install-operatorversion.yaml
@@ -1,4 +1,4 @@
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: OperatorVersion
 metadata:
   name: racy-operator

--- a/test/integration/rendering-error-plan-failed/00-assert.yaml
+++ b/test/integration/rendering-error-plan-failed/00-assert.yaml
@@ -1,10 +1,10 @@
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: PlanExecution
 metadata:
   labels:
     kudo.dev/instance: invalid1
   ownerReferences:
-    - apiVersion: kudo.k8s.io/v1alpha1
+    - apiVersion: kudo.dev/v1alpha1
       blockOwnerDeletion: true
       controller: true
       kind: Instance

--- a/test/integration/rendering-error-plan-failed/00-install.yaml
+++ b/test/integration/rendering-error-plan-failed/00-install.yaml
@@ -1,11 +1,11 @@
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: Operator
 metadata:
   labels:
     controller-tools.k8s.io: "1.0"
   name: invalid
 ---
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: OperatorVersion
 metadata:
   labels:
@@ -57,7 +57,7 @@ spec:
               tasks:
                 - invalid-task
 ---
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: Instance
 metadata:
   labels:

--- a/test/integration/step-delete/00-assert.yaml
+++ b/test/integration/step-delete/00-assert.yaml
@@ -1,5 +1,5 @@
 # We only check the Instance here as the Job is deleted at the end of the step, so we cannot check for its existence.
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: Instance
 metadata:
   name: step-delete-instance

--- a/test/integration/step-delete/00-install-instance.yaml
+++ b/test/integration/step-delete/00-install-instance.yaml
@@ -1,7 +1,7 @@
 # This test validates that the plan execution controller properly deletes resources when a step has delete=true.
 # We validate this by setting a label in the Job's Pod spec via a parameter - Job Pod specs are immutable, so the second
 # step cannot pass if the Job was not deleted by KUDO.
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: OperatorVersion
 metadata:
   name: job-operator
@@ -40,7 +40,7 @@ spec:
             - name: test
               image: alpine
 ---
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: Instance
 metadata:
   name: step-delete-instance

--- a/test/integration/step-delete/01-assert.yaml
+++ b/test/integration/step-delete/01-assert.yaml
@@ -1,5 +1,5 @@
 # We only check the Instance here as the Job is deleted at the end of the step, so we cannot check for its existence.
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: Instance
 metadata:
   name: step-delete-instance

--- a/test/integration/step-delete/01-upgrade.yaml
+++ b/test/integration/step-delete/01-upgrade.yaml
@@ -1,5 +1,5 @@
 # Set the hello label on the instance Job so that we verify that it was deleted (it is immutable).
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: Instance
 metadata:
   name: step-delete-instance

--- a/test/manifests/test-operator.yaml
+++ b/test/manifests/test-operator.yaml
@@ -1,10 +1,10 @@
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: Operator
 metadata:
   name: test-operator
   namespace: default
 ---
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: OperatorVersion
 metadata:
   name: test-operator-1.0

--- a/test/manifests/toy.yaml
+++ b/test/manifests/toy.yaml
@@ -1,11 +1,11 @@
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: Operator
 metadata:
   labels:
     controller-tools.k8s.io: "1.0"
   name: toy
 ---
-apiVersion: kudo.k8s.io/v1alpha1
+apiVersion: kudo.dev/v1alpha1
 kind: OperatorVersion
 metadata:
   labels:


### PR DESCRIPTION
**What type of PR is this?**
> /kind api-change

**What this PR does / why we need it**:
The .k8s.io suffix is reserved for use by the Kubernetes project. 

**Which issue(s) this PR fixes**:
Fixes #449

**Does this PR introduce a user-facing change?**:
```release-note
All `apiVersion` fields were updated, so CRDs need to be re-created and operators might have to be updated.
```