### PR TITLE
Implement CLI and E2E testing using the KUDO test harness.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ test:
 
 .PHONY: integration-test
 # Run integration tests
-integration-test:
+integration-test: cli-test
 	go test -tags integration ./pkg/... ./cmd/... -v -mod=readonly -coverprofile cover-integration.out
 	go run ./cmd/kubectl-kudo test
 
@@ -116,6 +116,11 @@ generate:
 .PHONY: generate-clean
 generate-clean:
 	rm -rf hack/code-gen
+
+.PHONY: cli-test
+# Build CLI for tests
+cli-test:
+	go build -o bin/${CLI} cmd/kubectl-kudo/main.go
 
 .PHONY: cli
 # Build CLI

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ test:
 
 .PHONY: integration-test
 # Run integration tests
-integration-test: cli-test
+integration-test: cli-fast
 	go test -tags integration ./pkg/... ./cmd/... -v -mod=readonly -coverprofile cover-integration.out
 	go run ./cmd/kubectl-kudo test
 

--- a/Makefile
+++ b/Makefile
@@ -117,16 +117,14 @@ generate:
 generate-clean:
 	rm -rf hack/code-gen
 
-.PHONY: cli-test
-# Build CLI for tests
-cli-test:
-	go build -o bin/${CLI} cmd/kubectl-kudo/main.go
+.PHONY: cli-fast
+# Build CLI but don't lint or run code generation first.
+cli-fast:
+	go build -ldflags "${LDFLAGS}" -o bin/${CLI} cmd/kubectl-kudo/main.go
 
 .PHONY: cli
 # Build CLI
-cli: prebuild
-	# developer convince for platform they are running
-	go build -ldflags "${LDFLAGS}" -o bin/${CLI} cmd/kubectl-kudo/main.go
+cli: prebuild cli-fast
 
 .PHONY: cli-clean
 # Clean CLI build

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/gobuffalo/envy v1.6.15 // indirect
 	github.com/google/go-github v17.0.0+incompatible
 	github.com/google/go-querystring v1.0.0 // indirect
+	github.com/google/shlex v0.0.0-20181106134648-c34317bd91bf
 	github.com/gophercloud/gophercloud v0.2.0 // indirect
 	github.com/hashicorp/golang-lru v0.5.1 // indirect
 	github.com/huandu/xstrings v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -112,7 +112,6 @@ github.com/gobuffalo/envy v1.6.5/go.mod h1:N+GkhhZ/93bGZc6ZKhJLP6+m+tCNPKwgSpH9k
 github.com/gobuffalo/envy v1.6.15 h1:OsV5vOpHYUpP7ZLS6sem1y40/lNX1BZj+ynMiRi21lQ=
 github.com/gobuffalo/envy v1.6.15/go.mod h1:n7DRkBerg/aorDM8kbduw5dN3oXGswK5liaSCx4T5NI=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
-github.com/gogo/protobuf v1.2.0 h1:xU6/SpYbvkNYiptHJYEDRseDLvYE7wSqhYYNy0QSUzI=
 github.com/gogo/protobuf v1.2.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1 h1:/s5zKNz0uPFCZ5hddgPdo2TK2TVrUNMn0OOX8/aZMTE=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
@@ -144,6 +143,8 @@ github.com/google/gofuzz v1.0.0 h1:A8PeW59pxE9IoFRqBp37U+mSNaQoZ46F1f0f863XSXw=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
+github.com/google/shlex v0.0.0-20181106134648-c34317bd91bf h1:7+FW5aGwISbqUtkfmIpZJGRgNFg2ioYPvFaUxdqpDsg=
+github.com/google/shlex v0.0.0-20181106134648-c34317bd91bf/go.mod h1:RpwtwJQFrIEPstU94h88MWPXP2ektJZ8cZ0YntAmXiE=
 github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=

--- a/pkg/apis/kudo/v1alpha1/test_types.go
+++ b/pkg/apis/kudo/v1alpha1/test_types.go
@@ -40,6 +40,8 @@ type TestSuite struct {
 	Parallel int `json:"parallel"`
 	// The directory to output artifacts to (current working directory if not specified).
 	ArtifactsDir string `json:"artifactsDir"`
+	// Kubectl commands to run before running any tests.
+	Kubectl []string `json:"kubectl"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -57,6 +59,9 @@ type TestStep struct {
 
 	// Indicates that this is a unit test - safe to run without a real Kubernetes cluster.
 	UnitTest bool `json:"unitTest"`
+
+	// Kubectl commands to run at the start of the test
+	Kubectl []string `json:"kubectl"`
 
 	// Allowed environment labels
 	// Disallowed environment labels

--- a/pkg/apis/kudo/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/kudo/v1alpha1/zz_generated.deepcopy.go
@@ -1347,6 +1347,11 @@ func (in *TestStep) DeepCopyInto(out *TestStep) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.Kubectl != nil {
+		in, out := &in.Kubectl, &out.Kubectl
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 
@@ -1373,8 +1378,18 @@ func (in *TestSuite) DeepCopyInto(out *TestSuite) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
 	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
+	if in.ManifestDirs != nil {
+		in, out := &in.ManifestDirs, &out.ManifestDirs
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.TestDirs != nil {
 		in, out := &in.TestDirs, &out.TestDirs
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
+	if in.Kubectl != nil {
+		in, out := &in.Kubectl, &out.Kubectl
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}

--- a/pkg/test/case.go
+++ b/pkg/test/case.go
@@ -74,7 +74,7 @@ func (t *Case) CreateNamespace(namespace string) error {
 	})
 }
 
-// TestCaseFactory creates a new Go test that runs a set of test steps.
+// Run runs a test case including all of its steps.
 func (t *Case) Run(test *testing.T) {
 	test.Parallel()
 

--- a/pkg/test/case.go
+++ b/pkg/test/case.go
@@ -75,39 +75,35 @@ func (t *Case) CreateNamespace(namespace string) error {
 }
 
 // TestCaseFactory creates a new Go test that runs a set of test steps.
-func (t *Case) TestCaseFactory() func(*testing.T) {
-	return func(test *testing.T) {
-		t.Logger = testutils.NewTestLogger(test, t.Name)
+func (t *Case) Run(test *testing.T) {
+	test.Parallel()
 
-		test.Parallel()
+	ns := fmt.Sprintf("kudo-test-%s", petname.Generate(2, "-"))
 
-		ns := fmt.Sprintf("kudo-test-%s", petname.Generate(2, "-"))
+	if err := t.CreateNamespace(ns); err != nil {
+		test.Fatal(err)
+	}
 
-		if err := t.CreateNamespace(ns); err != nil {
-			test.Fatal(err)
-		}
+	if !t.SkipDelete {
+		defer t.DeleteNamespace(ns)
+	}
+
+	for _, testStep := range t.Steps {
+		testStep.Client = t.Client
+		testStep.DiscoveryClient = t.DiscoveryClient
+		testStep.Logger = t.Logger.WithPrefix(testStep.String())
 
 		if !t.SkipDelete {
-			defer t.DeleteNamespace(ns)
+			defer testStep.Clean(ns)
 		}
 
-		for _, testStep := range t.Steps {
-			testStep.Client = t.Client
-			testStep.DiscoveryClient = t.DiscoveryClient
-			testStep.Logger = t.Logger.WithPrefix(testStep.String())
-
-			if !t.SkipDelete {
-				defer testStep.Clean(ns)
+		if errs := testStep.Run(ns); len(errs) > 0 {
+			for _, err := range errs {
+				test.Error(err)
 			}
 
-			if errs := testStep.Run(ns); len(errs) > 0 {
-				for _, err := range errs {
-					test.Error(err)
-				}
-
-				test.Error(fmt.Errorf("failed in step %s", testStep.String()))
-				break
-			}
+			test.Error(fmt.Errorf("failed in step %s", testStep.String()))
+			break
 		}
 	}
 }
@@ -126,6 +122,7 @@ func (t *Case) CollectTestStepFiles() (map[int64][]string, error) {
 		matches := testStepRegex.FindStringSubmatch(file.Name())
 
 		if len(matches) < 2 {
+			t.Logger.Log("Ignoring", file.Name(), "as it does not match file name regexp:", testStepRegex.String())
 			continue
 		}
 

--- a/pkg/test/case.go
+++ b/pkg/test/case.go
@@ -125,6 +125,10 @@ func (t *Case) CollectTestStepFiles() (map[int64][]string, error) {
 	for _, file := range files {
 		matches := testStepRegex.FindStringSubmatch(file.Name())
 
+		if len(matches) < 2 {
+			continue
+		}
+
 		index, err := strconv.ParseInt(matches[1], 10, 32)
 		if err != nil {
 			return nil, err
@@ -168,6 +172,7 @@ func (t *Case) LoadTestSteps() error {
 		testStep := &Step{
 			Timeout: t.Timeout,
 			Index:   int(index),
+			Dir:     t.Dir,
 			Asserts: []runtime.Object{},
 			Apply:   []runtime.Object{},
 			Errors:  []runtime.Object{},

--- a/pkg/test/case_test.go
+++ b/pkg/test/case_test.go
@@ -222,7 +222,7 @@ func TestLoadTestSteps(t *testing.T) {
 		},
 	} {
 		t.Run(tt.path, func(t *testing.T) {
-			test := &Case{Dir: tt.path}
+			test := &Case{Dir: tt.path, Logger: testutils.NewTestLogger(t, tt.path)}
 
 			err := test.LoadTestSteps()
 			assert.Nil(t, err)
@@ -285,7 +285,7 @@ func TestCollectTestStepFiles(t *testing.T) {
 		},
 	} {
 		t.Run(tt.path, func(t *testing.T) {
-			test := &Case{Dir: tt.path}
+			test := &Case{Dir: tt.path, Logger: testutils.NewTestLogger(t, tt.path)}
 			testStepFiles, err := test.CollectTestStepFiles()
 			assert.Nil(t, err)
 			assert.Equal(t, tt.expected, testStepFiles)

--- a/pkg/test/case_test.go
+++ b/pkg/test/case_test.go
@@ -234,10 +234,12 @@ func TestLoadTestSteps(t *testing.T) {
 
 			assert.Equal(t, len(tt.testSteps), len(testStepsVal))
 			for index := range tt.testSteps {
+				tt.testSteps[index].Dir = tt.path
 				assert.Equal(t, tt.testSteps[index].Apply, testStepsVal[index].Apply)
 				assert.Equal(t, tt.testSteps[index].Asserts, testStepsVal[index].Asserts)
 				assert.Equal(t, tt.testSteps[index].Errors, testStepsVal[index].Errors)
 				assert.Equal(t, tt.testSteps[index].Step, testStepsVal[index].Step)
+				assert.Equal(t, tt.testSteps[index].Dir, testStepsVal[index].Dir)
 				assert.Equal(t, tt.testSteps[index], testStepsVal[index])
 			}
 		})

--- a/pkg/test/harness.go
+++ b/pkg/test/harness.go
@@ -270,9 +270,10 @@ func (h *Harness) RunTests() {
 		for _, test := range tests {
 			test.Client = h.Client
 			test.DiscoveryClient = h.DiscoveryClient
-			test.Logger = testutils.NewTestLogger(t, test.Name)
 
 			t.Run(test.Name, func(t *testing.T) {
+				test.Logger = testutils.NewTestLogger(t, test.Name)
+
 				if err := test.LoadTestSteps(); err != nil {
 					t.Fatal(err)
 				}

--- a/pkg/test/harness.go
+++ b/pkg/test/harness.go
@@ -284,12 +284,15 @@ func (h *Harness) RunTests() {
 		for _, test := range tests {
 			test.Client = h.Client
 			test.DiscoveryClient = h.DiscoveryClient
+			test.Logger = testutils.NewTestLogger(t, test.Name)
 
-			if err := test.LoadTestSteps(); err != nil {
-				t.Fatal(err)
-			}
+			t.Run(test.Name, func(t *testing.T) {
+				if err := test.LoadTestSteps(); err != nil {
+					t.Fatal(err)
+				}
 
-			t.Run(test.Name, test.TestCaseFactory())
+				test.Run(t)
+			})
 		}
 	})
 }

--- a/pkg/test/test_data/cli-test/00-assert.yaml
+++ b/pkg/test/test_data/cli-test/00-assert.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: cli-test-pod

--- a/pkg/test/test_data/cli-test/00-create-pod.yaml
+++ b/pkg/test/test_data/cli-test/00-create-pod.yaml
@@ -1,0 +1,4 @@
+apiVersion: kudo.dev/v1alpha1
+kind: TestStep
+kubectl:
+- apply -f ./test_data/pod.yaml

--- a/pkg/test/test_data/cli-test/test_data/pod.yaml
+++ b/pkg/test/test_data/cli-test/test_data/pod.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: cli-test-pod
+spec:
+  containers:
+  - name: cli-test
+    image: alpine
+  restartPolicy: Never

--- a/pkg/test/utils/kubernetes.go
+++ b/pkg/test/utils/kubernetes.go
@@ -858,10 +858,10 @@ func RunKubectlCommands(logger Logger, namespace string, commands []string, work
 
 		err := Kubectl(context.TODO(), namespace, cmd, workdir, stdout, stderr)
 		if err != nil {
-			errs = append(errs, errors.New(stderr.String()))
 			errs = append(errs, err)
 		}
 
+		logger.Log(stderr.String())
 		logger.Log(stdout.String())
 	}
 

--- a/pkg/test/utils/kubernetes.go
+++ b/pkg/test/utils/kubernetes.go
@@ -818,6 +818,36 @@ func Kubectl(ctx context.Context, namespace string, args string, cwd string, std
 	return cmd.Run()
 }
 
+// RunKubectlCommands runs a set of kubectl commands, returning any errors.
+func RunKubectlCommands(logger Logger, namespace string, commands []string, workdir string) []error {
+	errs := []error{}
+
+	if commands == nil {
+		return nil
+	}
+
+	for _, cmd := range commands {
+		stdout := &bytes.Buffer{}
+		stderr := &bytes.Buffer{}
+
+		logger.Log("Running kubectl:", cmd)
+
+		err := Kubectl(context.TODO(), namespace, cmd, workdir, stdout, stderr)
+		if err != nil {
+			errs = append(errs, errors.New(stderr.String()))
+			errs = append(errs, err)
+		}
+
+		logger.Log(stdout.String())
+	}
+
+	if len(errs) == 0 {
+		return nil
+	}
+
+	return errs
+}
+
 // Kubeconfig converts a rest.Config into a YAML kubeconfig and writes it to w
 func Kubeconfig(cfg *rest.Config, w io.Writer) error {
 	var authProvider *api.AuthProviderConfig

--- a/test/integration/cli-install/00-assert.yaml
+++ b/test/integration/cli-install/00-assert.yaml
@@ -1,0 +1,20 @@
+apiVersion: kudo.dev/v1alpha1
+kind: Instance
+metadata:
+  labels:
+    kudo.dev/operator: cli-install-operator
+spec:
+  operatorVersion:
+    name: cli-install-operator-0.1.0
+status:
+  status: COMPLETE
+  activePlan:
+    apiVersion: kudo.dev/v1alpha1
+    kind: PlanExecution
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    memory: "1Gi"
+    cpu: "0.25"

--- a/test/integration/cli-install/00-install.yaml
+++ b/test/integration/cli-install/00-install.yaml
@@ -1,0 +1,4 @@
+apiVersion: kudo.dev/v1alpha1
+kind: TestStep
+kubectl:
+- kudo install --instance cli-install ./cli-install-operator

--- a/test/integration/cli-install/01-assert.yaml
+++ b/test/integration/cli-install/01-assert.yaml
@@ -1,0 +1,22 @@
+apiVersion: kudo.dev/v1alpha1
+kind: Instance
+metadata:
+  labels:
+    kudo.dev/operator: cli-install-operator
+  name: cli-install
+spec:
+  operatorVersion:
+    name: cli-install-operator-0.1.0
+status:
+  status: COMPLETE
+  activePlan:
+    apiVersion: kudo.dev/v1alpha1
+    kind: PlanExecution
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    memory: "2Gi"
+    cpu: "0.25"
+  name: cli-install-cli-install-operator

--- a/test/integration/cli-install/01-upgrade.yaml
+++ b/test/integration/cli-install/01-upgrade.yaml
@@ -1,0 +1,11 @@
+apiVersion: kudo.dev/v1alpha1
+kind: Instance
+metadata:
+  name: cli-install
+  labels:
+    kudo.dev/operator: cli-install-operator
+spec:
+  operatorVersion:
+    name: cli-install-operator-0.1.0
+  parameters:
+    memory: "2Gi"

--- a/test/integration/cli-install/cli-install-operator/operator.yaml
+++ b/test/integration/cli-install/cli-install-operator/operator.yaml
@@ -1,0 +1,20 @@
+name: "cli-install-operator"
+version: "0.1.0"
+kudoVersion: 0.3.0
+kubernetesVersion: 1.5.1
+maintainers:
+  - Justin Taylor-Barrick <jbarrick-mesosphere@mesosphere.com>
+tasks:
+  infra:
+    resources:
+      - deployment.yaml
+plans:
+  deploy:
+    strategy: serial
+    phases:
+      - name: infra
+        strategy: parallel
+        steps:
+          - name: everything
+            tasks:
+              - infra

--- a/test/integration/cli-install/cli-install-operator/params.yaml
+++ b/test/integration/cli-install/cli-install-operator/params.yaml
@@ -1,0 +1,6 @@
+memory:
+  description: Amount of memory to provide to Zookeeper pods
+  default: "1Gi"
+cpus:
+  description: Amount of cpu to provide to Zookeeper pods
+  default: "0.25"

--- a/test/integration/cli-install/cli-install-operator/templates/deployment.yaml
+++ b/test/integration/cli-install/cli-install-operator/templates/deployment.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .OperatorName }}
+  namespace: {{ .Namespace }}
+  labels:
+    memory: "{{ .Params.memory }}"
+    cpu: "{{ .Params.cpus }}"
+spec:
+  ports:
+  - port: 8080
+    name: {{ .Name }}


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kudo/blob/master/CONTRIBUTING.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kudobuilder/kudo/blob/master/RELEASE.md
3. Ensure you have added or ran the appropriate tests for your PR
4. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

This adds a `kubectl` setting to the KUDO test harness TestSuite and TestStep configurations to support running kubectl commands as a part of tests.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #368 (support CLI commands)
Fixes #369 (support install kudo frameworks)
Fixes #520 (panic when executing test harness)

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Test harness now supports running kubectl commands as a part of tests.
```