### PR TITLE
Fix race with WaitForCRDs not waiting for CRDs to be fully ready.

### DIFF
--- a/pkg/test/harness.go
+++ b/pkg/test/harness.go
@@ -282,7 +282,7 @@ func (h *Harness) Run() {
 		h.T.Fatal(err)
 	}
 
-	if err := testutils.WaitForCRDs(dClient, crds); err != nil {
+	if err := testutils.WaitForCRDs(cl, dClient, crds); err != nil {
 		h.T.Fatal(err)
 	}
 

--- a/pkg/test/utils/kubernetes_integration_test.go
+++ b/pkg/test/utils/kubernetes_integration_test.go
@@ -86,7 +86,7 @@ func TestWaitForCRDs(t *testing.T) {
 	assert.Nil(t, err)
 
 	// WaitForCRDs to be created.
-	assert.Nil(t, WaitForCRDs(testenv.DiscoveryClient, crds))
+	assert.Nil(t, WaitForCRDs(testenv.Client, testenv.DiscoveryClient, crds))
 
 	// Kubernetes client caches the types, se we need to re-initialize it.
 	testClient, err = NewRetryClient(testenv.Config, client.Options{


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

We were not properly waiting for CRDs to be fully ready - only for them to appear in the discovery client. This occasionally causes flakes if the CRD type is not ready for use.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

**Special notes for your reviewer**:

I was seeing this consistently on https://github.com/kudobuilder/test-infra/pull/1 but this patch fixes it.

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```