### PR TITLE
Instance Controller:  Refactored Create Operation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/kudobuilder/kudo
 go 1.12
 
 require (
-	cloud.google.com/go v0.38.0 // indirect
+	cloud.google.com/go v0.38.0
 	github.com/Azure/go-autorest/autorest v0.5.0 // indirect
 	github.com/Masterminds/goutils v1.1.0 // indirect
 	github.com/Masterminds/semver v1.4.2
@@ -25,6 +25,7 @@ require (
 	github.com/leodido/go-urn v1.1.0 // indirect
 	github.com/markbates/inflect v1.0.4 // indirect
 	github.com/masterminds/sprig v2.18.0+incompatible
+	github.com/onsi/ginkgo v1.7.0 // indirect
 	github.com/onsi/gomega v1.4.3
 	github.com/pborman/uuid v0.0.0-20180906182336-adf5a7427709 // indirect
 	github.com/pkg/errors v0.8.1

--- a/go.sum
+++ b/go.sum
@@ -146,6 +146,7 @@ github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXi
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/googleapis/gax-go/v2 v2.0.4 h1:hU4mGcQI4DaAYW+IbTun+2qEZVFxK0ySjQLTbS0VQKc=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gnostic v0.0.0-20170426233943-68f4ded48ba9/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=
 github.com/googleapis/gnostic v0.2.0 h1:l6N3VoaVzTncYYW+9yOz2LJJammFZGBO13sqgEhpy9g=

--- a/pkg/controller/instance/instance_controller.go
+++ b/pkg/controller/instance/instance_controller.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
@@ -103,7 +104,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 					instance.Status.ActivePlan.Name == "" {
 
 					log.Printf("InstanceController: Creating a deploy execution plan for the instance %v", instance.Name)
-					err = createPlan2(mgr, "deploy", &instance)
+					err = createPlanOld(mgr, "deploy", &instance)
 					if err != nil {
 						log.Printf("InstanceController: Error creating \"%v\" object for \"deploy\": %v", instance.Name, err)
 					}
@@ -266,7 +267,7 @@ func instanceEventFilter(mgr manager.Manager) predicate.Funcs {
 					}
 				}
 
-				if err = createPlan2(mgr, planName, new); err != nil {
+				if err = createPlanOld(mgr, planName, new); err != nil {
 					log.Printf("InstanceController: Error creating PlanExecution \"%v\" for instance \"%v\": %v", planName, new.Name, err)
 				}
 			}
@@ -310,15 +311,17 @@ func instanceEventFilter(mgr manager.Manager) predicate.Funcs {
 func createPlan(r *ReconcileInstance, planName string, instance *kudov1alpha1.Instance) error {
 	ctx := context.TODO()
 	gvk, _ := apiutil.GVKForObject(instance, r.scheme)
-	log.Printf("Creating PlanExecution of plan %s for instance %s", planName, instance.Name)
-	r.recorder.Event(instance, "Normal", "CreatePlanExecution", fmt.Sprintf("Creating \"%v\" plan execution", planName))
 
+	planExecution := getPlanExecution(gvk, instance, planName)
+	return createPlanExecution(ctx, instance, planExecution, r, planName)
+}
+
+func getPlanExecution(gvk schema.GroupVersionKind, instance *kudov1alpha1.Instance, planName string) kudov1alpha1.PlanExecution {
 	ref := corev1.ObjectReference{
 		Kind:      gvk.Kind,
 		Name:      instance.Name,
 		Namespace: instance.Namespace,
 	}
-
 	planExecution := kudov1alpha1.PlanExecution{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%v-%v-%v", instance.Name, planName, time.Now().Nanosecond()),
@@ -334,26 +337,32 @@ func createPlan(r *ReconcileInstance, planName string, instance *kudov1alpha1.In
 			PlanName: planName,
 		},
 	}
+	return planExecution
+}
+
+// createPlanExecution takes all the k8s objects needed to create the actual plan
+func createPlanExecution(ctx context.Context, instance *kudov1alpha1.Instance, plan kudov1alpha1.PlanExecution, r *ReconcileInstance, planName string) error {
+	log.Printf("Creating PlanExecution of plan %s for instance %s", planName, instance.Name)
+	r.recorder.Event(instance, "Normal", "CreatePlanExecution", fmt.Sprintf("Creating \"%v\" plan execution", planName))
 
 	// Make this instance the owner of the PlanExecution
-	if err := controllerutil.SetControllerReference(instance, &planExecution, r.scheme); err != nil {
+	if err := controllerutil.SetControllerReference(instance, &plan, r.scheme); err != nil {
 		log.Printf("InstanceController: Error setting ControllerReference")
 		return err
 	}
-
-	if err := r.Create(ctx, &planExecution); err != nil {
-		log.Printf("InstanceController: Error creating planexecution \"%v\": %v", planExecution.Name, err)
-		r.recorder.Event(instance, "Warning", "CreatePlanExecution", fmt.Sprintf("Error creating planexecution \"%v\": %v", planExecution.Name, err))
+	if err := r.Create(ctx, &plan); err != nil {
+		log.Printf("InstanceController: Error creating planexecution \"%v\": %v", plan.Name, err)
+		r.recorder.Event(instance, "Warning", "CreatePlanExecution", fmt.Sprintf("Error creating planexecution \"%v\": %v", plan.Name, err))
 		return err
 	}
 	log.Printf("Created PlanExecution of plan %s for instance %s", planName, instance.Name)
-	r.recorder.Event(instance, "Normal", "PlanCreated", fmt.Sprintf("PlanExecution \"%v\" created", planExecution.Name))
+	r.recorder.Event(instance, "Normal", "PlanCreated", fmt.Sprintf("PlanExecution \"%v\" created", plan.Name))
 	return nil
 }
 
 //todo: REMOVE this... we do not want to create a plan outside of reconcile
 // most likely... any use of this function is wrong... all plans should be created in reconcile
-func createPlan2(mgr manager.Manager, planName string, instance *kudov1alpha1.Instance) error {
+func createPlanOld(mgr manager.Manager, planName string, instance *kudov1alpha1.Instance) error {
 	ctx := context.TODO()
 	gvk, _ := apiutil.GVKForObject(instance, mgr.GetScheme())
 	recorder := mgr.GetEventRecorderFor("instance-controller")

--- a/pkg/controller/planexecution/planexecution_controller.go
+++ b/pkg/controller/planexecution/planexecution_controller.go
@@ -22,6 +22,7 @@ import (
 	"log"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/kudobuilder/kudo/pkg/util/kudo"
 
@@ -624,4 +625,29 @@ func (r *ReconcilePlanExecution) Cleanup(obj runtime.Object) error {
 func prettyPrint(i interface{}) string {
 	s, _ := json.MarshalIndent(i, "", "  ")
 	return string(s)
+}
+
+// New creates a PlanExecution based on the kind and instance for a given planName
+func New(kind string, instance *kudov1alpha1.Instance, planName string) kudov1alpha1.PlanExecution {
+	ref := corev1.ObjectReference{
+		Kind:      kind,
+		Name:      instance.Name,
+		Namespace: instance.Namespace,
+	}
+	planExecution := kudov1alpha1.PlanExecution{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%v-%v-%v", instance.Name, planName, time.Now().Nanosecond()),
+			Namespace: instance.GetNamespace(),
+			// TODO: Should also add one for Operator in here as well.
+			Labels: map[string]string{
+				kudo.OperatorVersionAnnotation: instance.Spec.OperatorVersion.Name,
+				kudo.InstanceLabel:             instance.Name,
+			},
+		},
+		Spec: kudov1alpha1.PlanExecutionSpec{
+			Instance: ref,
+			PlanName: planName,
+		},
+	}
+	return planExecution
 }


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
 /kind cleanup

**What this PR does / why we need it**:
While working #634 it was challenging to resolve those 3 bugs.  It is generally agreed that instance controller needs to be refactored.  It is not coded according to the recommendations of https://godoc.org/github.com/kubernetes-sigs/controller-runtime/pkg.  The predicates have side effects.   All reconciliation activities should move to the reconciler.  @alenkacz and I paired this morning and took on everything at once.  As I continued that work, it seemed logical to break it appear into several PRs.   This is the work for `Create` operation of instance controller.   It includes:

1.  Consolidation of similar functions for getInstance and getOV
2. Removal of `createPlan` from Create predicate
3. Addition of `createPlan` in reconcile
4. create predicate is false for missing OV, otherwise true
5. definition a newly created instance (ActivePlan.Name == "")
6. consolidation of context.TODO()

**Note:** there are current 2 createPlans.  `createPlanOld` is the old createPlan and should likely be removed at some point.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```