### PR TITLE
Fix EXE path when generating Krew plugin.

### DIFF
--- a/hack/generate_krew.sh
+++ b/hack/generate_krew.sh
@@ -35,7 +35,7 @@ kind: Plugin
 metadata:
   name: kudo
 spec:
-  version: "${VERSION}"
+  version: "v${VERSION}"
 
   shortDescription: Declaratively build, install, and run operators using KUDO.
   homepage: https://kudo.dev/

--- a/hack/generate_krew.sh
+++ b/hack/generate_krew.sh
@@ -20,7 +20,7 @@ function generate_platform {
         arch: "${2}"
     uri: https://github.com/kudobuilder/kudo/releases/download/v${VERSION}/kudo_${VERSION}_${1}_${ARCH}.tar.gz
     sha256: "$(curl -L https://github.com/kudobuilder/kudo/releases/download/v${VERSION}/kudo_${VERSION}_${1}_${ARCH}.tar.gz |sha256sum - |awk '{print $1}')"
-    bin: "./kubectl-kudo"
+    bin: "${3}"
     files:
     - from: "*"
       to: "."
@@ -47,11 +47,11 @@ spec:
   platforms:
 EOF
 
-generate_platform linux amd64 >> kudo.yaml
-generate_platform linux 386 >> kudo.yaml
-generate_platform darwin amd64 >> kudo.yaml
-generate_platform darwin 386 >> kudo.yaml
-generate_platform windows amd64 >> kudo.yaml
-generate_platform windows 386 >> kudo.yaml
+generate_platform linux amd64 ./kubectl-kudo >> kudo.yaml
+generate_platform linux 386 ./kubectl-kudo >> kudo.yaml
+generate_platform darwin amd64 ./kubectl-kudo >> kudo.yaml
+generate_platform darwin 386 ./kubectl-kudo >> kudo.yaml
+generate_platform windows amd64 ./kubectl-kudo.exe >> kudo.yaml
+generate_platform windows 386 ./kubectl-kudo.exe >> kudo.yaml
 
 echo "To publish to the krew index, create a pull request to https://github.com/kubernetes-sigs/krew-index/tree/master/plugins to update kudo.yaml with the newly generated kudo.yaml."


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This fixes the Krew plugin path for Windows EXEs.

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```