### PR TITLE
Consistent help messages for all commands

### DIFF
--- a/pkg/kudoctl/cmd/get.go
+++ b/pkg/kudoctl/cmd/get.go
@@ -20,6 +20,5 @@ func newGetCmd() *cobra.Command {
 	}
 
 	getCmd.Flags().StringVar(&options.Namespace, "namespace", "default", "The namespace where the operator watches for changes.")
-
 	return getCmd
 }

--- a/pkg/kudoctl/cmd/install.go
+++ b/pkg/kudoctl/cmd/install.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"github.com/kudobuilder/kudo/pkg/kudoctl/cmd/install"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -58,11 +56,5 @@ func newInstallCmd() *cobra.Command {
 	installCmd.Flags().StringArrayVarP(&parameters, "parameter", "p", nil, "The parameter name and value separated by '='")
 	installCmd.Flags().StringVarP(&options.PackageVersion, "version", "v", "", "A specific package version on the official GitHub repo. (default to the most recent)")
 	installCmd.Flags().BoolVar(&options.SkipInstance, "skip-instance", false, "If set, install will install the Operator and OperatorVersion, but not an instance. (default \"false\")")
-
-	const usageFmt = "Usage:\n  %s\n\nFlags:\n%s"
-	installCmd.SetUsageFunc(func(cmd *cobra.Command) error {
-		fmt.Fprintf(installCmd.OutOrStderr(), usageFmt, installCmd.UseLine(), installCmd.Flags().FlagUsages())
-		return nil
-	})
 	return installCmd
 }

--- a/pkg/kudoctl/cmd/update.go
+++ b/pkg/kudoctl/cmd/update.go
@@ -54,12 +54,6 @@ func newUpdateCmd() *cobra.Command {
 
 	updateCmd.Flags().StringArrayVarP(&parameters, "parameter", "p", nil, "The parameter name and value separated by '='")
 	updateCmd.Flags().StringVar(&options.Namespace, "namespace", defaultOptions.Namespace, "The namespace where the instance you want to upgrade is installed in.")
-
-	const usageFmt = "Usage:\n  %s\n\nFlags:\n%s"
-	updateCmd.SetUsageFunc(func(cmd *cobra.Command) error {
-		fmt.Fprintf(updateCmd.OutOrStderr(), usageFmt, updateCmd.UseLine(), updateCmd.Flags().FlagUsages())
-		return nil
-	})
 	return updateCmd
 }
 

--- a/pkg/kudoctl/cmd/upgrade.go
+++ b/pkg/kudoctl/cmd/upgrade.go
@@ -69,11 +69,6 @@ func newUpgradeCmd() *cobra.Command {
 	upgradeCmd.Flags().StringVar(&options.Namespace, "namespace", defaultOptions.Namespace, "The namespace where the instance you want to upgrade is installed in.")
 	upgradeCmd.Flags().StringVarP(&options.PackageVersion, "version", "v", "", "A specific package version on the official repository. When installing from other sources than official repository, version from inside operator.yaml will be used. (default to the most recent)")
 
-	const usageFmt = "Usage:\n  %s\n\nFlags:\n%s"
-	upgradeCmd.SetUsageFunc(func(cmd *cobra.Command) error {
-		fmt.Fprintf(upgradeCmd.OutOrStderr(), usageFmt, upgradeCmd.UseLine(), upgradeCmd.Flags().FlagUsages())
-		return nil
-	})
 	return upgradeCmd
 }
 

--- a/pkg/kudoctl/cmd/version.go
+++ b/pkg/kudoctl/cmd/version.go
@@ -25,11 +25,6 @@ func newVersionCmd() *cobra.Command {
 		SilenceUsage: true,
 	}
 
-	const usageFmt = "Usage:\n  %s"
-	versionCmd.SetUsageFunc(func(cmd *cobra.Command) error {
-		fmt.Fprintf(versionCmd.OutOrStderr(), usageFmt, versionCmd.UseLine())
-		return nil
-	})
 	return versionCmd
 }
 


### PR DESCRIPTION

**What type of PR is this?**
/component kudoctl
/kind cleanup

**What this PR does / why we need it**:
Commands previously were inconsistent with usage info... some used the default (like `test` and `get`) however several overrode the default help.   All the overrides resulted in the help text not be displayed at all.   For instance `go run cmd/kubectl-kudo/main.go update --help`
resulted in:
```
Update installed KUDO operator with new parameters.

Usage:
  kubectl-kudo update <instance-name> [flags]

Flags:
  -h, --help                    help for update
      --kubeconfig string       Path to your Kubernetes configuration file (default "/Users/kensipe/.kube/config")
      --namespace string        The namespace where the instance you want to upgrade is installed in. (default "default")
  -p, --parameter stringArray   The parameter name and value separated by '='
```

Now it results in:
```
go run cmd/kubectl-kudo/main.go update --help
Update installed KUDO operator with new parameters.

Usage:
  kubectl-kudo update <instance-name> [flags]

Examples:

		The update argument must be a name of the instance.

		# Update dev-flink instance with setting parameter param with value value
		kubectl kudo update dev-flink -p param=value

		# Update dev-flink instance in namespace services with setting parameter param with value value
		kubectl kudo update dev-flink -n services -p param=value

Flags:
  -h, --help                    help for update
      --namespace string        The namespace where the instance you want to upgrade is installed in. (default "default")
  -p, --parameter stringArray   The parameter name and value separated by '='

Global Flags:
      --kubeconfig string   Path to your Kubernetes configuration file (default "/Users/kensipe/.kube/config")
```

Making use of the examples in code.   It also has the advantage of showing what the global flags are.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```