### PR TITLE
update min minikube spec to allow zk/kafka

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -28,7 +28,7 @@ If you want to use the KUDO kubectl plugin, you can now follow the [CLI plugin i
 If you plan on developing and testing KUDO locally via Minikube, you'll need to launch your cluster with a reasonable amount of memory allocated. By default, this is only 2GB - we recommend at least 8GB, especially if you're working with applications such as [Kafka](/docs/examples/apache-kafka/). You can start Minikube with some suitable resource adjustments as follows:
 
 ```shell
-minikube start --cpus=4 --memory=8192 --disk-size=40g
+minikube start --cpus=4 --memory=10240 --disk-size=40g
 ```
 
 ## Deploy your first Operator


### PR DESCRIPTION
Based on simplistic testing, [here](https://docs.google.com/spreadsheets/d/1QXr5726SMlrGxFkLup7UfJrJaM1oaRRw1aK2uTcjvoY/edit#gid=0), minimum minikube requirements to deploy zk and kafka is 4cpu and 10gig of memory.