### PR TITLE
Instance spec as part of plan execution CRD

### DIFF
--- a/config/crds/kudo_v1alpha1_instance.yaml
+++ b/config/crds/kudo_v1alpha1_instance.yaml
@@ -48,6 +48,7 @@ spec:
               description: Operator specifies a reference to a specific Operator object.
               type: object
             parameters:
+              description: 'TODO: this is deprecated and should not be used'
               type: object
           type: object
         status:

--- a/config/crds/kudo_v1alpha1_planexecution.yaml
+++ b/config/crds/kudo_v1alpha1_planexecution.yaml
@@ -36,9 +36,36 @@ spec:
               description: This flag tells the controller to suspend subsequent executions,
                 it does not apply to already started executions.  Defaults to false.
               type: boolean
+            template:
+              properties:
+                dependencies:
+                  items:
+                    properties:
+                      referenceName:
+                        description: Name specifies the name of the dependency. Referenced
+                          via defaults.config.
+                        type: string
+                      version:
+                        description: 'Version captures the requirements for what versions
+                          of the above object are allowed.  Example: ^3.1.4'
+                        type: string
+                    required:
+                    - referenceName
+                    - version
+                    type: object
+                  type: array
+                operatorVersion:
+                  description: Operator specifies a reference to a specific Operator
+                    object.
+                  type: object
+                parameters:
+                  description: 'TODO: this is deprecated and should not be used'
+                  type: object
+              type: object
           required:
           - planName
           - instance
+          - template
           type: object
         status:
           properties:

--- a/config/crds/kudo_v1alpha1_teststep.yaml
+++ b/config/crds/kudo_v1alpha1_teststep.yaml
@@ -22,6 +22,38 @@ spec:
         delete:
           description: Objects to delete at the beginning of the test step.
           items:
+            properties:
+              apiVersion:
+                description: API version of the referent.
+                type: string
+              fieldPath:
+                description: 'If referring to a piece of an object instead of an entire
+                  object, this string should contain a valid JSON/Go field access
+                  statement, such as desiredState.manifest.containers[2]. For example,
+                  if the object reference is to a container within a pod, this would
+                  take on a value like: "spec.containers{name}" (where "name" refers
+                  to the name of the container that triggered the event) or if no
+                  container name is specified "spec.containers[2]" (container with
+                  index 2 in this pod). This syntax is chosen only to have some well-defined
+                  way of referencing a part of an object. TODO: this design is not
+                  final and this field is subject to change in the future.'
+                type: string
+              kind:
+                description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                type: string
+              name:
+                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                type: string
+              namespace:
+                description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                type: string
+              resourceVersion:
+                description: 'Specific resourceVersion to which this reference is
+                  made, if any. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency'
+                type: string
+              uid:
+                description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                type: string
             type: object
           type: array
         index:
@@ -32,6 +64,11 @@ spec:
             object represents. Servers may infer this from the endpoint the client
             submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
           type: string
+        kubectl:
+          description: Kubectl commands to run at the start of the test
+          items:
+            type: string
+          type: array
         metadata:
           description: Override the default metadata. Set labels or override the test
             step name.
@@ -42,6 +79,7 @@ spec:
           type: boolean
       required:
       - unitTest
+      - kubectl
   version: v1alpha1
 status:
   acceptedNames:

--- a/config/crds/kudo_v1alpha1_testsuite.yaml
+++ b/config/crds/kudo_v1alpha1_testsuite.yaml
@@ -19,6 +19,10 @@ spec:
             of an object. Servers should convert recognized schemas to the latest
             internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
           type: string
+        artifactsDir:
+          description: The directory to output artifacts to (current working directory
+            if not specified).
+          type: string
         crdDir:
           description: Path to CRDs to install before running tests.
           type: string
@@ -27,15 +31,43 @@ spec:
             object represents. Servers may infer this from the endpoint the client
             submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
           type: string
-        manifestsDir:
-          description: Path to manifests to install before running tests.
+        kindConfig:
+          description: Path to the KIND configuration file to use.
           type: string
+        kindContext:
+          description: KIND context to use.
+          type: string
+        kubectl:
+          description: Kubectl commands to run before running any tests.
+          items:
+            type: string
+          type: array
+        manifestDirs:
+          description: Paths to directories containing manifests to install before
+            running tests.
+          items:
+            type: string
+          type: array
         metadata:
           description: Set labels or the test suite name.
           type: object
+        parallel:
+          description: 'The maximum number of tests to run at once (default: 8).'
+          format: int64
+          type: integer
+        skipClusterDelete:
+          description: If set, do not delete the mocked control plane or kind cluster.
+          type: boolean
+        skipDelete:
+          description: If set, do not delete the resources after running the tests
+            (implies SkipClusterDelete).
+          type: boolean
         startControlPlane:
           description: Whether or not to start a local etcd and kubernetes API server
             for the tests.
+          type: boolean
+        startKIND:
+          description: Whether or not to start a local kind cluster for the tests.
           type: boolean
         startKUDO:
           description: Whether or not to start the KUDO controller for the tests.
@@ -45,12 +77,25 @@ spec:
           items:
             type: string
           type: array
+        timeout:
+          description: Override the default timeout of 30 seconds (in seconds).
+          format: int64
+          type: integer
       required:
       - crdDir
-      - manifestsDir
+      - manifestDirs
       - testDirs
       - startControlPlane
+      - startKIND
+      - kindConfig
+      - kindContext
       - startKUDO
+      - skipDelete
+      - skipClusterDelete
+      - timeout
+      - parallel
+      - artifactsDir
+      - kubectl
   version: v1alpha1
 status:
   acceptedNames:

--- a/hack/update_manifests.sh
+++ b/hack/update_manifests.sh
@@ -20,4 +20,4 @@ else
 fi
 
 go run "$CONTROLLER_GEN_DIR"/cmd/controller-gen/main.go rbac
-go run "$CONTROLLER_GEN_DIR"/cmd/controller-gen/main.go crd
+go run "$CONTROLLER_GEN_DIR"/cmd/controller-gen/main.go crd --domain dev

--- a/pkg/apis/kudo/v1alpha1/planexecution_types.go
+++ b/pkg/apis/kudo/v1alpha1/planexecution_types.go
@@ -30,7 +30,7 @@ type PlanExecutionSpec struct {
 
 	PlanName string                 `json:"planName"`
 	Instance corev1.ObjectReference `json:"instance"`
-	Template InstanceSpec `json:"template"`
+	Template InstanceSpec           `json:"template"`
 }
 
 // PlanExecutionStatus defines the observed state of PlanExecution

--- a/pkg/apis/kudo/v1alpha1/planexecution_types.go
+++ b/pkg/apis/kudo/v1alpha1/planexecution_types.go
@@ -30,6 +30,7 @@ type PlanExecutionSpec struct {
 
 	PlanName string                 `json:"planName"`
 	Instance corev1.ObjectReference `json:"instance"`
+	Template InstanceSpec `json:"template"`
 }
 
 // PlanExecutionStatus defines the observed state of PlanExecution

--- a/pkg/apis/kudo/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/kudo/v1alpha1/zz_generated.deepcopy.go
@@ -687,6 +687,7 @@ func (in *PlanExecutionSpec) DeepCopyInto(out *PlanExecutionSpec) {
 		**out = **in
 	}
 	out.Instance = in.Instance
+	in.Template.DeepCopyInto(&out.Template)
 	return
 }
 

--- a/pkg/controller/instance/instance_controller.go
+++ b/pkg/controller/instance/instance_controller.go
@@ -28,8 +28,6 @@ import (
 	"k8s.io/client-go/tools/record"
 
 	kudov1alpha1 "github.com/kudobuilder/kudo/pkg/apis/kudo/v1alpha1"
-	"github.com/kudobuilder/kudo/pkg/controller/planexecution"
-
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -309,9 +307,8 @@ func instanceEventFilter(mgr manager.Manager) predicate.Funcs {
 
 func createPlan(r *ReconcileInstance, planName string, instance *kudov1alpha1.Instance) error {
 	ctx := context.TODO()
-	gvk, _ := apiutil.GVKForObject(instance, r.scheme)
 
-	planExecution := planexecution.New(gvk.Kind, instance, planName)
+	planExecution := newPlanExecution(instance, planName, r.scheme)
 	return createPlanExecution(ctx, instance, planExecution, r, planName)
 }
 
@@ -339,32 +336,11 @@ func createPlanExecution(ctx context.Context, instance *kudov1alpha1.Instance, p
 // most likely... any use of this function is wrong... all plans should be created in reconcile
 func createPlanOld(mgr manager.Manager, planName string, instance *kudov1alpha1.Instance) error {
 	ctx := context.TODO()
-	gvk, _ := apiutil.GVKForObject(instance, mgr.GetScheme())
 	recorder := mgr.GetEventRecorderFor("instance-controller")
 	log.Printf("Creating PlanExecution of plan %s for instance %s", planName, instance.Name)
 	recorder.Event(instance, "Normal", "CreatePlanExecution", fmt.Sprintf("Creating \"%v\" plan execution", planName))
 
-	ref := corev1.ObjectReference{
-		Kind:      gvk.Kind,
-		Name:      instance.Name,
-		Namespace: instance.Namespace,
-	}
-
-	planExecution := kudov1alpha1.PlanExecution{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%v-%v-%v", instance.Name, planName, time.Now().Nanosecond()),
-			Namespace: instance.GetNamespace(),
-			// TODO: Should also add one for Operator in here as well.
-			Labels: map[string]string{
-				kudo.OperatorVersionAnnotation: instance.Spec.OperatorVersion.Name,
-				kudo.InstanceLabel:             instance.Name,
-			},
-		},
-		Spec: kudov1alpha1.PlanExecutionSpec{
-			Instance: ref,
-			PlanName: planName,
-		},
-	}
+	planExecution := newPlanExecution(instance, planName, mgr.GetScheme())
 
 	// Make this instance the owner of the PlanExecution
 	if err := controllerutil.SetControllerReference(instance, &planExecution, mgr.GetScheme()); err != nil {
@@ -498,4 +474,31 @@ func parameterDifference(old, new map[string]string) map[string]string {
 	}
 
 	return diff
+}
+
+// newPlanExecution creates a PlanExecution based on the kind and instance for a given planName
+func newPlanExecution(instance *kudov1alpha1.Instance, planName string, scheme *runtime.Scheme) kudov1alpha1.PlanExecution {
+	gvk, _ := apiutil.GVKForObject(instance, scheme)
+	ref := corev1.ObjectReference{
+		Kind:      gvk.Kind,
+		Name:      instance.Name,
+		Namespace: instance.Namespace,
+	}
+	planExecution := kudov1alpha1.PlanExecution{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%v-%v-%v", instance.Name, planName, time.Now().Nanosecond()),
+			Namespace: instance.GetNamespace(),
+			// TODO: Should also add one for Operator in here as well.
+			Labels: map[string]string{
+				kudo.OperatorVersionAnnotation: instance.Spec.OperatorVersion.Name,
+				kudo.InstanceLabel:             instance.Name,
+			},
+		},
+		Spec: kudov1alpha1.PlanExecutionSpec{
+			Instance: ref,
+			PlanName: planName,
+			Template: instance.Spec,
+		},
+	}
+	return planExecution
 }

--- a/pkg/controller/planexecution/planexecution_controller.go
+++ b/pkg/controller/planexecution/planexecution_controller.go
@@ -19,12 +19,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/kudobuilder/kudo/pkg/util/kudo"
 	"log"
 	"strconv"
 	"strings"
-	"time"
-
-	"github.com/kudobuilder/kudo/pkg/util/kudo"
 
 	apijson "k8s.io/apimachinery/pkg/util/json"
 
@@ -625,29 +623,4 @@ func (r *ReconcilePlanExecution) Cleanup(obj runtime.Object) error {
 func prettyPrint(i interface{}) string {
 	s, _ := json.MarshalIndent(i, "", "  ")
 	return string(s)
-}
-
-// New creates a PlanExecution based on the kind and instance for a given planName
-func New(kind string, instance *kudov1alpha1.Instance, planName string) kudov1alpha1.PlanExecution {
-	ref := corev1.ObjectReference{
-		Kind:      kind,
-		Name:      instance.Name,
-		Namespace: instance.Namespace,
-	}
-	planExecution := kudov1alpha1.PlanExecution{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%v-%v-%v", instance.Name, planName, time.Now().Nanosecond()),
-			Namespace: instance.GetNamespace(),
-			// TODO: Should also add one for Operator in here as well.
-			Labels: map[string]string{
-				kudo.OperatorVersionAnnotation: instance.Spec.OperatorVersion.Name,
-				kudo.InstanceLabel:             instance.Name,
-			},
-		},
-		Spec: kudov1alpha1.PlanExecutionSpec{
-			Instance: ref,
-			PlanName: planName,
-		},
-	}
-	return planExecution
 }

--- a/pkg/controller/planexecution/planexecution_controller.go
+++ b/pkg/controller/planexecution/planexecution_controller.go
@@ -19,10 +19,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/kudobuilder/kudo/pkg/util/kudo"
 	"log"
 	"strconv"
 	"strings"
+
+	"github.com/kudobuilder/kudo/pkg/util/kudo"
 
 	apijson "k8s.io/apimachinery/pkg/util/json"
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kudo/blob/master/CONTRIBUTING.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kudobuilder/kudo/blob/master/RELEASE.md
3. Ensure you have added or ran the appropriate tests for your PR
4. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
As part of #422 to be able to cleanly reconcile instance we need to be able to say from what state of instance the previous plan was ran (to be able to diff params etc.) as kubernetes does not guarantee for us to hold history of instance objects.

The design of this is inspired by deployment x replicaset x pod relation in core k8s. There also RS references whole podspec and when deployment is updated, they try to figure out if that RS has the same podspec or what changed.

This is just first step, as we introduce the instance spec on that CRD and make sure it's filled when planexecution is created. to use that for processing, that will come in the next PR.

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
PlanExecution CRD now contains copy of whole instance object.
```