### PR TITLE
Update date for K8s Finland Meetup, fix community link in announcements

### DIFF
--- a/site/content/posts/announcing-kudo-0.2.0.md
+++ b/site/content/posts/announcing-kudo-0.2.0.md
@@ -66,4 +66,4 @@ To see the full changelog and the list of contributors who contribued to this re
 
 Now that KUDO v0.2.0 has shipped, the team will begin planning and executing on v0.3.0. The focus of v0.3.0 is to stabilize the packaging format for operator developers, as well as operator extensions to provide KUDO's sequencing logic to formats including Helm Charts and [CNAB](https://cnab.io) bundles.
 
-[Get started](/docs/getting-started) with KUDO today. Our [community](/docs/community) is ready for feedback to make KUDO even better!
+[Get started](/docs/getting-started) with KUDO today. Our [community](/community) is ready for feedback to make KUDO even better!

--- a/site/content/posts/announcing-kudo-0.3.0.md
+++ b/site/content/posts/announcing-kudo-0.3.0.md
@@ -73,4 +73,4 @@ To see the full changelog and the list of contributors who contribued to this re
 
 Now that KUDO v0.3.0 has shipped, the team will begin planning and executing on v0.4.0. The focus of v0.4.0 is to provide operator extensions to provide KUDO's sequencing logic to formats including Helm Charts and [CNAB](https://cnab.io) bundles. v0.4.0 will also focus on the operator release process for operators being released into the repository.
 
-[Get started](/docs/getting-started) with KUDO today. Our [community](/docs/community) is ready for feedback to make KUDO even better!
+[Get started](/docs/getting-started) with KUDO today. Our [community](/community) is ready for feedback to make KUDO even better!

--- a/site/content/posts/announcing-kudo-0.4.0.md
+++ b/site/content/posts/announcing-kudo-0.4.0.md
@@ -58,4 +58,4 @@ To see the full changelog and the list of contributors who contribued to this re
 Now that KUDO v0.4.0 has shipped, we will shortly after follow with v0.5.0 containing features like kudo upgrade or test harness enhanced with ability to execute kubectl commands. After that, in 0.6.0, we will focus on implementing extensions as described in [KEP-12](https://github.com/kudobuilder/kudo/blob/master/keps/0012-operator-extensions.md) as well as improvements for observability and debugging.
 See the [KUDO Roadmap](https://github.com/orgs/kudobuilder/projects/2) for details.
 
-[Get started](/docs/getting-started) with KUDO today. Our [community](/docs/community) is ready for feedback to make KUDO even better!
+[Get started](/docs/getting-started) with KUDO today. Our [community](/community) is ready for feedback to make KUDO even better!

--- a/site/content/posts/announcing-kudo-0.5.0.md
+++ b/site/content/posts/announcing-kudo-0.5.0.md
@@ -21,4 +21,4 @@ If you're using test harness to write your tests (and you should!) you can now e
 Next minor planned release will be 0.6.0. We will focus on implementing extensions as described in [KEP-12](https://github.com/kudobuilder/kudo/blob/master/keps/0012-operator-extensions.md) as well as improvements for observability and debugging.
 See the [KUDO Roadmap](https://github.com/orgs/kudobuilder/projects/2) for details.
 
-[Get started](/docs/getting-started) with KUDO today. Our [community](/docs/community) is ready for feedback to make KUDO even better!
+[Get started](/docs/getting-started) with KUDO today. Our [community](/community) is ready for feedback to make KUDO even better!

--- a/site/data/events/kubernetesfinland.yaml
+++ b/site/data/events/kubernetesfinland.yaml
@@ -1,6 +1,6 @@
-event: Kubernetes Finland
+event: Kubernetes and CNCF Finland Meetup
 topic: KUDO - Kubernetes Operators the easy way
 speaker: Nick Jones
-date: 2019-08-28
+date: 2019-08-27
 location: Helsinki, Finland
-url: Coming Soon
+url: https://www.meetup.com/Kubernetes-Finland/


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

The date for the Kubernetes and CNCF Meetup in Finland has changed, so we need to update our events page to reflect that.

This commit also fixes a broken link to the community page from the release announcements.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```