### PR TITLE
Fix testing link

### DIFF
--- a/docs/developing-operators.md
+++ b/docs/developing-operators.md
@@ -218,4 +218,4 @@ spec:
 
 ## Testing your operator
 
-You should aim for your operators being tested for day 1. To help you with testing your operator, we have developed a tool called test harness (it's also what we use to test KUDO itself). For more information please go to [test harness documentation](docs/testing.md).
+You should aim for your operators being tested for day 1. To help you with testing your operator, we have developed a tool called test harness (it's also what we use to test KUDO itself). For more information please go to [test harness documentation](/docs/testing).


### PR DESCRIPTION
* Make path absolute, otherwise it points to `/docs/developing-operators/docs/testing
* Remove `.md` ending

**What type of PR is this?**
/component operator
/kind documentation
