### PR TITLE
Fix some wording around the update subcommand

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -392,13 +392,13 @@ $ kubectl kudo package ../operators/repository/zookeeper/operator/ --destination
   Package created: /Users/kensipe/zookeeper-0.1.0.tgz
 ```
 
-### Update parameters on running operator
+### Update parameters on running operator instance
 
-Every operator can define overridable parameters in `params.yaml`. When installing an operator, you can use the defined defaults or override them with `-p` parameters for `kudo install`.
+Every operator can define overridable parameters in `params.yaml`. When installing an operator and deploying an instance, you can use the defaults or override them with `-p` parameters to `kudo install`.
 
-The `kudo update` command allows you to change these parameters even on an already installed operator. If you have an operator instance in your cluster named `dev-flink` (you can figure out what you have installed with `kubectl get instances`) and that instance exposes a parameter with the name `param` you can change its value with the following command:
+The `kudo update` command allows you to change these parameters even on an already running operator instance. For example, if you have an instance in your cluster named `dev-flink` (you can figure out what you have installed with `kubectl get instances`) and that operator exposes a parameter with the name `param`, you can change its value with the following command:
 
-`kubectl kudo update dev-flink -p param=value`
+`kubectl kudo update --instance dev-flink -p param=value`
 
 ### Upgrade running operator from one version to another
 

--- a/pkg/kudoctl/cmd/update.go
+++ b/pkg/kudoctl/cmd/update.go
@@ -38,8 +38,8 @@ func newUpdateCmd() *cobra.Command {
 	var parameters []string
 	updateCmd := &cobra.Command{
 		Use:     "update",
-		Short:   "Update installed KUDO operator.",
-		Long:    `Update installed KUDO operator with new parameters.`,
+		Short:   "Update KUDO operator instance.",
+		Long:    `Update KUDO operator instance with new parameters.`,
 		Example: updateExample,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Prior to command execution we parse and validate passed parameters
@@ -102,6 +102,6 @@ func update(instanceToUpdate string, kc *kudo.Client, options *updateOptions) er
 	if err != nil {
 		return errors.Wrapf(err, "updating instance %s", instanceToUpdate)
 	}
-	fmt.Printf("Instance %s was updated ヽ(•‿•)ノ", instanceToUpdate)
+	fmt.Printf("Instance %s was updated.", instanceToUpdate)
 	return nil
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
Fixes the the example in the docs for the `kubectl kudo update` command as this is currently incorrect (you need to prefix the instance name with `--instance`).

I've also tried to fix up some of the wording and naming used inline in the subcommand itself as well as in the documentation.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```