### PR TITLE
Proposal: Support calling out to arbitrary commands in the test harness.

### DIFF
--- a/keps/0008-operator-testing.md
+++ b/keps/0008-operator-testing.md
@@ -151,6 +151,8 @@ type TestSuite struct {
 	TestDirs          []string
 	// Kubectl specifies a list of kubectl commands to run prior to running the tests.
 	Kubectl []string `json:"kubectl"`
+	// Commands to run prior to running the tests. 
+	Commands []Command `json:"commands"`
 	// Whether or not to start a local etcd and kubernetes API server for the tests (cannot be set with StartKIND)
 	StartControlPlane bool
 	// Whether or not to start a local kind cluster for the tests (cannot be set with StartControlPlane).
@@ -167,6 +169,13 @@ type TestSuite struct {
 	SkipClusterDelete bool `json:"skipClusterDelete"`
 	// Override the default assertion timeout of 30 seconds (in seconds).
 	Timeout int
+}
+
+type Command struct {
+	// The command and argument to run as a string.
+	Command string `json:"command"`
+	// If set, the `--namespace` flag will be appended to the command with the namespace to use.
+	Namespaced bool `json:"namespaced"`
 }
 ```
 
@@ -247,6 +256,9 @@ type TestStep struct {
     // Kubectl specifies a list of kubectl commands to run at the beginning of the test step.
     Kubectl []string `json:"kubectl"`
 
+    // Commands to run prior at the beginning of the test step.
+    Commands []Command `json:"commands"`
+
     // Indicates that this is a unit test - safe to run without a real Kubernetes cluster.
     UnitTest bool
 
@@ -325,6 +337,12 @@ type TestAssert struct {
     Timeout int
 }
 ```
+
+#### Commands
+
+If commands are set in the test suite or step they will be run at the beginning of the test suite or step, respectively. Commands are run in order and are typed so that functionality can be extended.
+
+The command is split on spaces (while respecting quoted strings, e.g., using [shlex](https://godoc.org/github.com/google/shlex)). If the command has the `Namespaced` setting set, then the `--namespace` flag will be added with the test case namespace (or "default" for the the test suite).
 
 ### Results collection
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kudo/blob/master/CONTRIBUTING.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kudobuilder/kudo/blob/master/RELEASE.md
3. Ensure you have added or ran the appropriate tests for your PR
4. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What type of PR is this?**
/kind kep

**What this PR does / why we need it**:

Currently the test harness only supports running kubectl commands and plugins, but this is limiting:

* It prevents testing Helm charts (you cannot use Helm).
* It prevents using kind subcommands (e.g., `kind load docker-image`).

This would have us support the `Commands` setting to allow this flexibility.

The downside is that now tests can call arbitrary commands. Alternatively, we could retain the kubectl restriction and require helm/kind/etc to be installed as kubectl plugins in order to be used in tests.

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
