### PR TITLE
Uses Repo Name in kudo install and upgrade

### DIFF
--- a/pkg/kudoctl/cmd/init.go
+++ b/pkg/kudoctl/cmd/init.go
@@ -191,7 +191,7 @@ func ensureRepositoryFile(fs afero.Fs, home kudohome.Home, out io.Writer) error 
 	}
 	if !exists {
 		fmt.Fprintf(out, "Creating %s \n", home.RepositoryFile())
-		r := repo.NewRepoFile()
+		r := repo.NewRepositories()
 		if err := r.WriteFile(fs, home.RepositoryFile(), 0644); err != nil {
 			return err
 		}

--- a/pkg/kudoctl/cmd/init_test.go
+++ b/pkg/kudoctl/cmd/init_test.go
@@ -207,5 +207,5 @@ func TestClientInitialize(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	assert.Equal(t, r.CurrentRepo().URL, RepositoryURL)
+	assert.Equal(t, r.CurrentConfiguration().URL, RepositoryURL)
 }

--- a/pkg/kudoctl/cmd/install.go
+++ b/pkg/kudoctl/cmd/install.go
@@ -4,6 +4,7 @@ import (
 	"github.com/kudobuilder/kudo/pkg/kudoctl/cmd/install"
 
 	"github.com/pkg/errors"
+	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 )
 
@@ -31,7 +32,7 @@ var (
 )
 
 // newInstallCmd creates the install command for the CLI
-func newInstallCmd() *cobra.Command {
+func newInstallCmd(fs afero.Fs) *cobra.Command {
 	options := install.DefaultOptions
 	var parameters []string
 	installCmd := &cobra.Command{
@@ -47,7 +48,7 @@ func newInstallCmd() *cobra.Command {
 				return errors.WithMessage(err, "could not parse parameters")
 			}
 
-			return install.Run(args, options, &Settings)
+			return install.Run(args, options, fs, &Settings)
 		},
 	}
 

--- a/pkg/kudoctl/cmd/install/install.go
+++ b/pkg/kudoctl/cmd/install/install.go
@@ -89,7 +89,7 @@ func GetPackageCRDs(name string, version string, repository repo.Repository) (*b
 // installOperator is installing single operator into cluster and returns error in case of error
 func installOperator(operatorArgument string, options *Options, fs afero.Fs, settings *env.Settings) error {
 
-	repository, err := repo.ClientFromSettings(fs, settings)
+	repository, err := repo.ClientFromSettings(fs, settings.Home, settings.RepoName)
 	if err != nil {
 		return errors.WithMessage(err, "could not build operator repository")
 	}

--- a/pkg/kudoctl/cmd/install/install.go
+++ b/pkg/kudoctl/cmd/install/install.go
@@ -88,12 +88,8 @@ func GetPackageCRDs(name string, version string, repository repo.Repository) (*b
 
 // installOperator is installing single operator into cluster and returns error in case of error
 func installOperator(operatorArgument string, options *Options, fs afero.Fs, settings *env.Settings) error {
-	rc, err := repo.RepositoryFromSettings(fs, settings)
-	if err != nil {
-		return err
-	}
 
-	repository, err := repo.NewOperatorRepository(rc)
+	repository, err := repo.GetOperatorRepository(fs, settings)
 	if err != nil {
 		return errors.WithMessage(err, "could not build operator repository")
 	}

--- a/pkg/kudoctl/cmd/install/install.go
+++ b/pkg/kudoctl/cmd/install/install.go
@@ -14,6 +14,7 @@ import (
 	"github.com/kudobuilder/kudo/pkg/kudoctl/util/repo"
 
 	"github.com/pkg/errors"
+	"github.com/spf13/afero"
 )
 
 // Options defines configuration options for the install command
@@ -31,14 +32,14 @@ var DefaultOptions = &Options{
 }
 
 // Run returns the errors associated with cmd env
-func Run(args []string, options *Options, settings *env.Settings) error {
+func Run(args []string, options *Options, fs afero.Fs, settings *env.Settings) error {
 
 	err := validate(args, options)
 	if err != nil {
 		return err
 	}
 
-	err = installOperator(args[0], options, settings)
+	err = installOperator(args[0], options, fs, settings)
 	return err
 }
 
@@ -86,8 +87,13 @@ func GetPackageCRDs(name string, version string, repository repo.Repository) (*b
 }
 
 // installOperator is installing single operator into cluster and returns error in case of error
-func installOperator(operatorArgument string, options *Options, settings *env.Settings) error {
-	repository, err := repo.NewOperatorRepository(repo.Default)
+func installOperator(operatorArgument string, options *Options, fs afero.Fs, settings *env.Settings) error {
+	rc, err := repo.RepositoryFromSettings(fs, settings)
+	if err != nil {
+		return err
+	}
+
+	repository, err := repo.NewOperatorRepository(rc)
 	if err != nil {
 		return errors.WithMessage(err, "could not build operator repository")
 	}

--- a/pkg/kudoctl/cmd/install/install.go
+++ b/pkg/kudoctl/cmd/install/install.go
@@ -89,7 +89,7 @@ func GetPackageCRDs(name string, version string, repository repo.Repository) (*b
 // installOperator is installing single operator into cluster and returns error in case of error
 func installOperator(operatorArgument string, options *Options, fs afero.Fs, settings *env.Settings) error {
 
-	repository, err := repo.GetOperatorRepository(fs, settings)
+	repository, err := repo.ClientFromSettings(fs, settings)
 	if err != nil {
 		return errors.WithMessage(err, "could not build operator repository")
 	}

--- a/pkg/kudoctl/cmd/install_test.go
+++ b/pkg/kudoctl/cmd/install_test.go
@@ -4,12 +4,13 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestNewCmdInstallReturnsCmd(t *testing.T) {
 
-	newCmdInstall := newInstallCmd()
+	newCmdInstall := newInstallCmd(afero.NewOsFs())
 
 	if newCmdInstall.Parent() != nil {
 		t.Fatal("We expect the newCmdInstall command to be returned")
@@ -41,7 +42,7 @@ var cmdParameterTests = []struct {
 
 func TestTableNewInstallCmd_WithParameters(t *testing.T) {
 	for _, test := range cmdParameterTests {
-		newCmdInstall := newInstallCmd()
+		newCmdInstall := newInstallCmd(afero.NewOsFs())
 		for _, flag := range test.parameters {
 			newCmdInstall.Flags().Set("parameter", flag)
 		}

--- a/pkg/kudoctl/cmd/root.go
+++ b/pkg/kudoctl/cmd/root.go
@@ -56,7 +56,7 @@ and serves as an API aggregation layer.
 
 	cmd.AddCommand(newInstallCmd(fs))
 	cmd.AddCommand(newInitCmd(fs, cmd.OutOrStdout()))
-	cmd.AddCommand(newUpgradeCmd())
+	cmd.AddCommand(newUpgradeCmd(fs))
 	cmd.AddCommand(newUpdateCmd())
 	cmd.AddCommand(newPackageCmd(fs, cmd.OutOrStdout()))
 	cmd.AddCommand(newGetCmd())

--- a/pkg/kudoctl/cmd/root.go
+++ b/pkg/kudoctl/cmd/root.go
@@ -54,7 +54,7 @@ and serves as an API aggregation layer.
 		Version: version.Get().GitVersion,
 	}
 
-	cmd.AddCommand(newInstallCmd())
+	cmd.AddCommand(newInstallCmd(fs))
 	cmd.AddCommand(newInitCmd(fs, cmd.OutOrStdout()))
 	cmd.AddCommand(newUpgradeCmd())
 	cmd.AddCommand(newUpdateCmd())

--- a/pkg/kudoctl/cmd/upgrade.go
+++ b/pkg/kudoctl/cmd/upgrade.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/Masterminds/semver"
 	"github.com/pkg/errors"
+	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 )
 
@@ -45,7 +46,7 @@ var defaultOptions = &options{
 }
 
 // newUpgradeCmd creates the install command for the CLI
-func newUpgradeCmd() *cobra.Command {
+func newUpgradeCmd(fs afero.Fs) *cobra.Command {
 	options := defaultOptions
 	var parameters []string
 	upgradeCmd := &cobra.Command{
@@ -60,7 +61,7 @@ func newUpgradeCmd() *cobra.Command {
 			if err != nil {
 				return errors.WithMessage(err, "could not parse parameters")
 			}
-			return runUpgrade(args, options, &Settings)
+			return runUpgrade(args, options, fs, &Settings)
 		},
 	}
 
@@ -83,7 +84,7 @@ func validateCmd(args []string, options *options) error {
 	return nil
 }
 
-func runUpgrade(args []string, options *options, settings *env.Settings) error {
+func runUpgrade(args []string, options *options, fs afero.Fs, settings *env.Settings) error {
 	err := validateCmd(args, options)
 	if err != nil {
 		return err
@@ -96,7 +97,7 @@ func runUpgrade(args []string, options *options, settings *env.Settings) error {
 	}
 
 	// Resolve the package to upgrade to
-	repository, err := repo.NewOperatorRepository(repo.Default)
+	repository, err := repo.GetOperatorRepository(fs, settings)
 	if err != nil {
 		return errors.WithMessage(err, "could not build operator repository")
 	}

--- a/pkg/kudoctl/cmd/upgrade.go
+++ b/pkg/kudoctl/cmd/upgrade.go
@@ -97,7 +97,7 @@ func runUpgrade(args []string, options *options, fs afero.Fs, settings *env.Sett
 	}
 
 	// Resolve the package to upgrade to
-	repository, err := repo.ClientFromSettings(fs, settings)
+	repository, err := repo.ClientFromSettings(fs, settings.Home, settings.RepoName)
 	if err != nil {
 		return errors.WithMessage(err, "could not build operator repository")
 	}

--- a/pkg/kudoctl/cmd/upgrade.go
+++ b/pkg/kudoctl/cmd/upgrade.go
@@ -97,7 +97,7 @@ func runUpgrade(args []string, options *options, fs afero.Fs, settings *env.Sett
 	}
 
 	// Resolve the package to upgrade to
-	repository, err := repo.GetOperatorRepository(fs, settings)
+	repository, err := repo.ClientFromSettings(fs, settings)
 	if err != nil {
 		return errors.WithMessage(err, "could not build operator repository")
 	}

--- a/pkg/kudoctl/cmd/upgrade_test.go
+++ b/pkg/kudoctl/cmd/upgrade_test.go
@@ -8,10 +8,11 @@ import (
 	"github.com/kudobuilder/kudo/pkg/apis/kudo/v1alpha1"
 	"github.com/kudobuilder/kudo/pkg/client/clientset/versioned/fake"
 	"github.com/kudobuilder/kudo/pkg/kudoctl/util/kudo"
+	util "github.com/kudobuilder/kudo/pkg/util/kudo"
+
+	"github.com/spf13/afero"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	util "github.com/kudobuilder/kudo/pkg/util/kudo"
 )
 
 func TestUpgradeCommand_Validation(t *testing.T) {
@@ -27,7 +28,7 @@ func TestUpgradeCommand_Validation(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		cmd := newUpgradeCmd()
+		cmd := newUpgradeCmd(afero.NewOsFs())
 		cmd.SetArgs(tt.args)
 		if tt.instanceName != "" {
 			cmd.Flags().Set("instance", tt.instanceName)

--- a/pkg/kudoctl/env/environoment.go
+++ b/pkg/kudoctl/env/environoment.go
@@ -38,9 +38,9 @@ func (s *Settings) AddFlags(fs *pflag.FlagSet) {
 }
 
 // Init sets values from the environment.
-func (s *Settings) Init(fs *pflag.FlagSet) {
+func (s *Settings) Init(f *pflag.FlagSet) {
 	for name, envar := range envMap {
-		setFlagFromEnv(name, envar, fs)
+		setFlagFromEnv(name, envar, f)
 	}
 }
 

--- a/pkg/kudoctl/env/environoment.go
+++ b/pkg/kudoctl/env/environoment.go
@@ -27,14 +27,14 @@ type Settings struct {
 var envMap = map[string]string{
 	"home":       "KUDO_HOME",
 	"kubeconfig": "KUBECONFIG",
-	"repo-name":  "KUDO_REPO_NAME",
+	"repo":       "KUDO_REPO",
 }
 
 // AddFlags binds flags to the given flagset.
 func (s *Settings) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar((*string)(&s.Home), "home", DefaultKudoHome, "location of your KUDO config.")
 	fs.StringVar(&s.KubeConfig, "kubeconfig", os.Getenv("HOME")+"/.kube/config", "Path to your Kubernetes configuration file")
-	fs.StringVar(&s.RepoName, "repo-name", "community", "Name of repo to use")
+	fs.StringVar(&s.RepoName, "repo", "community", "Name of repo to use")
 }
 
 // Init sets values from the environment.

--- a/pkg/kudoctl/util/repo/repo.go
+++ b/pkg/kudoctl/util/repo/repo.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/kudobuilder/kudo/pkg/kudoctl/env"
+	"github.com/kudobuilder/kudo/pkg/kudoctl/kudohome"
 
 	"github.com/spf13/afero"
 	"sigs.k8s.io/yaml"
@@ -65,15 +65,15 @@ func (r Repositories) CurrentConfiguration() *Configuration {
 }
 
 // ConfigurationFromSettings gets the repo configuration from settings
-func ConfigurationFromSettings(fs afero.Fs, settings *env.Settings) (*Configuration, error) {
-	r, err := LoadRepositories(fs, settings.Home.RepositoryFile())
+func ConfigurationFromSettings(fs afero.Fs, home kudohome.Home, repoName string) (*Configuration, error) {
+	r, err := LoadRepositories(fs, home.RepositoryFile())
 	if err != nil {
 		// this allows for no client init... perhaps we should return the error requesting kudo init
 		r = NewRepositories()
 	}
-	repo := r.GetConfiguration(settings.RepoName)
+	repo := r.GetConfiguration(repoName)
 	if repo == nil {
-		return nil, fmt.Errorf("unable to find respository for %s", settings.RepoName)
+		return nil, fmt.Errorf("unable to find respository for %s", repoName)
 	}
 	return repo, nil
 }

--- a/pkg/kudoctl/util/repo/repo.go
+++ b/pkg/kudoctl/util/repo/repo.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/kudobuilder/kudo/pkg/kudoctl/env"
+
 	"github.com/spf13/afero"
 	"sigs.k8s.io/yaml"
 )
@@ -55,6 +57,20 @@ func (r Repositories) GetRepo(name string) *RepositoryConfiguration {
 // CurrentRepo provides the repo config for the current context
 func (r Repositories) CurrentRepo() *RepositoryConfiguration {
 	return r.GetRepo(r.Context)
+}
+
+// RepositoryFromSettings gets the repo configuration from settings
+func RepositoryFromSettings(fs afero.Fs, settings *env.Settings) (*RepositoryConfiguration, error) {
+	r, err := LoadRepositories(fs, settings.Home.RepositoryFile())
+	if err != nil {
+		// this allow for no client init... perhaps we should return the error requesting kudo init
+		r = NewRepoFile()
+	}
+	repo := r.GetRepo(settings.RepoName)
+	if repo == nil {
+		return nil, fmt.Errorf("unable to find respository for %s", settings.RepoName)
+	}
+	return repo, nil
 }
 
 // LoadRepositories reads the Repositories file

--- a/pkg/kudoctl/util/repo/repo.go
+++ b/pkg/kudoctl/util/repo/repo.go
@@ -10,42 +10,47 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
+// A repository is a http backed service which holds operators and an index file for those operators.
+// To interact with a repository the client is repo.Client.   To construct the Client
+// it is necessary to have a Configuration.   Several Configurations can be stored locally on a
+// client in a repositories.yaml file which represented by the Repositories struct.
+
 const (
 	// Version is the repo / packaging version
 	Version         = "v1"
 	defaultRepoName = "community"
 )
 
-// RepositoryConfiguration represents a collection of parameters for operator repository.
-type RepositoryConfiguration struct {
+// Configuration represents a collection of parameters for operator repository.
+type Configuration struct {
 	URL  string `json:"url"`
 	Name string `json:"name"`
 }
 
 // Repositories represents the repositories.yaml file usually in the $KUDO_HOME
 type Repositories struct {
-	RepoVersion  string                     `json:"repoVersion"`
-	Context      string                     `json:"context"`
-	Repositories []*RepositoryConfiguration `json:"repositories"`
+	RepoVersion  string           `json:"repoVersion"`
+	Context      string           `json:"context"`
+	Repositories []*Configuration `json:"repositories"`
 }
 
 // Default initialized repository.
-var Default = &RepositoryConfiguration{
+var Default = &Configuration{
 	Name: defaultRepoName,
 	URL:  "https://kudo-repository.storage.googleapis.com",
 }
 
-// NewRepoFile creates a new repo with only defaults populated
-func NewRepoFile() *Repositories {
+// NewRepositories creates a new repo with only defaults populated
+func NewRepositories() *Repositories {
 	return &Repositories{
 		RepoVersion:  Version,
 		Context:      defaultRepoName,
-		Repositories: []*RepositoryConfiguration{Default},
+		Repositories: []*Configuration{Default},
 	}
 }
 
-// GetRepo returns a RepoName Config for a name or nil
-func (r Repositories) GetRepo(name string) *RepositoryConfiguration {
+// GetConfiguration returns a RepoName Config for a name or nil
+func (r Repositories) GetConfiguration(name string) *Configuration {
 	for _, repo := range r.Repositories {
 		if repo.Name == name {
 			return repo
@@ -54,19 +59,19 @@ func (r Repositories) GetRepo(name string) *RepositoryConfiguration {
 	return nil
 }
 
-// CurrentRepo provides the repo config for the current context
-func (r Repositories) CurrentRepo() *RepositoryConfiguration {
-	return r.GetRepo(r.Context)
+// CurrentConfiguration provides the repo config for the current context
+func (r Repositories) CurrentConfiguration() *Configuration {
+	return r.GetConfiguration(r.Context)
 }
 
-// RepositoryConfig gets the repo configuration from settings
-func RepositoryConfig(fs afero.Fs, settings *env.Settings) (*RepositoryConfiguration, error) {
+// ConfigurationFromSettings gets the repo configuration from settings
+func ConfigurationFromSettings(fs afero.Fs, settings *env.Settings) (*Configuration, error) {
 	r, err := LoadRepositories(fs, settings.Home.RepositoryFile())
 	if err != nil {
-		// this allow for no client init... perhaps we should return the error requesting kudo init
-		r = NewRepoFile()
+		// this allows for no client init... perhaps we should return the error requesting kudo init
+		r = NewRepositories()
 	}
-	repo := r.GetRepo(settings.RepoName)
+	repo := r.GetConfiguration(settings.RepoName)
 	if repo == nil {
 		return nil, fmt.Errorf("unable to find respository for %s", settings.RepoName)
 	}

--- a/pkg/kudoctl/util/repo/repo.go
+++ b/pkg/kudoctl/util/repo/repo.go
@@ -59,8 +59,8 @@ func (r Repositories) CurrentRepo() *RepositoryConfiguration {
 	return r.GetRepo(r.Context)
 }
 
-// RepositoryFromSettings gets the repo configuration from settings
-func RepositoryFromSettings(fs afero.Fs, settings *env.Settings) (*RepositoryConfiguration, error) {
+// RepositoryConfig gets the repo configuration from settings
+func RepositoryConfig(fs afero.Fs, settings *env.Settings) (*RepositoryConfiguration, error) {
 	r, err := LoadRepositories(fs, settings.Home.RepositoryFile())
 	if err != nil {
 		// this allow for no client init... perhaps we should return the error requesting kudo init

--- a/pkg/kudoctl/util/repo/repo_operator.go
+++ b/pkg/kudoctl/util/repo/repo_operator.go
@@ -9,9 +9,11 @@ import (
 
 	"github.com/kudobuilder/kudo/pkg/apis/kudo/v1alpha1"
 	"github.com/kudobuilder/kudo/pkg/kudoctl/bundle"
+	"github.com/kudobuilder/kudo/pkg/kudoctl/env"
 	"github.com/kudobuilder/kudo/pkg/kudoctl/http"
 
 	"github.com/pkg/errors"
+	"github.com/spf13/afero"
 )
 
 // Repository is an abstraction for a service that can retrieve package bundles
@@ -23,6 +25,16 @@ type Repository interface {
 type OperatorRepository struct {
 	Config *RepositoryConfiguration
 	Client http.Client
+}
+
+// GetOperatorRepository retrieves the operator repo for the configured repo in settings
+func GetOperatorRepository(fs afero.Fs, settings *env.Settings) (*OperatorRepository, error) {
+	rc, err := RepositoryConfig(fs, settings)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewOperatorRepository(rc)
 }
 
 // NewOperatorRepository constructs OperatorRepository

--- a/pkg/kudoctl/util/repo/repo_operator.go
+++ b/pkg/kudoctl/util/repo/repo_operator.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/kudobuilder/kudo/pkg/apis/kudo/v1alpha1"
 	"github.com/kudobuilder/kudo/pkg/kudoctl/bundle"
-	"github.com/kudobuilder/kudo/pkg/kudoctl/env"
 	"github.com/kudobuilder/kudo/pkg/kudoctl/http"
+	"github.com/kudobuilder/kudo/pkg/kudoctl/kudohome"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/afero"
@@ -28,8 +28,8 @@ type Client struct {
 }
 
 // ClientFromSettings retrieves the operator repo for the configured repo in settings
-func ClientFromSettings(fs afero.Fs, settings *env.Settings) (*Client, error) {
-	rc, err := ConfigurationFromSettings(fs, settings)
+func ClientFromSettings(fs afero.Fs, home kudohome.Home, repoName string) (*Client, error) {
+	rc, err := ConfigurationFromSettings(fs, home, repoName)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kudoctl/util/repo/repo_test.go
+++ b/pkg/kudoctl/util/repo/repo_test.go
@@ -28,7 +28,7 @@ func TestLoadRepositories(t *testing.T) {
 
 	if *update {
 		t.Log("update golden file")
-		r := NewRepoFile()
+		r := NewRepositories()
 
 		if err := r.WriteFile(fs, gp, 0644); err != nil {
 			t.Fatalf("failed to update golden file: %s", err)
@@ -39,6 +39,6 @@ func TestLoadRepositories(t *testing.T) {
 		t.Fatalf("failed reading .golden: %s", err)
 	}
 
-	assert.Equal(t, r.CurrentRepo().Name, Default.Name)
-	assert.Equal(t, r.CurrentRepo().URL, Default.URL)
+	assert.Equal(t, r.CurrentConfiguration().Name, Default.Name)
+	assert.Equal(t, r.CurrentConfiguration().URL, Default.URL)
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Adds use of kudo repositories and repo name for install and upgrade
`go run cmd/kubectl-kudo/main.go install --repo-name=community test` will fail on not find `test` but it did find the repo
`go run cmd/kubectl-kudo/main.go install --repo-name=foo test` will fail because it can not find the repo.
The default repo is used if `kudo init --client-only` is not executed.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
repo-name can now be used with `install` and `upgrade`
```
