### PR TITLE
Uses Repo Name in kudo install and upgrade

### DIFF
--- a/pkg/kudoctl/cmd/init.go
+++ b/pkg/kudoctl/cmd/init.go
@@ -191,7 +191,7 @@ func ensureRepositoryFile(fs afero.Fs, home kudohome.Home, out io.Writer) error 
 	}
 	if !exists {
 		fmt.Fprintf(out, "Creating %s \n", home.RepositoryFile())
-		r := repo.NewRepoFile()
+		r := repo.NewRepositories()
 		if err := r.WriteFile(fs, home.RepositoryFile(), 0644); err != nil {
 			return err
 		}

--- a/pkg/kudoctl/cmd/init_test.go
+++ b/pkg/kudoctl/cmd/init_test.go
@@ -207,5 +207,5 @@ func TestClientInitialize(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	assert.Equal(t, r.CurrentRepo().URL, RepositoryURL)
+	assert.Equal(t, r.CurrentConfiguration().URL, RepositoryURL)
 }

--- a/pkg/kudoctl/cmd/install.go
+++ b/pkg/kudoctl/cmd/install.go
@@ -4,6 +4,7 @@ import (
 	"github.com/kudobuilder/kudo/pkg/kudoctl/cmd/install"
 
 	"github.com/pkg/errors"
+	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 )
 
@@ -31,7 +32,7 @@ var (
 )
 
 // newInstallCmd creates the install command for the CLI
-func newInstallCmd() *cobra.Command {
+func newInstallCmd(fs afero.Fs) *cobra.Command {
 	options := install.DefaultOptions
 	var parameters []string
 	installCmd := &cobra.Command{
@@ -47,7 +48,7 @@ func newInstallCmd() *cobra.Command {
 				return errors.WithMessage(err, "could not parse parameters")
 			}
 
-			return install.Run(args, options, &Settings)
+			return install.Run(args, options, fs, &Settings)
 		},
 	}
 

--- a/pkg/kudoctl/cmd/install/install.go
+++ b/pkg/kudoctl/cmd/install/install.go
@@ -14,6 +14,7 @@ import (
 	"github.com/kudobuilder/kudo/pkg/kudoctl/util/repo"
 
 	"github.com/pkg/errors"
+	"github.com/spf13/afero"
 )
 
 // Options defines configuration options for the install command
@@ -31,14 +32,14 @@ var DefaultOptions = &Options{
 }
 
 // Run returns the errors associated with cmd env
-func Run(args []string, options *Options, settings *env.Settings) error {
+func Run(args []string, options *Options, fs afero.Fs, settings *env.Settings) error {
 
 	err := validate(args, options)
 	if err != nil {
 		return err
 	}
 
-	err = installOperator(args[0], options, settings)
+	err = installOperator(args[0], options, fs, settings)
 	return err
 }
 
@@ -86,8 +87,9 @@ func GetPackageCRDs(name string, version string, repository repo.Repository) (*b
 }
 
 // installOperator is installing single operator into cluster and returns error in case of error
-func installOperator(operatorArgument string, options *Options, settings *env.Settings) error {
-	repository, err := repo.NewOperatorRepository(repo.Default)
+func installOperator(operatorArgument string, options *Options, fs afero.Fs, settings *env.Settings) error {
+
+	repository, err := repo.ClientFromSettings(fs, settings.Home, settings.RepoName)
 	if err != nil {
 		return errors.WithMessage(err, "could not build operator repository")
 	}

--- a/pkg/kudoctl/cmd/install_test.go
+++ b/pkg/kudoctl/cmd/install_test.go
@@ -4,12 +4,13 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestNewCmdInstallReturnsCmd(t *testing.T) {
 
-	newCmdInstall := newInstallCmd()
+	newCmdInstall := newInstallCmd(afero.NewOsFs())
 
 	if newCmdInstall.Parent() != nil {
 		t.Fatal("We expect the newCmdInstall command to be returned")
@@ -41,7 +42,7 @@ var cmdParameterTests = []struct {
 
 func TestTableNewInstallCmd_WithParameters(t *testing.T) {
 	for _, test := range cmdParameterTests {
-		newCmdInstall := newInstallCmd()
+		newCmdInstall := newInstallCmd(afero.NewOsFs())
 		for _, flag := range test.parameters {
 			newCmdInstall.Flags().Set("parameter", flag)
 		}

--- a/pkg/kudoctl/cmd/root.go
+++ b/pkg/kudoctl/cmd/root.go
@@ -54,9 +54,9 @@ and serves as an API aggregation layer.
 		Version: version.Get().GitVersion,
 	}
 
-	cmd.AddCommand(newInstallCmd())
+	cmd.AddCommand(newInstallCmd(fs))
 	cmd.AddCommand(newInitCmd(fs, cmd.OutOrStdout()))
-	cmd.AddCommand(newUpgradeCmd())
+	cmd.AddCommand(newUpgradeCmd(fs))
 	cmd.AddCommand(newUpdateCmd())
 	cmd.AddCommand(newPackageCmd(fs, cmd.OutOrStdout()))
 	cmd.AddCommand(newGetCmd())

--- a/pkg/kudoctl/cmd/upgrade.go
+++ b/pkg/kudoctl/cmd/upgrade.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/Masterminds/semver"
 	"github.com/pkg/errors"
+	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 )
 
@@ -45,7 +46,7 @@ var defaultOptions = &options{
 }
 
 // newUpgradeCmd creates the install command for the CLI
-func newUpgradeCmd() *cobra.Command {
+func newUpgradeCmd(fs afero.Fs) *cobra.Command {
 	options := defaultOptions
 	var parameters []string
 	upgradeCmd := &cobra.Command{
@@ -60,7 +61,7 @@ func newUpgradeCmd() *cobra.Command {
 			if err != nil {
 				return errors.WithMessage(err, "could not parse parameters")
 			}
-			return runUpgrade(args, options, &Settings)
+			return runUpgrade(args, options, fs, &Settings)
 		},
 	}
 
@@ -83,7 +84,7 @@ func validateCmd(args []string, options *options) error {
 	return nil
 }
 
-func runUpgrade(args []string, options *options, settings *env.Settings) error {
+func runUpgrade(args []string, options *options, fs afero.Fs, settings *env.Settings) error {
 	err := validateCmd(args, options)
 	if err != nil {
 		return err
@@ -96,7 +97,7 @@ func runUpgrade(args []string, options *options, settings *env.Settings) error {
 	}
 
 	// Resolve the package to upgrade to
-	repository, err := repo.NewOperatorRepository(repo.Default)
+	repository, err := repo.ClientFromSettings(fs, settings.Home, settings.RepoName)
 	if err != nil {
 		return errors.WithMessage(err, "could not build operator repository")
 	}

--- a/pkg/kudoctl/cmd/upgrade_test.go
+++ b/pkg/kudoctl/cmd/upgrade_test.go
@@ -8,10 +8,11 @@ import (
 	"github.com/kudobuilder/kudo/pkg/apis/kudo/v1alpha1"
 	"github.com/kudobuilder/kudo/pkg/client/clientset/versioned/fake"
 	"github.com/kudobuilder/kudo/pkg/kudoctl/util/kudo"
+	util "github.com/kudobuilder/kudo/pkg/util/kudo"
+
+	"github.com/spf13/afero"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	util "github.com/kudobuilder/kudo/pkg/util/kudo"
 )
 
 func TestUpgradeCommand_Validation(t *testing.T) {
@@ -27,7 +28,7 @@ func TestUpgradeCommand_Validation(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		cmd := newUpgradeCmd()
+		cmd := newUpgradeCmd(afero.NewOsFs())
 		cmd.SetArgs(tt.args)
 		if tt.instanceName != "" {
 			cmd.Flags().Set("instance", tt.instanceName)

--- a/pkg/kudoctl/env/environoment.go
+++ b/pkg/kudoctl/env/environoment.go
@@ -27,20 +27,20 @@ type Settings struct {
 var envMap = map[string]string{
 	"home":       "KUDO_HOME",
 	"kubeconfig": "KUBECONFIG",
-	"repo-name":  "KUDO_REPO_NAME",
+	"repo":       "KUDO_REPO",
 }
 
 // AddFlags binds flags to the given flagset.
 func (s *Settings) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar((*string)(&s.Home), "home", DefaultKudoHome, "location of your KUDO config.")
 	fs.StringVar(&s.KubeConfig, "kubeconfig", os.Getenv("HOME")+"/.kube/config", "Path to your Kubernetes configuration file")
-	fs.StringVar(&s.RepoName, "repo-name", "community", "Name of repo to use")
+	fs.StringVar(&s.RepoName, "repo", "community", "Name of repo to use")
 }
 
 // Init sets values from the environment.
-func (s *Settings) Init(fs *pflag.FlagSet) {
+func (s *Settings) Init(f *pflag.FlagSet) {
 	for name, envar := range envMap {
-		setFlagFromEnv(name, envar, fs)
+		setFlagFromEnv(name, envar, f)
 	}
 }
 

--- a/pkg/kudoctl/util/repo/repo_operator.go
+++ b/pkg/kudoctl/util/repo/repo_operator.go
@@ -10,8 +10,10 @@ import (
 	"github.com/kudobuilder/kudo/pkg/apis/kudo/v1alpha1"
 	"github.com/kudobuilder/kudo/pkg/kudoctl/bundle"
 	"github.com/kudobuilder/kudo/pkg/kudoctl/http"
+	"github.com/kudobuilder/kudo/pkg/kudoctl/kudohome"
 
 	"github.com/pkg/errors"
+	"github.com/spf13/afero"
 )
 
 // Repository is an abstraction for a service that can retrieve package bundles
@@ -19,14 +21,24 @@ type Repository interface {
 	GetBundle(name string, version string) (bundle.Bundle, error)
 }
 
-// OperatorRepository represents an operator repository
-type OperatorRepository struct {
-	Config *RepositoryConfiguration
+// Client represents an operator repository
+type Client struct {
+	Config *Configuration
 	Client http.Client
 }
 
-// NewOperatorRepository constructs OperatorRepository
-func NewOperatorRepository(conf *RepositoryConfiguration) (*OperatorRepository, error) {
+// ClientFromSettings retrieves the operator repo for the configured repo in settings
+func ClientFromSettings(fs afero.Fs, home kudohome.Home, repoName string) (*Client, error) {
+	rc, err := ConfigurationFromSettings(fs, home, repoName)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewClient(rc)
+}
+
+// NewClient constructs repository client
+func NewClient(conf *Configuration) (*Client, error) {
 	_, err := url.Parse(conf.URL)
 	if err != nil {
 		return nil, fmt.Errorf("invalid repository URL: %s", conf.URL)
@@ -34,14 +46,14 @@ func NewOperatorRepository(conf *RepositoryConfiguration) (*OperatorRepository, 
 
 	client := http.NewClient()
 
-	return &OperatorRepository{
+	return &Client{
 		Config: conf,
 		Client: *client,
 	}, nil
 }
 
 // downloadIndexFile fetches the index file from a repository.
-func (r *OperatorRepository) downloadIndexFile() (*IndexFile, error) {
+func (r *Client) downloadIndexFile() (*IndexFile, error) {
 	var indexURL string
 	parsedURL, err := url.Parse(r.Config.URL)
 	if err != nil {
@@ -66,7 +78,7 @@ func (r *OperatorRepository) downloadIndexFile() (*IndexFile, error) {
 }
 
 // getPackageReaderByFullPackageName downloads the tgz file from the remote repository and unmarshals it to the package CRDs
-func (r *OperatorRepository) getPackageReaderByFullPackageName(fullPackageName string) (io.Reader, error) {
+func (r *Client) getPackageReaderByFullPackageName(fullPackageName string) (io.Reader, error) {
 	var fileURL string
 	parsedURL, err := url.Parse(r.Config.URL)
 	if err != nil {
@@ -78,7 +90,7 @@ func (r *OperatorRepository) getPackageReaderByFullPackageName(fullPackageName s
 	return r.getPackageReaderByURL(fileURL)
 }
 
-func (r *OperatorRepository) getPackageReaderByURL(packageURL string) (io.Reader, error) {
+func (r *Client) getPackageReaderByURL(packageURL string) (io.Reader, error) {
 	resp, err := r.Client.Get(packageURL)
 	if err != nil {
 		return nil, errors.Wrap(err, "getting package url")
@@ -88,7 +100,7 @@ func (r *OperatorRepository) getPackageReaderByURL(packageURL string) (io.Reader
 }
 
 // GetPackageReader provides an io.Reader for a provided package name and optional version
-func (r *OperatorRepository) GetPackageReader(name string, version string) (io.Reader, error) {
+func (r *Client) GetPackageReader(name string, version string) (io.Reader, error) {
 	// Construct the package name and download the index file from the remote repo
 	indexFile, err := r.downloadIndexFile()
 	if err != nil {
@@ -106,7 +118,7 @@ func (r *OperatorRepository) GetPackageReader(name string, version string) (io.R
 }
 
 // GetBundle provides an Bundle for a provided package name and optional version
-func (r *OperatorRepository) GetBundle(name string, version string) (bundle.Bundle, error) {
+func (r *Client) GetBundle(name string, version string) (bundle.Bundle, error) {
 	reader, err := r.GetPackageReader(name, version)
 	if err != nil {
 		return nil, err

--- a/pkg/kudoctl/util/repo/repo_test.go
+++ b/pkg/kudoctl/util/repo/repo_test.go
@@ -28,7 +28,7 @@ func TestLoadRepositories(t *testing.T) {
 
 	if *update {
 		t.Log("update golden file")
-		r := NewRepoFile()
+		r := NewRepositories()
 
 		if err := r.WriteFile(fs, gp, 0644); err != nil {
 			t.Fatalf("failed to update golden file: %s", err)
@@ -39,6 +39,6 @@ func TestLoadRepositories(t *testing.T) {
 		t.Fatalf("failed reading .golden: %s", err)
 	}
 
-	assert.Equal(t, r.CurrentRepo().Name, Default.Name)
-	assert.Equal(t, r.CurrentRepo().URL, Default.URL)
+	assert.Equal(t, r.CurrentConfiguration().Name, Default.Name)
+	assert.Equal(t, r.CurrentConfiguration().URL, Default.URL)
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Adds use of kudo repositories and repo name for install and upgrade
`go run cmd/kubectl-kudo/main.go install --repo-name=community test` will fail on not find `test` but it did find the repo
`go run cmd/kubectl-kudo/main.go install --repo-name=foo test` will fail because it can not find the repo.
The default repo is used if `kudo init --client-only` is not executed.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
--repo can now be used with `install` and `upgrade`
```
