### PR TITLE
Nit: Remove the trailing period after printing $KUDO_HOME

### DIFF
--- a/pkg/kudoctl/cmd/init.go
+++ b/pkg/kudoctl/cmd/init.go
@@ -124,14 +124,14 @@ func (initCmd *initCmd) run() error {
 	if err := initCmd.initialize(); err != nil {
 		return fmt.Errorf("error initializing: %s", err)
 	}
-	fmt.Fprintf(initCmd.out, "$KUDO_HOME has been configured at %s.\n", Settings.Home)
+	fmt.Fprintf(initCmd.out, "$KUDO_HOME has been configured at %s\n", Settings.Home)
 
 	// initialize server
 	if !initCmd.clientOnly {
 		if initCmd.client == nil {
 			client, err := kube.GetKubeClient(Settings.KubeConfig)
 			if err != nil {
-				return fmt.Errorf("could not get kubernetes client: %s", err)
+				return fmt.Errorf("could not get Kubernetes client: %s", err)
 			}
 			initCmd.client = client
 		}

--- a/pkg/kudoctl/cmd/init_test.go
+++ b/pkg/kudoctl/cmd/init_test.go
@@ -67,7 +67,7 @@ func TestInitCmd_exists(t *testing.T) {
 	if err := cmd.run(); err == nil {
 		t.Errorf("expected error: %v", err)
 	}
-	expected := "$KUDO_HOME has been configured at /opt.\n" + "Warning: KUDO is already installed in the cluster.\n" +
+	expected := "$KUDO_HOME has been configured at /opt\n" + "Warning: KUDO is already installed in the cluster.\n" +
 		"(Use --client-only to suppress this message)"
 
 	if !strings.Contains(buf.String(), expected) {


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

The trailing period is too easy to pick up when selecting text in your terminal to copy.

Also it looks weird.

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
