### PR TITLE
fix broken link to getting started

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Kubernetes Universal Declarative Operator (KUDO) provides a declarative approach
 
 ## Getting Started
 
-Please refer to the [getting started guide](https://kudo.dev/docs/getting-started/) on the website.
+Please refer to the [getting started guide](https://kudo.dev/docs/) on the website.
 
 ![Quick Start](docs/images/quickstart-0.1.0.gif)
 


### PR DESCRIPTION
Changed to working link: https://kudo.dev/docs/


**What type of PR is this?**
 /kind documentation


**Does this PR introduce a user-facing change?**: No
