### PR TITLE
Implement test commands feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ vendor/
 hack/code-gen
 hack/controller-gen
 test/.git-credentials
+reports/
 
 ### mac
 .DS_Store

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ test:
 .PHONY: integration-test
 # Run integration tests
 integration-test: cli-fast
+	mkdir -p reports/
 	go get github.com/jstemmer/go-junit-report
 	go test -tags integration ./pkg/... ./cmd/... -v -mod=readonly -coverprofile cover-integration.out 2>&1 | go-junit-report -set-exit-code > reports/integration_report.xml
 	go run ./cmd/kubectl-kudo test 2>&1 | go-junit-report -set-exit-code > reports/kudo_test_report.xml

--- a/Makefile
+++ b/Makefile
@@ -29,8 +29,8 @@ test:
 integration-test: cli-fast
 	mkdir -p reports/
 	go get github.com/jstemmer/go-junit-report
-	go test -tags integration ./pkg/... ./cmd/... -v -mod=readonly -coverprofile cover-integration.out 2>&1 | go-junit-report -set-exit-code > reports/integration_report.xml
-	go run ./cmd/kubectl-kudo test 2>&1 | go-junit-report -set-exit-code > reports/kudo_test_report.xml
+	go test -tags integration ./pkg/... ./cmd/... -v -mod=readonly -coverprofile cover-integration.out 2>&1 |tee /dev/fd/2 |go-junit-report -set-exit-code > reports/integration_report.xml
+	go run ./cmd/kubectl-kudo test 2>&1 |tee /dev/fd/2 |go-junit-report -set-exit-code > reports/kudo_test_report.xml
 
 .PHONY: test-clean
 # Clean test reports

--- a/go.sum
+++ b/go.sum
@@ -172,6 +172,7 @@ github.com/json-iterator/go v1.1.5 h1:gL2yXlmiIo4+t+y32d4WGwOjKGYcGOuyrg46vadswD
 github.com/json-iterator/go v1.1.5/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.6 h1:MrUvLMLTMxbqFJ9kzlvat/rYZqZnW3u4wkLzWTaFwKs=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
+github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024 h1:rBMNdlhTLzJjJSDIjNEXX1Pz3Hmwmz91v+zycvx9PJc=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=

--- a/keps/0008-operator-testing.md
+++ b/keps/0008-operator-testing.md
@@ -176,6 +176,8 @@ type Command struct {
 	Command string `json:"command"`
 	// If set, the `--namespace` flag will be appended to the command with the namespace to use.
 	Namespaced bool `json:"namespaced"`
+	// If set, failures will be ignored.
+	IgnoreFailure bool `json:"ignoreFailure"`
 }
 ```
 

--- a/pkg/apis/kudo/v1alpha1/test_types.go
+++ b/pkg/apis/kudo/v1alpha1/test_types.go
@@ -96,4 +96,6 @@ type Command struct {
 	Command string `json:"command"`
 	// If set, the `--namespace` flag will be appended to the command with the namespace to use.
 	Namespaced bool `json:"namespaced"`
+	// If set, failures will be ignored.
+	IgnoreFailure bool `json:"ignoreFailure"`
 }

--- a/pkg/apis/kudo/v1alpha1/test_types.go
+++ b/pkg/apis/kudo/v1alpha1/test_types.go
@@ -42,6 +42,8 @@ type TestSuite struct {
 	ArtifactsDir string `json:"artifactsDir"`
 	// Kubectl commands to run before running any tests.
 	Kubectl []string `json:"kubectl"`
+	// Commands to run prior to running the tests.
+	Commands []Command `json:"commands"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -63,6 +65,9 @@ type TestStep struct {
 	// Kubectl commands to run at the start of the test
 	Kubectl []string `json:"kubectl"`
 
+	// Commands to run prior at the beginning of the test step.
+	Commands []Command `json:"commands"`
+
 	// Allowed environment labels
 	// Disallowed environment labels
 }
@@ -83,4 +88,12 @@ type ObjectReference struct {
 	corev1.ObjectReference `json:",inline"`
 	// Labels to match on.
 	Labels map[string]string
+}
+
+// Command describes a command to run as a part of a test step or suite.
+type Command struct {
+	// The command and argument to run as a string.
+	Command string `json:"command"`
+	// If set, the `--namespace` flag will be appended to the command with the namespace to use.
+	Namespaced bool `json:"namespaced"`
 }

--- a/pkg/test/harness.go
+++ b/pkg/test/harness.go
@@ -325,6 +325,10 @@ func (h *Harness) Run() {
 		}
 	}
 
+	if err := testutils.RunCommands(h.GetLogger(), "default", "", h.TestSuite.Commands, ""); err != nil {
+		h.T.Fatal(err)
+	}
+
 	if err := testutils.RunKubectlCommands(h.GetLogger(), "default", h.TestSuite.Kubectl, ""); err != nil {
 		h.T.Fatal(err)
 	}

--- a/pkg/test/step.go
+++ b/pkg/test/step.go
@@ -304,6 +304,10 @@ func (s *Step) Run(namespace string) []error {
 	testErrors := []error{}
 
 	if s.Step != nil {
+		if errors := testutils.RunCommands(s.Logger, namespace, "", s.Step.Commands, s.Dir); errors != nil {
+			testErrors = append(testErrors, errors...)
+		}
+
 		if errors := testutils.RunKubectlCommands(s.Logger, namespace, s.Step.Kubectl, s.Dir); errors != nil {
 			testErrors = append(testErrors, errors...)
 		}

--- a/pkg/test/test_data/cli-test/01-assert.yaml
+++ b/pkg/test/test_data/cli-test/01-assert.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: cli-test-pod
+  labels:
+    test: "true"

--- a/pkg/test/test_data/cli-test/01-patch.yaml
+++ b/pkg/test/test_data/cli-test/01-patch.yaml
@@ -3,3 +3,5 @@ kind: TestStep
 commands:
 - command: kubectl label pod cli-test-pod test=true
   namespaced: true
+- command: kubectl command is bad
+  ignoreFailure: true

--- a/pkg/test/test_data/cli-test/01-patch.yaml
+++ b/pkg/test/test_data/cli-test/01-patch.yaml
@@ -1,0 +1,5 @@
+apiVersion: kudo.dev/v1alpha1
+kind: TestStep
+commands:
+- command: kubectl label pod cli-test-pod test=true
+  namespaced: true

--- a/pkg/test/utils/kubernetes.go
+++ b/pkg/test/utils/kubernetes.go
@@ -843,7 +843,7 @@ func GetArgs(ctx context.Context, command string, cmd kudo.Command, namespace st
 	return builtCmd, nil
 }
 
-// Kubectl runs a kubectl command (or plugin) with args.
+// RunCommand runs a command with args.
 // args gets split on spaces (respecting quoted strings).
 func RunCommand(ctx context.Context, namespace string, command string, cmd kudo.Command, cwd string, stdout io.Writer, stderr io.Writer) error {
 	actualDir, err := os.Getwd()

--- a/pkg/test/utils/kubernetes.go
+++ b/pkg/test/utils/kubernetes.go
@@ -864,7 +864,14 @@ func RunCommand(ctx context.Context, namespace string, command string, cmd kudo.
 		fmt.Sprintf("PATH=%s/bin/:%s", actualDir, os.Getenv("PATH")),
 	}
 
-	return builtCmd.Run()
+	err = builtCmd.Run()
+	if err != nil {
+		if _, ok := err.(*exec.ExitError); ok && cmd.IgnoreFailure {
+			return nil
+		}
+	}
+
+	return err
 }
 
 // RunCommands runs a set of commands, returning any errors.

--- a/pkg/test/utils/kubernetes_test.go
+++ b/pkg/test/utils/kubernetes_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	kudo "github.com/kudobuilder/kudo/pkg/apis/kudo/v1alpha1"
+
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -396,9 +398,12 @@ func TestGetKubectlArgs(t *testing.T) {
 		},
 	} {
 		t.Run(test.testName, func(t *testing.T) {
-			args, err := GetKubectlArgs(test.args, test.namespace)
+			cmd, err := GetArgs(context.TODO(), "kubectl", kudo.Command{
+				Command:    test.args,
+				Namespaced: true,
+			}, test.namespace)
 			assert.Nil(t, err)
-			assert.Equal(t, test.expected, args)
+			assert.Equal(t, test.expected, cmd.Args)
 		})
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kudo/blob/master/CONTRIBUTING.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kudobuilder/kudo/blob/master/RELEASE.md
3. Ensure you have added or ran the appropriate tests for your PR
4. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What type of PR is this?**

/component kudoctl
/kind test

**What this PR does / why we need it**:

This implements the test commands feature to support running commands that are not kubectl plugins, see #754 for more details.

To use, set:

```
apiVersion: kudo.dev/v1alpha1
kind: TestSuite
commands:
- command: kubectl kudo init
```

Or:

```
apiVersion: kudo.dev/v1alpha1
kind: TestStep
commands:
- command: kubectl label mypod label=true
  namespaced: true
```

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
The test harness now supports running non-kubectl-based commands as a part of tests.
```
