### PR TITLE
Bumping go version to 1.13 for builds and tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
           path: reports/
   release:
     docker:
-      - image: kudobuilder/golang:1.12
+      - image: kudobuilder/golang:1.13
     working_directory: /go/src/github.com/kudobuilder/kudo
     steps:
       - checkout
@@ -23,7 +23,7 @@ jobs:
 
   code-formatting:
     docker:
-      - image: kudobuilder/golang:1.12
+      - image: kudobuilder/golang:1.13
     working_directory: /go/src/github.com/kudobuilder/kudo
     steps:
       - checkout

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.12 as builder
+FROM golang:1.13 as builder
 
 # Setting arguments
 ARG git_version_arg

--- a/build/test-images.sh
+++ b/build/test-images.sh
@@ -10,5 +10,8 @@ docker push kudobuilder/golang:1.11
 docker build --build-arg GOLANG_VERSION=1.12 -t kudobuilder/golang:1.12 .
 docker push kudobuilder/golang:1.12
 
+docker build --build-arg GOLANG_VERSION=1.13 -t kudobuilder/golang:1.13 .
+docker push kudobuilder/golang:1.13
+
 docker build --build-arg GOLANG_VERSION=latest -t kudobuilder/golang:latest .
 docker push kudobuilder/golang:latest

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,4 +1,4 @@
-FROM kudobuilder/golang:1.12
+FROM kudobuilder/golang:1.13
 
 WORKDIR $GOPATH/src/github.com/kudobuilder/kudo
 


### PR DESCRIPTION
**What type of PR is this?**
 /kind infrastructure

**What this PR does / why we need it**:
Bump Go 1.13 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
