### PR TITLE
Lint shell scripts and ensure consistency

### DIFF
--- a/hack/check_formatting.sh
+++ b/hack/check_formatting.sh
@@ -1,15 +1,18 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-set -x -e -o pipefail
+set -o errexit
+set -o nounset
+set -o pipefail
 
-ROOT=$(dirname "${BASH_SOURCE}")/..
+ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 PACKAGES="${ROOT}/pkg/ ${ROOT}/cmd/"
 
 # Make sure goimports doesn't find any errors
 go install golang.org/x/tools/cmd/goimports
 
 echo "goimports -d ${PACKAGES}"
-differences=`goimports -d ${PACKAGES}`
+# shellcheck disable=SC2086
+differences=$(goimports -d ${PACKAGES})
 if [[ ! "$differences" == "" ]]; then
     echo "goimports found the following differences"
     echo "$differences"

--- a/hack/update_codegen.sh
+++ b/hack/update_codegen.sh
@@ -11,12 +11,11 @@ export GO111MODULE=on
 VERSION=$(go list -m all | grep k8s.io/code-generator | rev | cut -d"-" -f1 | cut -d" " -f1 | rev)
 CODE_GEN_DIR="hack/code-gen/$VERSION"
 
-if [ -d $CODE_GEN_DIR ]   # for file "if [-f /home/rama/file]"
-then
+if [ -d "$CODE_GEN_DIR" ]; then
     echo "Using cached code generator version: $VERSION"
 else
-  git clone https://github.com/kubernetes/code-generator.git "${CODE_GEN_DIR}"
-  (cd "${CODE_GEN_DIR}" && git reset --hard "${VERSION}" && go mod init)
+    git clone https://github.com/kubernetes/code-generator.git "${CODE_GEN_DIR}"
+    cd "${CODE_GEN_DIR}" && git reset --hard "${VERSION}" && go mod init
 fi
 
 "${CODE_GEN_DIR}"/generate-groups.sh \

--- a/hack/update_manifests.sh
+++ b/hack/update_manifests.sh
@@ -11,12 +11,11 @@ export GO111MODULE=on
 VERSION=$(go list -m all | grep sigs.k8s.io/controller-tools | rev | cut -d"-" -f1 | cut -d" " -f1 | rev)
 CONTROLLER_GEN_DIR="hack/controller-gen/$VERSION"
 
-if [ -d $CONTROLLER_GEN_DIR ]   # for file "if [-f /home/rama/file]"
-then
+if [ -d "${CONTROLLER_GEN_DIR}" ]; then
     echo "Using cached controller generator version: $VERSION"
 else
-  git clone https://github.com/kubernetes-sigs/controller-tools.git "${CONTROLLER_GEN_DIR}"
-  (cd "${CONTROLLER_GEN_DIR}" && git reset --hard "${VERSION}" && go mod init)
+    git clone https://github.com/kubernetes-sigs/controller-tools.git "${CONTROLLER_GEN_DIR}"
+    (cd "${CONTROLLER_GEN_DIR}" && git reset --hard "${VERSION}" && go mod init)
 fi
 
 go run "$CONTROLLER_GEN_DIR"/cmd/controller-gen/main.go rbac

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -1,12 +1,16 @@
-#!/bin/sh
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
 
 # Pull the builder image with retries if it doesn't already exist.
 retries=0
-builder_image=$(grep FROM test/Dockerfile | awk '{print $2}')
+builder_image=$(awk '/FROM/ {print $2}' test/Dockerfile)
 
 if ! docker inspect "$builder_image"; then
     until docker pull "$builder_image"; do
-        if [ retries -eq 3 ]; then
+        if [ $retries -eq 3 ]; then
             echo "Giving up downloading builder image, failing build."
             exit 1
         fi
@@ -16,20 +20,13 @@ if ! docker inspect "$builder_image"; then
     done
 fi
 
-docker build -f test/Dockerfile -t kudo-test .
-if [ $? -eq 0 ]
-then
-   docker run -it -m 4g -v $(pwd)/reports:/go/src/github.com/kudobuilder/kudo/reports --rm kudo-test
+if docker build -f test/Dockerfile -t kudo-test .; then
+    if docker run -it -m 4g -v "$(pwd)"/reports:/go/src/github.com/kudobuilder/kudo/reports --rm kudo-test; then
+        echo "Tests finished successfully! ヽ(•‿•)ノ"
+    else
+        exit $?
+    fi
 else
     echo "Error when building test docker image, cannot run tests."
     exit 1
 fi
-
-DOCKER_EXIT_CODE=$?
-
-if [ $DOCKER_EXIT_CODE -eq 0 ]
-then
-   echo "Tests finished successfully! ヽ(•‿•)ノ"
-fi
-
-exit $DOCKER_EXIT_CODE


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kudo/blob/master/CONTRIBUTING.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kudobuilder/kudo/blob/master/RELEASE.md
3. Ensure you have added or ran the appropriate tests for your PR
4. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
These shell scripts have been linted with [shellcheck](https://www.shellcheck.net/) and made consistent by
  * Using `bash` for all scripts
  * Indenting with 4 spaces
  * Having 'then' in the same line as 'if'
  * Using the same options for all scripts
  * Using `$(...)` notation instead of backticks
  * Removing `grep` when `awk` alone can do the job

This also fixes an issue with `docker pull` retries not working in `test/run_tests.sh`.

**Does this PR introduce a user-facing change?**:
<!--  
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
