### PR TITLE
Log a timeout that is going to be used for the suite

### DIFF
--- a/pkg/test/harness.go
+++ b/pkg/test/harness.go
@@ -62,7 +62,7 @@ func (h *Harness) LoadTests(dir string) ([]*Case, error) {
 		}
 
 		timeout := h.GetTimeout()
-		h.T.Log("Going to run test suite with timeout of %d seconds for each step", timeout)
+		h.T.Logf("Going to run test suite with timeout of %d seconds for each step", timeout)
 
 		tests = append(tests, &Case{
 			Timeout:    timeout,

--- a/pkg/test/harness.go
+++ b/pkg/test/harness.go
@@ -61,8 +61,11 @@ func (h *Harness) LoadTests(dir string) ([]*Case, error) {
 			continue
 		}
 
+		timeout := h.GetTimeout()
+		h.T.Log("Going to run test suite with timeout of %d seconds for each step", timeout)
+
 		tests = append(tests, &Case{
-			Timeout:    h.GetTimeout(),
+			Timeout:    timeout,
 			Steps:      []*Step{},
 			Name:       file.Name(),
 			Dir:        filepath.Join(dir, file.Name()),


### PR DESCRIPTION
Just a very minor/cosmetic thing. I think it would be nice to see in logs what was value of the timeout for the suite you're running.