### PR TITLE
Fix flake in operator-in-operator test

### DIFF
--- a/pkg/controller/instance/instance_controller.go
+++ b/pkg/controller/instance/instance_controller.go
@@ -310,7 +310,7 @@ func createPlanAndUpdateReference(c client.Client, r record.EventRecorder, schem
 
 	planExecution := newPlanExecution(instance, planName, scheme)
 	log.Printf("Creating PlanExecution of planExecution %s for instance %s", planName, instance.Name)
-	r.Event(instance, "Normal", "CreatePlanExecution", fmt.Sprintf("Creating \"%v\" planExecution execution", planName))
+	r.Event(instance, "Normal", "CreatePlanExecution", fmt.Sprintf("Creating \"%v\" planExecution on %s", planName, instance.Name))
 
 	// Make this instance the owner of the PlanExecution
 	if err := controllerutil.SetControllerReference(instance, planExecution, scheme); err != nil {


### PR DESCRIPTION
The flakes I have seen were all in operator-in-operator test. The reason for them was that in this PR  https://github.com/kudobuilder/kudo/commit/47e7da741a71e35ef21d6ad708afb55e520b70cf I have moved code to create PE relation to instance controller, but that means that we need to make sure that reconciliation is triggered not only after PE is created but also after PE is linked to instance. That was not happening for the instance in instance example because I was triggering reconcile only for the outer instance.

Fixes #766 

