### PR TITLE
Set minimum go version and fix go test logging for go 1.13

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kudobuilder/kudo
 
-go 1.12
+go 1.13
 
 require (
 	cloud.google.com/go v0.38.0 // indirect

--- a/pkg/test/utils/testing.go
+++ b/pkg/test/utils/testing.go
@@ -15,6 +15,9 @@ import (
 // If testToRun is set to a non-empty string, it is passed as a `-run` argument to the go test harness.
 // If paralellism is set, it limits the number of concurrently running tests.
 func RunTests(testName string, testToRun string, parallelism int, testFunc func(*testing.T)) {
+	flag.Parse()
+	testing.Init()
+
 	// Set the verbose test flag to true since we are not using the regular go test CLI.
 	flag.Set("test.v", "true")
 


### PR DESCRIPTION
**What type of PR is this?**

/component kudoctl
/kind cleanup

**What this PR does / why we need it**:

go 1.13 introduces breaking changes that cause our go test logging to fail (#803) and the fix is not backwards compatible. This sets a minimum go version of 1.13 and fixes the logging issue.

As far as I know, there is not a way to set a maximum go version.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #803 

**Special notes for your reviewer**:

All kudo developers will need to use go 1.13, otherwise it will fail to build with a warning:

```
➜  kudo git:(jbarrick/kind-0.5.1) ✗ go1.12.5 run ./cmd/kubectl-kudo test
# github.com/kudobuilder/kudo/pkg/test/utils
pkg/test/utils/testing.go:19:2: undefined: "testing".Init
note: module requires Go 1.13
➜  kudo git:(jbarrick/kind-0.5.1) ✗
```
