### PR TITLE
Updates current-time to published version

### DIFF
--- a/.github/workflows/release-on-master.yml
+++ b/.github/workflows/release-on-master.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v1
       - name: Get current time
-        uses: gerred/actions/current-time@master
+        uses: gerred/current-time@v1.0.0
         id: current-time
       - name: Login to Github Package Registry
         uses: actions/docker/login@master

--- a/.github/workflows/release-on-master.yml
+++ b/.github/workflows/release-on-master.yml
@@ -7,10 +7,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Code
-        uses: actions/checkout@v1
       - name: Get current time
         uses: gerred/current-time@v1.0.0
+      - name: Checkout Code
+        uses: actions/checkout@v1
         id: current-time
       - name: Login to Github Package Registry
         uses: actions/docker/login@master


### PR DESCRIPTION
I put this on the Github Marketplace so others could use it, which doesn't allow you to have a monorepo of actions.

Located here: https://github.com/marketplace/actions/current-time