### PR TITLE
CLI cleanup

### DIFF
--- a/pkg/kudoctl/cmd/get.go
+++ b/pkg/kudoctl/cmd/get.go
@@ -5,14 +5,16 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const getExample = `  # Get all available instances
+  kubectl kudo get instances 
+`
+
 // newGetCmd creates a command that lists the instances in the cluster
 func newGetCmd() *cobra.Command {
 	getCmd := &cobra.Command{
-		Use:   "get instances",
-		Short: "Gets all available instances.",
-		Long: `
-	# Get all available instances
-	kudoctl get instances`,
+		Use:     "get instances",
+		Short:   "Gets all available instances.",
+		Example: getExample,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return get.Run(args, &Settings)
 		},

--- a/pkg/kudoctl/cmd/init.go
+++ b/pkg/kudoctl/cmd/init.go
@@ -16,7 +16,8 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
-const initDesc = `
+const (
+	initDesc = `
 This command installs KUDO onto your Kubernetes Cluster and sets up local configuration in $KUDO_HOME (default ~/.kudo/).
 
 As with the rest of the KUDO commands, 'kudo init' discovers Kubernetes clusters by reading 
@@ -31,6 +32,16 @@ or '--version' which will replace the version designation on the standard image.
 
 To dump a manifest containing the KUDO deployment YAML, combine the '--dry-run' and '--output=yaml' flags.
 `
+	initExample = `  # yaml outout
+  kubectl kudo init --dry-run --output yaml
+  # waiting for KUDO to be init complete at the server
+  kubectl kudo init --wait
+  # init client
+  kubectl kudo init --client-only
+  # init client for non-default home
+  kubectl kudo init --client-only --home /opt/home2
+`
+)
 
 type initCmd struct {
 	out        io.Writer
@@ -50,9 +61,10 @@ func newInitCmd(fs afero.Fs, out io.Writer) *cobra.Command {
 	i := &initCmd{fs: fs, out: out}
 
 	cmd := &cobra.Command{
-		Use:   "init",
-		Short: "Initialize KUDO on both the client and server",
-		Long:  initDesc,
+		Use:     "init",
+		Short:   "Initialize KUDO on both the client and server",
+		Long:    initDesc,
+		Example: initExample,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 0 {
 				return errors.New("this command does not accept arguments")

--- a/pkg/kudoctl/cmd/install.go
+++ b/pkg/kudoctl/cmd/install.go
@@ -9,26 +9,24 @@ import (
 )
 
 var (
-	installExample = `
-		The install argument must be a name of the package in the repository, a path to package in *.tgz format,
-		or a path to an unpacked package directory.
+	installExample = `  The install argument must be a name of the package in the repository, a path to package in *.tgz format,
+  or a path to an unpacked package directory.
 
-		# Install the most recent Flink package to your cluster.
-		kubectl kudo install flink
-		
-		*Note*: should you have a local  "flink" folder in the current directory it will take precedence over the remote repository.
+  # Install the most recent Flink package to your cluster.
+  kubectl kudo install flink
+  #*Note*: should you have a local  "flink" folder in the current directory it will take precedence over the remote repository.
 
-		# Install operator from a local filesystem
-		kubectl kudo install pkg/kudoctl/util/repo/testdata/zk
+  # Install operator from a local filesystem
+  kubectl kudo install pkg/kudoctl/util/repo/testdata/zk
 
-		# Install operator from tarball on a local filesystem
-		kubectl kudo install pkg/kudoctl/util/repo/testdata/zk.tgz
+  # Install operator from tarball on a local filesystem
+  kubectl kudo install pkg/kudoctl/util/repo/testdata/zk.tgz
 
-		# Install operator from tarball at URL
-		kubectl kudo install http://kudo.dev/zk.tgz
+  # Install operator from tarball at URL
+  kubectl kudo install http://kudo.dev/zk.tgz
 
-		# Specify a package version of Kafka to install to your cluster.
-		kubectl kudo install kafka --version=1.1.1`
+  # Specify a package version of Kafka to install to your cluster
+  kubectl kudo install kafka --version=1.1.1`
 )
 
 // newInstallCmd creates the install command for the CLI

--- a/pkg/kudoctl/cmd/package.go
+++ b/pkg/kudoctl/cmd/package.go
@@ -10,14 +10,14 @@ import (
 )
 
 const (
-	example = `
-		The package argument must be a directory which contains the operator definition files.  The package command will create a tgz file containing the operator.
+	pkgDesc = `Package a KUDO operator from local filesystem into a package tarball.
+The package argument must be a directory which contains the operator definition files.  The package command will create a tgz file containing the operator.
+`
+	pkgExample = `  # package zookeeper (where zookeeper is a folder in the current directory)
+  kubectl kudo package zookeeper
 
-		# package zookeeper (where zookeeper is a folder in the current directory)
-		kubectl kudo package zookeeper
-
-		# Specify a destination folder other than current working directory
-		kubectl kudo package ../operators/repository/zookeeper/operator/ --destination=out-folder`
+  # Specify a destination folder other than current working directory
+  kubectl kudo package ../operators/repository/zookeeper/operator/ --destination=out-folder`
 )
 
 type packageCmd struct {
@@ -35,8 +35,8 @@ func newPackageCmd(fs afero.Fs, out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "package <operator_dir>",
 		Short:   "Package a local KUDO operator into a tarball.",
-		Long:    `Package a KUDO operator from local filesystem into a package tarball.`,
-		Example: example,
+		Long:    pkgDesc,
+		Example: pkgExample,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := validate(args); err != nil {
 				return err
@@ -51,7 +51,7 @@ func newPackageCmd(fs afero.Fs, out io.Writer) *cobra.Command {
 
 	f := cmd.Flags()
 	f.StringVarP(&pkg.destination, "destination", "d", ".", "Location to write the package.")
-	f.BoolVarP(&pkg.overwrite, "overwrite", "o", false, "Overwrite existing package.")
+	f.BoolVarP(&pkg.overwrite, "overwrite", "w", false, "Overwrite existing package.")
 	return cmd
 }
 

--- a/pkg/kudoctl/cmd/plan.go
+++ b/pkg/kudoctl/cmd/plan.go
@@ -5,6 +5,15 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const (
+	planHistExample = `  # View plan status
+  kubectl kudo plan history <operatorVersion> --instance=<instanceName>
+`
+	planStatuExample = `  # View plan status
+  kubectl kudo plan status --instance=<instanceName>
+`
+)
+
 // newPlanCmd creates a new command that shows the plans available for an instance
 func newPlanCmd() *cobra.Command {
 	newCmd := &cobra.Command{
@@ -23,11 +32,9 @@ func newPlanCmd() *cobra.Command {
 func NewPlanHistoryCmd() *cobra.Command {
 	options := plan.DefaultHistoryOptions
 	listCmd := &cobra.Command{
-		Use:   "history",
-		Short: "Lists history to a specific operator-version of an instance.",
-		Long: `
-	# View plan status
-	kudoctl plan history <operatorVersion> --instance=<instanceName>`,
+		Use:     "history",
+		Short:   "Lists history to a specific operator-version of an instance.",
+		Example: planHistExample,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return plan.RunHistory(cmd, args, options, &Settings)
 		},
@@ -43,11 +50,9 @@ func NewPlanHistoryCmd() *cobra.Command {
 func NewPlanStatusCmd() *cobra.Command {
 	options := plan.DefaultStatusOptions
 	statusCmd := &cobra.Command{
-		Use:   "status",
-		Short: "Shows the status of all plans to an particular instance.",
-		Long: `
-	# View plan status
-	kudoctl plan status --instance=<instanceName>`,
+		Use:     "status",
+		Short:   "Shows the status of all plans to an particular instance.",
+		Example: planStatuExample,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return plan.RunStatus(cmd, args, options, &Settings)
 		},

--- a/pkg/kudoctl/cmd/repo.go
+++ b/pkg/kudoctl/cmd/repo.go
@@ -15,7 +15,7 @@ It can be used to add, remove, list, and index kudo repositories.
 `
 
 const examples = `  kubectl kudo repo add [NAME] [REPO_URL]
-  kubectl kudo repo remmove
+  kubectl kudo repo remove
   kubectl kudo repo list
   kubectl kudo repo context [NAME]
 `

--- a/pkg/kudoctl/cmd/repo_add.go
+++ b/pkg/kudoctl/cmd/repo_add.go
@@ -12,6 +12,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const (
+	repoAddExample = `  kubectl kudo repo add local http://localhost
+  # to skip url and index.yaml validation
+  kubectl kudo repo add local http://localhost --skip-check
+`
+)
+
 type repoAddCmd struct {
 	name      string
 	url       string
@@ -64,8 +71,9 @@ func newRepoAddCmd(fs afero.Fs, out io.Writer) *cobra.Command {
 	add := &repoAddCmd{out: out}
 
 	cmd := &cobra.Command{
-		Use:   "add [flags] [NAME] [URL]",
-		Short: "Add an operator repository",
+		Use:     "add [flags] [NAME] [URL]",
+		Short:   "Add an operator repository",
+		Example: repoAddExample,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 2 {
 				return errors.New("this command needs 2. name and url of the operator repository")

--- a/pkg/kudoctl/cmd/repo_context.go
+++ b/pkg/kudoctl/cmd/repo_context.go
@@ -11,6 +11,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const (
+	repoContextDesc = `When using an KUDO operation that requires access to a repository, KUDO needs to know which repository.
+This is defined by the "context". 'kubectl kudo repo list' will provide the list of repositories.  The "*" next to one of the
+names is the current context. 'kubectl kudo repo context local' will change the context to respository named local if it exists.
+`
+)
+
 type repoContextCmd struct {
 	name string
 	home kudohome.Home
@@ -22,8 +29,10 @@ func newRepoContextCmd(fs afero.Fs) *cobra.Command {
 	ctxCmd := &repoContextCmd{}
 
 	cmd := &cobra.Command{
-		Use:   "context [flags] [NAME]",
-		Short: "Set default for operator repository context",
+		Use:     "context [flags] [NAME]",
+		Short:   "Set default for operator repository context",
+		Long:    repoContextDesc,
+		Example: "  kubectl kudo repo context local",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				return fmt.Errorf("need at least one argument, name of operator repository")

--- a/pkg/kudoctl/cmd/repo_index.go
+++ b/pkg/kudoctl/cmd/repo_index.go
@@ -32,14 +32,13 @@ repo name out of the local repositories list.
 # Create an index file for all KUDO packages in the repo-dir.
 	$ kubectl kudo repo index repo-dir`
 
-	repoIndexExample = `
- #simple index of operators in /opt/repo
- kubectl kudo repo index /opt/repo
- kubectl kudo repo index /opt/repo --url https://kudo-repository.storage.googleapis.com
+	repoIndexExample = `  #simple index of operators in /opt/repo
+  kubectl kudo repo index /opt/repo
+  kubectl kudo repo index /opt/repo --url https://kudo-repository.storage.googleapis.com
 	
- # merge with community repo
- kubectl kudo repo index /opt/repo --merge https://kudo-repository.storage.googleapis.com
- kubectl kudo repo index /opt/repo --merge-repo community	
+  # merge with community repo
+  kubectl kudo repo index /opt/repo --merge https://kudo-repository.storage.googleapis.com
+  kubectl kudo repo index /opt/repo --merge-repo community	
 `
 )
 

--- a/pkg/kudoctl/cmd/repo_list.go
+++ b/pkg/kudoctl/cmd/repo_list.go
@@ -22,8 +22,9 @@ func newRepoListCmd(fs afero.Fs, out io.Writer) *cobra.Command {
 	list := &repoListCmd{out: out}
 
 	cmd := &cobra.Command{
-		Use:   "list [flags]",
-		Short: "List operator repositories",
+		Use:     "list [flags]",
+		Short:   "List operator repositories",
+		Example: "  kubectl kudo repo list",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			list.home = Settings.Home
 			return list.run(fs)

--- a/pkg/kudoctl/cmd/repo_remove.go
+++ b/pkg/kudoctl/cmd/repo_remove.go
@@ -11,6 +11,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const (
+	repoRemoveExample = `  kubectl kudo repo remove local
+  kubectl kudo repo rm local`
+)
+
 type repoRemoveCmd struct {
 	out  io.Writer
 	name string
@@ -25,6 +30,7 @@ func newRepoRemoveCmd(fs afero.Fs, out io.Writer) *cobra.Command {
 		Use:     "remove [flags] [NAME]",
 		Aliases: []string{"rm"},
 		Short:   "Remove an operator repository",
+		Example: repoRemoveExample,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				return fmt.Errorf("need at least one argument, name of operator repository")

--- a/pkg/kudoctl/cmd/root.go
+++ b/pkg/kudoctl/cmd/root.go
@@ -24,32 +24,29 @@ func NewKudoctlCmd() *cobra.Command {
 		// Workaround or Compromise as "kubectl kudo" would result in Usage print out "kubectl install <name> [flags]"
 		Use:   "kubectl-kudo",
 		Short: "CLI to manipulate, inspect and troubleshoot KUDO-specific CRDs.",
-		Long: `
-KUDO CLI and future sub-commands can be used to manipulate, inspect and troubleshoot KUDO-specific CRDs
+		Long: `KUDO CLI and future sub-commands can be used to manipulate, inspect and troubleshoot KUDO-specific CRDs
 and serves as an API aggregation layer.
 `,
-		Example: `
-	# Install a KUDO package from the official GitHub repo.
-	kubectl kudo install <name> [flags]
+		Example: `  # Install a KUDO package from the official GitHub repo.
+  kubectl kudo install <name> [flags]
 
-	# View plan history of a specific package
-	kubectl kudo plan history <name> [flags]
+  # View plan history of a specific package
+  kubectl kudo plan history <name> [flags]
 
-	# View all plan history of a specific package
-	kubectl kudo plan history [flags]
+  # View all plan history of a specific package
+  kubectl kudo plan history [flags]
 
-	# Run integration tests against a Kubernetes cluster or mocked control plane.
-	kubectl kudo test
+  # Run integration tests against a Kubernetes cluster or mocked control plane.
+  kubectl kudo test
 
-	# Get instances
-	kubectl kudo get instances [flags]
+  # Get instances
+  kubectl kudo get instances [flags]
 
-	# View plan status
-	kubectl kudo plan status [flags]
+  # View plan status
+  kubectl kudo plan status [flags]
 
-	# View KUDO version
-	kubectl kudo version
-
+  # View KUDO version
+  kubectl kudo version
 `,
 		Version: version.Get().GitVersion,
 	}

--- a/pkg/kudoctl/cmd/test.go
+++ b/pkg/kudoctl/cmd/test.go
@@ -15,21 +15,20 @@ import (
 )
 
 var (
-	testExample = `
-      Run tests configured by kudo-test.yaml:
-            kubectl kudo test
+	testExample = `  Run tests configured by kudo-test.yaml:
+    kubectl kudo test
 
-      Load a specific test configuration:
-            kubectl kudo test --config test.yaml
+  Load a specific test configuration:
+    kubectl kudo test --config test.yaml
 
-      Run tests against an existing Kubernetes cluster:
-            kubectl kudo test ./test/integration/
+  Run tests against an existing Kubernetes cluster:
+    kubectl kudo test ./test/integration/
 
-      Run tests against an existing Kubernetes cluster, and install KUDO, manifests, and CRDs for the tests:
-            kubectl kudo test --crd-dir ./config/crds/ --manifests-dir ./test/manifests/ ./test/integration/
+  Run tests against an existing Kubernetes cluster, and install KUDO, manifests, and CRDs for the tests:
+    kubectl kudo test --crd-dir ./config/crds/ --manifests-dir ./test/manifests/ ./test/integration/
 
-      Run a Kubernetes control plane and KUDO and install manifests and CRDs for the running tests:
-            kubectl kudo test --start-control-plane --start-kudo --crd-dir ./config/crds/ --manifests-dir ./test/manifests/ ./test/integration/
+  Run a Kubernetes control plane and KUDO and install manifests and CRDs for the running tests:
+    kubectl kudo test --start-control-plane --start-kudo --crd-dir ./config/crds/ --manifests-dir ./test/manifests/ ./test/integration/
 `
 )
 
@@ -57,10 +56,8 @@ func newTestCmd() *cobra.Command {
 		Long: `Runs integration tests against a Kubernetes cluster.
 
 The test operator supports connecting to an existing Kubernetes cluster or it can start a Kubernetes API server during the test run.
-
-It can also start up KUDO and apply manifests before running the tests.
-
-If no arguments are provided, the test harness will attempt to load the test configuration from kudo-test.yaml.
+It can also start up KUDO and apply manifests before running the tests. If no arguments are provided, the test harness will attempt to 
+load the test configuration from kudo-test.yaml.
 
 For more detailed documentation, visit: https://kudo.dev/docs/testing`,
 		Example: testExample,

--- a/pkg/kudoctl/cmd/update.go
+++ b/pkg/kudoctl/cmd/update.go
@@ -12,14 +12,13 @@ import (
 )
 
 var (
-	updateExample = `
-		The update does not accept any arguments.
+	updateDesc = `Update KUDO operator instance with new arguments. The update does not accept any arguments.
+`
+	updateExample = `  # Update dev-flink instance with setting parameter param with value value
+  kubectl kudo update --instance dev-flink -p param=value
 
-		# Update dev-flink instance with setting parameter param with value value
-		kubectl kudo update --instance dev-flink -p param=value
-
-		# Update dev-flink instance in namespace services with setting parameter param with value value
-		kubectl kudo update --instance dev-flink -n services -p param=value`
+  # Update dev-flink instance in namespace services with setting parameter param with value value
+  kubectl kudo update --instance dev-flink -n services -p param=value`
 )
 
 type updateOptions struct {
@@ -37,7 +36,7 @@ func newUpdateCmd() *cobra.Command {
 	updateCmd := &cobra.Command{
 		Use:     "update",
 		Short:   "Update KUDO operator instance.",
-		Long:    `Update KUDO operator instance with new arguments.`,
+		Long:    updateDesc,
 		Example: updateExample,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Prior to command execution we parse and validate passed arguments

--- a/pkg/kudoctl/cmd/upgrade.go
+++ b/pkg/kudoctl/cmd/upgrade.go
@@ -17,20 +17,17 @@ import (
 )
 
 var (
-	upgradeExample = `
-		The upgrade argument must be a name of the package in the repository, a path to package in *.tgz format,
-		or a path to an unpacked package directory.
+	upgradeDesc = `Upgrade KUDO package from current version to new version. The upgrade argument must be a name of the 
+package in the repository, a path to package in *.tgz format, or a path to an unpacked package directory.`
+	upgradeExample = `  # Upgrade flink instance dev-flink to the latest version
+  kubectl kudo upgrade flink --instance dev-flink
+  *Note*: should you have a local "flink" folder in the current directory it will take precedence over the remote repository.
 
-		# Upgrade flink instance dev-flink to the latest version
-		kubectl kudo upgrade flink --instance dev-flink
-		
-		*Note*: should you have a local "flink" folder in the current directory it will take precedence over the remote repository.
+  # Upgrade flink to the version 1.1.1
+  kubectl kudo upgrade flink --instance dev-flink --version 1.1.1
 
-		# Upgrade flink to the version 1.1.1
-		kubectl kudo upgrade flink --instance dev-flink --version 1.1.1
-
-		# By default arguments are all reused from the previous installation, if you need to modify, use -p
-		kubectl kudo upgrade flink --instance dev-flink -p param=xxx`
+  # By default arguments are all reused from the previous installation, if you need to modify, use -p
+  kubectl kudo upgrade flink --instance dev-flink -p param=xxx`
 )
 
 type options struct {
@@ -50,7 +47,7 @@ func newUpgradeCmd(fs afero.Fs) *cobra.Command {
 	upgradeCmd := &cobra.Command{
 		Use:     "upgrade <name>",
 		Short:   "Upgrade KUDO package.",
-		Long:    `Upgrade KUDO package from current version to new version.`,
+		Long:    upgradeDesc,
 		Example: upgradeExample,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Prior to command execution we parse and validate passed arguments

--- a/pkg/kudoctl/cmd/version.go
+++ b/pkg/kudoctl/cmd/version.go
@@ -9,9 +9,8 @@ import (
 )
 
 var (
-	versionExample = `
-		# Print the current installed KUDO package version
-		kubectl kudo version`
+	versionExample = `  # Print the current installed KUDO package version
+  kubectl kudo version`
 )
 
 // newVersionCmd returns a new initialized instance of the version sub command


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
There were inconsistencies in the CLI and the following is what this PR cleans up:

* `-o` was used for overwrite and for output.  It is now only for output.  `-w` is overwrite.
* We needed more examples and better formatting of the examples.  All examples are 2 spaces in, thus the output looks like:

```
Examples:
  kubectl kudo repo remove local
  kubectl kudo repo rm local
```
with 2 space indention to the example section

* Long descs were either elaborated or removed (if they were a dup of the short)
* misspelling of "remmove" -> "remove"
* All long descs were pulled up to a const
* Descs in Examples were moved to Long desc... examples are examples

CLI now has a consistent look across commands.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
