### PR TITLE
Clog Client Controlled Verbosity (-V)

### DIFF
--- a/pkg/kudoctl/clog/log.go
+++ b/pkg/kudoctl/clog/log.go
@@ -34,10 +34,13 @@ func (l *Level) set(val Level) {
 	*l = val
 }
 
-// Get is part of the flag.Value interface.
+// Get is required for https://godoc.org/flag#Getter
+// the return of interface{} is forced by Getter interface
 func (l *Level) Get() interface{} {
 	return *l
 }
+
+//// Required for pflag.Value defined: https://godoc.org/github.com/spf13/pflag#Value
 
 // String is part of the flag.Value interface.
 func (l *Level) String() string {
@@ -58,6 +61,8 @@ func (l *Level) Set(value string) error {
 func (l *Level) Type() string {
 	return string(*l)
 }
+
+//// pflag.Value interface ends
 
 type loggingT struct {
 	verbosity Level // V logging level, the value of the -v flag/

--- a/pkg/kudoctl/clog/log.go
+++ b/pkg/kudoctl/clog/log.go
@@ -1,0 +1,131 @@
+package clog
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"sync/atomic"
+
+	"github.com/spf13/pflag"
+)
+
+// this package provides (C)lient logs, or CLI logs. Although this is called a log, it is for writing to STDOUT and is designed
+// for CLI output (not to log files etc.). We want -V behavior familiar to kubectl users, but klog comes with a lot of dependencies
+// and global flags that obfuscate KUDO.  glog is built more for a multi-threaded logger (managing buffers etc) which
+// KUDO CLI doesn't have a need for.  clog provides verbosity control for CLI output.
+
+// guidance for use of V level
+//  0-1 normal standard out
+//  2-4 as debug-level logs
+//  5-6 logical chooses
+//  7-8 input/output details
+//  9-10 as trace-level (http details)
+
+// Level specifies a level of verbosity for V logs.
+type Level int32
+
+// get returns the value of the Level.
+func (l *Level) get() Level {
+	return *l
+}
+
+// set sets the value of the Level.
+func (l *Level) set(val Level) {
+	atomic.StoreInt32((*int32)(l), int32(val))
+}
+
+// Get is part of the flag.Value interface.
+func (l *Level) Get() interface{} {
+	return *l
+}
+
+// String is part of the flag.Value interface.
+func (l *Level) String() string {
+	return strconv.FormatInt(int64(*l), 10)
+}
+
+// Set is part of the flag.Value interface.
+func (l *Level) Set(value string) error {
+	v, err := strconv.Atoi(value)
+	if err != nil {
+		return err
+	}
+	l.set(Level(v))
+	return nil
+}
+
+// Type is part of flag.Value interface
+func (l *Level) Type() string {
+	return string(*l)
+}
+
+type loggingT struct {
+	verbosity Level // V logging level, the value of the -v flag/
+	out       io.Writer
+}
+
+func (l *loggingT) printf(format string, args ...interface{}) {
+	fmt.Fprintf(l.out, format, args...)
+	fmt.Fprintf(l.out, "\n")
+}
+
+var logging loggingT
+
+// Verbose is boolean type that implements Println, Printf
+// See glog and documentation for V
+type Verbose bool
+
+// V reports true if the verbosity at the call site is at least the request level.
+// This the following glog style code samples are possible:
+//
+//  if clog.V(2) { clog.Print("log this") }
+// or
+//
+//  clog.V(2).Print("log this")
+//
+// Whether the call site logs is determined by the `-v` flags.
+func V(level Level) Verbose {
+	// This function tries hard to be cheap unless there's work to do.
+	// The fast path is two atomic loads and compares.
+
+	// Here is a cheap but safe test to see if V logging is enabled globally.
+	if logging.verbosity.get() >= level {
+		return Verbose(true)
+	}
+	return Verbose(false)
+}
+
+// Printf is equivalent to the global Printf function, guarded by the value of v.
+// See the documentation of V for usage.
+func (v Verbose) Printf(format string, args ...interface{}) {
+	if v {
+		logging.printf(format, args...)
+	}
+}
+
+// Init allows for the initialization of log via root command
+func Init(f *pflag.FlagSet, out io.Writer) {
+	// allows for initialization of writer in testing without CLI flags
+	if f != nil {
+		f.VarP(&logging.verbosity, "v", "v", "log level for V logs")
+	}
+	logging.out = out
+}
+
+// Printf provides default level printing for things that will always print
+func Printf(format string, args ...interface{}) {
+	V(0).Printf(format, args...)
+}
+
+// Errorf formats and returns error and logs at level 2
+func Errorf(format string, a ...interface{}) error {
+	err := fmt.Errorf(format, a...)
+	V(2).Printf(err.Error())
+	return err
+}
+
+func init() {
+	// expected to be overriden with Init().  This simplifies testing and default behavior
+	logging.out = os.Stdout
+}

--- a/pkg/kudoctl/clog/log.go
+++ b/pkg/kudoctl/clog/log.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"os"
 	"strconv"
-	"sync/atomic"
 
 	"github.com/spf13/pflag"
 )
@@ -23,7 +22,7 @@ import (
 //  9-10 as trace-level (http details)
 
 // Level specifies a level of verbosity for V logs.
-type Level int32
+type Level int8
 
 // get returns the value of the Level.
 func (l *Level) get() Level {
@@ -32,7 +31,7 @@ func (l *Level) get() Level {
 
 // set sets the value of the Level.
 func (l *Level) set(val Level) {
-	atomic.StoreInt32((*int32)(l), int32(val))
+	*l = val
 }
 
 // Get is part of the flag.Value interface.

--- a/pkg/kudoctl/clog/log_test.go
+++ b/pkg/kudoctl/clog/log_test.go
@@ -1,0 +1,71 @@
+package clog
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLevelCheck(t *testing.T) {
+
+	var buf bytes.Buffer
+
+	// verbosity set to 4 -v=4
+	logging.verbosity = Level(4)
+	defer func() { logging.verbosity = Level(0) }()
+	logging.out = &buf
+
+	// 3 prints with newline
+	V(3).Printf("level 3")
+	assert.Equal(t, "level 3\n", buf.String())
+	buf.Reset()
+
+	// 4 prints with newline
+	V(4).Printf("level 4")
+	assert.Equal(t, "level 4\n", buf.String())
+	buf.Reset()
+
+	// 5  does not print (v==4)
+	V(5).Printf("level 5")
+	assert.Equal(t, "", buf.String())
+}
+
+func TestDefaultPrintLevel(t *testing.T) {
+
+	//default is verbosity of 0 -v=0 or not supplied
+	var buf bytes.Buffer
+
+	logging.out = &buf
+
+	// 3 does not print
+	V(3).Printf("level 3")
+	assert.Equal(t, "", buf.String())
+	buf.Reset()
+
+	V(0).Printf("level 0")
+	assert.Equal(t, "level 0\n", buf.String())
+	buf.Reset()
+
+	// the clog.Printf defaults to level 0
+	Printf("level 0 check")
+	assert.Equal(t, "level 0 check\n", buf.String())
+}
+
+func TestErrorf(t *testing.T) {
+	//default is verbosity of 0 -v=0 or not supplied
+	var buf bytes.Buffer
+
+	logging.verbosity = Level(0)
+	logging.out = &buf
+
+	// error f prints at level 2, no output by default
+	Errorf("error msg")
+	assert.Equal(t, "", buf.String())
+	buf.Reset()
+
+	logging.verbosity = Level(2)
+	defer func() { logging.verbosity = Level(0) }()
+	Errorf("error msg")
+	assert.Equal(t, "error msg\n", buf.String())
+}

--- a/pkg/kudoctl/cmd/init.go
+++ b/pkg/kudoctl/cmd/init.go
@@ -140,7 +140,7 @@ func (initCmd *initCmd) run() error {
 	if err := initCmd.initialize(); err != nil {
 		return clog.Errorf("error initializing: %s", err)
 	}
-	clog.Printf("$KUDO_HOME has been configured at %s\n", Settings.Home)
+	clog.Printf("$KUDO_HOME has been configured at %s", Settings.Home)
 
 	// initialize server
 	if !initCmd.clientOnly {

--- a/pkg/kudoctl/cmd/init.go
+++ b/pkg/kudoctl/cmd/init.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"strings"
 
+	"github.com/kudobuilder/kudo/pkg/kudoctl/clog"
 	cmdInit "github.com/kudobuilder/kudo/pkg/kudoctl/cmd/init"
 	"github.com/kudobuilder/kudo/pkg/kudoctl/kube"
 	"github.com/kudobuilder/kudo/pkg/kudoctl/kudohome"
@@ -73,6 +74,7 @@ func newInitCmd(fs afero.Fs, out io.Writer) *cobra.Command {
 				return err
 			}
 			i.home = Settings.Home
+			clog.V(8).Printf("init cmd %v", i)
 			return i.run()
 		},
 	}
@@ -136,29 +138,31 @@ func (initCmd *initCmd) run() error {
 
 	// initialize client
 	if err := initCmd.initialize(); err != nil {
-		return fmt.Errorf("error initializing: %s", err)
+		return clog.Errorf("error initializing: %s", err)
 	}
-	fmt.Fprintf(initCmd.out, "$KUDO_HOME has been configured at %s\n", Settings.Home)
+	clog.Printf("$KUDO_HOME has been configured at %s\n", Settings.Home)
 
 	// initialize server
 	if !initCmd.clientOnly {
+		clog.V(4).Printf("initializing server")
 		if initCmd.client == nil {
 			client, err := kube.GetKubeClient(Settings.KubeConfig)
 			if err != nil {
-				return fmt.Errorf("could not get Kubernetes client: %s", err)
+				return clog.Errorf("could not get Kubernetes client: %s", err)
 			}
 			initCmd.client = client
 		}
 
 		if err := cmdInit.Install(initCmd.client, opts); err != nil {
 			if apierrors.IsAlreadyExists(err) {
-				fmt.Fprintln(initCmd.out, "Warning: KUDO is already installed in the cluster.\n"+
+				clog.Printf("Warning: KUDO is already installed in the cluster.\n" +
 					"(Use --client-only to suppress this message)")
-				return fmt.Errorf("error installing: %s", err)
+				return clog.Errorf("error installing: %s", err)
 			}
 		}
 
 		if initCmd.wait {
+			clog.V(4).Printf("waiting for kudo at server init")
 			finished := cmdInit.WatchKUDOUntilReady(initCmd.client.KubeClient, opts, initCmd.timeout)
 			if !finished {
 				return errors.New("watch timed out, readiness uncertain")
@@ -204,11 +208,13 @@ func ensureRepositoryFile(fs afero.Fs, home kudohome.Home, out io.Writer) error 
 		return err
 	}
 	if !exists {
-		fmt.Fprintf(out, "Creating %s \n", home.RepositoryFile())
+		clog.V(1).Printf("Creating %s \n", home.RepositoryFile())
 		r := repo.NewRepositories()
 		if err := r.WriteFile(fs, home.RepositoryFile(), 0644); err != nil {
 			return err
 		}
+	} else {
+		clog.V(1).Printf("%v exists", home.RepositoryFile())
 	}
 
 	return nil
@@ -225,10 +231,12 @@ func ensureDirectories(fs afero.Fs, home kudohome.Home, out io.Writer) error {
 			return err
 		}
 		if !exists {
-			fmt.Fprintf(out, "Creating %s \n", dir)
+			clog.V(1).Printf("creating %s \n", dir)
 			if err := fs.MkdirAll(dir, 0755); err != nil {
 				return fmt.Errorf("could not create %s: %s", dir, err)
 			}
+		} else {
+			clog.V(1).Printf("%v exists", dir)
 		}
 	}
 	return nil

--- a/pkg/kudoctl/cmd/init/manager.go
+++ b/pkg/kudoctl/cmd/init/manager.go
@@ -3,6 +3,7 @@ package init
 import (
 	"fmt"
 
+	"github.com/kudobuilder/kudo/pkg/kudoctl/clog"
 	"github.com/kudobuilder/kudo/pkg/kudoctl/kube"
 	"github.com/kudobuilder/kudo/pkg/version"
 
@@ -57,12 +58,15 @@ func NewOptions(v string) Options {
 
 // Install uses Kubernetes client to install KUDO.
 func Install(client *kube.Client, opts Options) error {
+	clog.V(4).Printf("installing prereqs")
 	if err := installPrereqs(client.KubeClient, opts); err != nil {
 		return err
 	}
+	clog.V(4).Printf("installing crds")
 	if err := installCrds(client.ExtClient); err != nil {
 		return err
 	}
+	clog.V(4).Printf("installing kudo controller")
 	if err := installManager(client.KubeClient, opts); err != nil {
 		return err
 	}

--- a/pkg/kudoctl/cmd/init_test.go
+++ b/pkg/kudoctl/cmd/init_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/kudobuilder/kudo/pkg/kudoctl/clog"
 	"github.com/kudobuilder/kudo/pkg/kudoctl/kube"
 	"github.com/kudobuilder/kudo/pkg/kudoctl/kudohome"
 	"github.com/kudobuilder/kudo/pkg/kudoctl/util/repo"
@@ -62,13 +63,14 @@ func TestInitCmd_exists(t *testing.T) {
 		fs:     afero.NewMemMapFs(),
 		client: &kube.Client{KubeClient: fc},
 	}
+	clog.Init(nil, &buf)
 	Settings.Home = "/opt"
 
 	if err := cmd.run(); err == nil {
 		t.Errorf("expected error: %v", err)
 	}
 	expected := "$KUDO_HOME has been configured at /opt\n" + "Warning: KUDO is already installed in the cluster.\n" +
-		"(Use --client-only to suppress this message)"
+		"(Use --client-only to suppress this message)\n"
 
 	if !strings.Contains(buf.String(), expected) {
 		t.Errorf("expected %q, got %q", expected, buf.String())

--- a/pkg/kudoctl/cmd/install.go
+++ b/pkg/kudoctl/cmd/install.go
@@ -52,8 +52,8 @@ func newInstallCmd(fs afero.Fs) *cobra.Command {
 
 	installCmd.Flags().StringVar(&options.InstanceName, "instance", "", "The instance name. (default to Operator name)")
 	installCmd.Flags().StringArrayVarP(&parameters, "parameter", "p", nil, "The parameter name and value separated by '='")
-	installCmd.Flags().StringVarP(&options.PackageVersion, "version", "v", "", "A specific package version on the official GitHub repo. (default to the most recent)")
 	installCmd.Flags().StringVar(&options.RepoName, "repo", "", "Name of repository configuration to use. (default defined by context)")
+	installCmd.Flags().StringVar(&options.PackageVersion, "version", "", "A specific package version on the official GitHub repo. (default to the most recent)")
 	installCmd.Flags().BoolVar(&options.SkipInstance, "skip-instance", false, "If set, install will install the Operator and OperatorVersion, but not an instance. (default \"false\")")
 	return installCmd
 }

--- a/pkg/kudoctl/cmd/install/install.go
+++ b/pkg/kudoctl/cmd/install/install.go
@@ -1,13 +1,13 @@
 package install
 
 import (
-	"fmt"
 	"os"
 	"strings"
 
 	"github.com/kudobuilder/kudo/pkg/apis/kudo/v1alpha1"
 	"github.com/kudobuilder/kudo/pkg/kudoctl/bundle"
 	"github.com/kudobuilder/kudo/pkg/kudoctl/bundle/finder"
+	"github.com/kudobuilder/kudo/pkg/kudoctl/clog"
 	"github.com/kudobuilder/kudo/pkg/kudoctl/env"
 	"github.com/kudobuilder/kudo/pkg/kudoctl/http"
 	"github.com/kudobuilder/kudo/pkg/kudoctl/util/kudo"
@@ -48,7 +48,7 @@ func Run(args []string, options *Options, fs afero.Fs, settings *env.Settings) e
 
 func validate(args []string, options *Options) error {
 	if len(args) != 1 {
-		return fmt.Errorf("expecting exactly one argument - name of the package or path to install")
+		return clog.Errorf("expecting exactly one argument - name of the package or path to install")
 	}
 
 	return nil
@@ -65,6 +65,7 @@ func GetPackageCRDs(name string, version string, repository repo.Repository) (*b
 
 	// Local files/folder have priority
 	if _, err := os.Stat(name); err == nil {
+		clog.V(2).Printf("local operator discovered: %v", name)
 		f := finder.NewLocal()
 		b, err := f.GetBundle(name, version)
 		if err != nil {
@@ -73,7 +74,9 @@ func GetPackageCRDs(name string, version string, repository repo.Repository) (*b
 		return b.GetCRDs()
 	}
 
+	clog.V(3).Printf("no local operator discovered, looking for http")
 	if http.IsValidURL(name) {
+		clog.V(3).Printf("operator using http protocol for %v", name)
 		f := finder.NewURL()
 		b, err := f.GetBundle(name, version)
 		if err != nil {
@@ -82,6 +85,7 @@ func GetPackageCRDs(name string, version string, repository repo.Repository) (*b
 		return b.GetCRDs()
 	}
 
+	clog.V(3).Printf("no http discovered, looking for repository")
 	b, err := repository.GetBundle(name, version)
 	if err != nil {
 		return nil, err
@@ -96,12 +100,16 @@ func installOperator(operatorArgument string, options *Options, fs afero.Fs, set
 	if err != nil {
 		return errors.WithMessage(err, "could not build operator repository")
 	}
+	clog.V(4).Printf("repository used %v", repository)
 
 	kc, err := kudo.NewClient(settings.Namespace, settings.KubeConfig)
+	clog.V(3).Printf("acquiring kudo client")
 	if err != nil {
+		clog.V(3).Printf("failed to acquire client")
 		return errors.Wrap(err, "creating kudo client")
 	}
 
+	clog.V(3).Printf("getting package crds")
 	crds, err := GetPackageCRDs(operatorArgument, options.PackageVersion, repository)
 	if err != nil {
 		return errors.Wrapf(err, "failed to resolve package CRDs for operator: %s", operatorArgument)
@@ -113,7 +121,9 @@ func installOperator(operatorArgument string, options *Options, fs afero.Fs, set
 func installCrds(crds *bundle.PackageCRDs, kc *kudo.Client, options *Options, settings *env.Settings) error {
 	// PRE-INSTALLATION SETUP
 	operatorName := crds.Operator.ObjectMeta.Name
+	clog.V(3).Printf("operator name: %v", operatorName)
 	operatorVersion := crds.OperatorVersion.Spec.Version
+	clog.V(3).Printf("operator version: %v", operatorVersion)
 	// make sure that our instance object is up to date with overrides from commandline
 	applyInstanceOverrides(crds.Instance, options)
 	// this validation cannot be done earlier because we need to do it after applying things from commandline
@@ -132,7 +142,6 @@ func installCrds(crds *bundle.PackageCRDs, kc *kudo.Client, options *Options, se
 	}
 
 	// OperatorVersion part
-
 	versionsInstalled, err := kc.OperatorVersionsInstalled(operatorName, settings.Namespace)
 	if err != nil {
 		return errors.Wrap(err, "retrieving existing operator versions")
@@ -168,7 +177,7 @@ func installCrds(crds *bundle.PackageCRDs, kc *kudo.Client, options *Options, se
 		}
 
 	} else {
-		return fmt.Errorf("can not install instance '%s' of operator '%s-%s' because instance of that name already exists in namespace %s",
+		return clog.Errorf("can not install instance '%s' of operator '%s-%s' because instance of that name already exists in namespace %s",
 			instanceName, operatorName, crds.OperatorVersion.Spec.Version, settings.Namespace)
 	}
 	return nil
@@ -177,6 +186,7 @@ func installCrds(crds *bundle.PackageCRDs, kc *kudo.Client, options *Options, se
 func validateCrds(crds *bundle.PackageCRDs, skipInstance bool) error {
 	if skipInstance {
 		// right now we are just validating parameters on instance, if we're not creating instance right now, there is nothing to validate
+		clog.V(3).Printf("skipping instance...")
 		return nil
 	}
 	parameters := crds.OperatorVersion.Spec.Parameters
@@ -191,7 +201,7 @@ func validateCrds(crds *bundle.PackageCRDs, skipInstance bool) error {
 	}
 
 	if len(missingParameters) > 0 {
-		return fmt.Errorf("missing required parameters during installation: %s", strings.Join(missingParameters, ","))
+		return clog.Errorf("missing required parameters during installation: %s", strings.Join(missingParameters, ","))
 	}
 	return nil
 }
@@ -212,7 +222,7 @@ func installSingleOperatorToCluster(name, namespace string, o *v1alpha1.Operator
 	if _, err := kc.InstallOperatorObjToCluster(o, namespace); err != nil {
 		return errors.Wrapf(err, "installing %s-operator.yaml", name)
 	}
-	fmt.Printf("operator.%s/%s created\n", o.APIVersion, o.Name)
+	clog.V(2).Printf("operator.%s/%s created\n", o.APIVersion, o.Name)
 	return nil
 }
 
@@ -222,7 +232,7 @@ func installSingleOperatorVersionToCluster(name, namespace string, kc *kudo.Clie
 	if _, err := kc.InstallOperatorVersionObjToCluster(ov, namespace); err != nil {
 		return errors.Wrapf(err, "installing %s-operatorversion.yaml", name)
 	}
-	fmt.Printf("operatorversion.%s/%s created\n", ov.APIVersion, ov.Name)
+	clog.V(2).Printf("operatorversion.%s/%s created\n", ov.APIVersion, ov.Name)
 	return nil
 }
 
@@ -232,15 +242,17 @@ func installSingleInstanceToCluster(name string, instance *v1alpha1.Instance, kc
 	if _, err := kc.InstallInstanceObjToCluster(instance, settings.Namespace); err != nil {
 		return errors.Wrapf(err, "installing instance %s", name)
 	}
-	fmt.Printf("instance.%s/%s created\n", instance.APIVersion, instance.Name)
+	clog.Printf("instance.%s/%s created\n", instance.APIVersion, instance.Name)
 	return nil
 }
 
 func applyInstanceOverrides(instance *v1alpha1.Instance, options *Options) {
 	if options.InstanceName != "" {
 		instance.ObjectMeta.SetName(options.InstanceName)
+		clog.V(3).Printf("instance name: %v", options.InstanceName)
 	}
 	if options.Parameters != nil {
 		instance.Spec.Parameters = options.Parameters
+		clog.V(3).Printf("parameters in use: %v", options.Parameters)
 	}
 }

--- a/pkg/kudoctl/cmd/root.go
+++ b/pkg/kudoctl/cmd/root.go
@@ -1,8 +1,10 @@
 package cmd
 
 import (
+	"io"
 	"os"
 
+	"github.com/kudobuilder/kudo/pkg/kudoctl/clog"
 	"github.com/kudobuilder/kudo/pkg/kudoctl/env"
 	"github.com/kudobuilder/kudo/pkg/version"
 
@@ -62,14 +64,15 @@ and serves as an API aggregation layer.
 	cmd.AddCommand(newTestCmd())
 	cmd.AddCommand(newVersionCmd())
 
-	initGlobalFlags(cmd)
+	initGlobalFlags(cmd, cmd.OutOrStdout())
 
 	return cmd
 }
 
-func initGlobalFlags(cmd *cobra.Command) {
+func initGlobalFlags(cmd *cobra.Command, out io.Writer) {
 	flags := cmd.PersistentFlags()
 	Settings.AddFlags(flags)
+	clog.Init(flags, out)
 	// FIXME: add error handling
 	cmd.ParseFlags(os.Args[1:])
 	// set ENV if flags are not used.

--- a/pkg/kudoctl/cmd/upgrade.go
+++ b/pkg/kudoctl/cmd/upgrade.go
@@ -63,7 +63,7 @@ func newUpgradeCmd(fs afero.Fs) *cobra.Command {
 	upgradeCmd.Flags().StringVar(&options.InstanceName, "instance", "", "The instance name.")
 	upgradeCmd.Flags().StringArrayVarP(&parameters, "parameter", "p", nil, "The parameter name and value separated by '='")
 	upgradeCmd.Flags().StringVar(&options.RepoName, "repo", "", "Name of repository configuration to use. (default defined by context)")
-	upgradeCmd.Flags().StringVarP(&options.PackageVersion, "version", "v", "", "A specific package version on the official repository. When installing from other sources than official repository, version from inside operator.yaml will be used. (default to the most recent)")
+	upgradeCmd.Flags().StringVar(&options.PackageVersion, "version", "", "A specific package version on the official repository. When installing from other sources than official repository, version from inside operator.yaml will be used. (default to the most recent)")
 
 	return upgradeCmd
 }

--- a/pkg/kudoctl/util/kudo/kudo.go
+++ b/pkg/kudoctl/util/kudo/kudo.go
@@ -3,17 +3,18 @@ package kudo
 import (
 	"encoding/json"
 	"fmt"
+
 	"strings"
 	"time"
 
-	v1core "k8s.io/api/core/v1"
-
+	"github.com/kudobuilder/kudo/pkg/apis/kudo/v1alpha1"
+	"github.com/kudobuilder/kudo/pkg/client/clientset/versioned"
+	"github.com/kudobuilder/kudo/pkg/kudoctl/clog"
 	"github.com/kudobuilder/kudo/pkg/util/kudo"
 	"k8s.io/apimachinery/pkg/types"
 
-	"github.com/kudobuilder/kudo/pkg/apis/kudo/v1alpha1"
-	"github.com/kudobuilder/kudo/pkg/client/clientset/versioned"
 	"github.com/pkg/errors"
+	v1core "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -78,9 +79,10 @@ func NewClientFromK8s(client versioned.Interface) *Client {
 func (c *Client) OperatorExistsInCluster(name, namespace string) bool {
 	operator, err := c.clientset.KudoV1alpha1().Operators(namespace).Get(name, v1.GetOptions{})
 	if err != nil {
+		clog.V(2).Printf("operator.kudo.dev/%s does not exist\n", name)
 		return false
 	}
-	fmt.Printf("operator.kudo.dev/%s unchanged\n", operator.Name)
+	clog.V(2).Printf("operator.kudo.dev/%s unchanged", operator.Name)
 	return true
 }
 
@@ -220,5 +222,6 @@ func (c *Client) InstallInstanceObjToCluster(obj *v1alpha1.Instance, namespace s
 	if err != nil {
 		return nil, errors.WithMessage(err, "installing Instance")
 	}
+	clog.V(2).Printf("instance %v created in namespace %v", createdObj.Name, namespace)
 	return createdObj, nil
 }

--- a/pkg/kudoctl/util/repo/repo_operator.go
+++ b/pkg/kudoctl/util/repo/repo_operator.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/kudobuilder/kudo/pkg/apis/kudo/v1alpha1"
 	"github.com/kudobuilder/kudo/pkg/kudoctl/bundle"
+	"github.com/kudobuilder/kudo/pkg/kudoctl/clog"
 	"github.com/kudobuilder/kudo/pkg/kudoctl/http"
 	"github.com/kudobuilder/kudo/pkg/kudoctl/kudohome"
 
@@ -87,6 +88,8 @@ func (r *Client) getPackageReaderByFullPackageName(fullPackageName string) (io.R
 	parsedURL.Path = fmt.Sprintf("%s/%s.tgz", parsedURL.Path, fullPackageName)
 
 	fileURL = parsedURL.String()
+	clog.V(4).Printf("using url: %v", fileURL)
+
 	return r.getPackageReaderByURL(fileURL)
 }
 
@@ -101,6 +104,8 @@ func (r *Client) getPackageReaderByURL(packageURL string) (io.Reader, error) {
 
 // GetPackageReader provides an io.Reader for a provided package name and optional version
 func (r *Client) GetPackageReader(name string, version string) (io.Reader, error) {
+	clog.V(4).Printf("getting package reader for %v, %v", name, version)
+	clog.V(5).Printf("repository using: %v", r.Config)
 	// Construct the package name and download the index file from the remote repo
 	indexFile, err := r.DownloadIndexFile()
 	if err != nil {
@@ -113,6 +118,7 @@ func (r *Client) GetPackageReader(name string, version string) (io.Reader, error
 	}
 
 	packageName := bundleVersion.Name + "-" + bundleVersion.Version
+	clog.V(4).Printf("bundle version returned  %v", packageName)
 
 	return r.getPackageReaderByFullPackageName(packageName)
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Adds -v as a global flag of verbosity
Adds easy logging for developer clog.V(5).Printf - provides stdout if verbosity is level 5.  The default level is 0
Adds convenient prints of messages that should always go to stdout `clog.Printf`
Adds convenient prints for Errorf, which is at level 2.

```
# output from install default level -v==0
go run cmd/kubectl-kudo/main.go install zookeeper  
instance.kudo.dev/v1alpha1/zookeeper-rkt85t created
```

```
# output v==3
go run cmd/kubectl-kudo/main.go install zookeeper  -v 3
acquiring kudo client
getting package crds
no local operator discovered, looking for http
no http discovered, looking for repository
operator name: zookeeper
operator version: 0.1.0
parameters in use: map[]
operator.kudo.dev/zookeeper unchanged
instance zookeeper-n78pvq created in namespace default
instance.kudo.dev/v1alpha1/zookeeper-n78pvq created
```

```
# output v==9
go run cmd/kubectl-kudo/main.go install zookeeper  -v 9
repository used &{0xc0005486c0 {0xc000324060}}
acquiring kudo client
getting package crds
no local operator discovered, looking for http
no http discovered, looking for repository
getting package reader for zookeeper, 
repository using: &{https://kudo-repository.storage.googleapis.com/0.7.0 community}
bundle version returned  zookeeper-0.1.0
using url: https://kudo-repository.storage.googleapis.com/0.7.0/zookeeper-0.1.0.tgz
operator name: zookeeper
operator version: 0.1.0
parameters in use: map[]
operator.kudo.dev/zookeeper unchanged
instance zookeeper-cbjvn8 created in namespace default
instance.kudo.dev/v1alpha1/zookeeper-cbjvn8 created
```

**Which issue(s) this PR fixes**:
Fixes #770 

**Special notes for your reviewer**:

Inspired by glog and klog... we just don't need all that.

**Does this PR introduce a user-facing change?**:
```release-note

```
