### PR TITLE
Kubernetes Version Server Check For Kudo Install

### DIFF
--- a/pkg/kudoctl/cmd/install/install.go
+++ b/pkg/kudoctl/cmd/install/install.go
@@ -132,8 +132,11 @@ func installCrds(crds *bundle.PackageCRDs, kc *kudo.Client, options *Options, se
 		return err
 	}
 
-	// Operator part
+	if err := kc.ValidateServerForOperator(crds.Operator); err != nil {
+		return err
+	}
 
+	// Operator part
 	// Check if Operator exists
 	if !kc.OperatorExistsInCluster(crds.Operator.ObjectMeta.Name, settings.Namespace) {
 		if err := installSingleOperatorToCluster(operatorName, settings.Namespace, crds.Operator, kc); err != nil {

--- a/pkg/kudoctl/util/kudo/kudo.go
+++ b/pkg/kudoctl/util/kudo/kudo.go
@@ -3,7 +3,6 @@ package kudo
 import (
 	"encoding/json"
 	"fmt"
-
 	"strings"
 	"time"
 
@@ -11,12 +10,15 @@ import (
 	"github.com/kudobuilder/kudo/pkg/client/clientset/versioned"
 	"github.com/kudobuilder/kudo/pkg/kudoctl/clog"
 	"github.com/kudobuilder/kudo/pkg/util/kudo"
-	"k8s.io/apimachinery/pkg/types"
+	"github.com/kudobuilder/kudo/pkg/version"
 
+	"github.com/Masterminds/semver"
 	"github.com/pkg/errors"
 	v1core "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/discovery"
 
 	// Import Kubernetes authentication providers to support GKE, etc.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
@@ -224,4 +226,39 @@ func (c *Client) InstallInstanceObjToCluster(obj *v1alpha1.Instance, namespace s
 	}
 	clog.V(2).Printf("instance %v created in namespace %v", createdObj.Name, namespace)
 	return createdObj, nil
+}
+
+// ValidateServerForOperator validates that the k8s server version and kudo version are valid for operator
+// error message will provide detail of failure, otherwise nil
+func (c *Client) ValidateServerForOperator(operator *v1alpha1.Operator) error {
+	expectedKubver, err := semver.NewVersion(operator.Spec.KubernetesVersion)
+	if err != nil {
+		return fmt.Errorf("unable to parse operators kubernetes version: %w", err)
+	}
+	//TODO : to be added in when we support kudo server providing server version
+	//expectedKudoVer, err := semver.NewVersion(operator.Spec.KudoVersion)
+	//if err != nil {
+	//	return fmt.Errorf("Unable to parse operators kudo version: %w", err)
+	//}
+	// semvar compares patch, for which we do not want to... compare maj, min only
+	kVer, err := getKubeVersion(c.clientset.Discovery())
+	if err != nil {
+		return err
+	}
+
+	kSemVer, err := semver.NewVersion(kVer)
+	if err != nil {
+		return err
+	}
+
+	return version.Valid("kubernetes", kSemVer, expectedKubver)
+}
+
+// getKubeVersion returns stringified version of k8s server
+func getKubeVersion(client discovery.DiscoveryInterface) (string, error) {
+	v, err := client.ServerVersion()
+	if err != nil {
+		return "", err
+	}
+	return version.Clean(v.String()), nil
 }

--- a/pkg/kudoctl/util/kudo/kudo_test.go
+++ b/pkg/kudoctl/util/kudo/kudo_test.go
@@ -5,11 +5,11 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/kudobuilder/kudo/pkg/util/kudo"
-
 	"github.com/kudobuilder/kudo/pkg/apis/kudo/v1alpha1"
 	"github.com/kudobuilder/kudo/pkg/client/clientset/versioned/fake"
+	"github.com/kudobuilder/kudo/pkg/util/kudo"
 	util "github.com/kudobuilder/kudo/pkg/util/kudo"
+
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"runtime"
 	"strings"
+
+	"github.com/Masterminds/semver"
 )
 
 // Info contains versioning information.
@@ -48,4 +50,37 @@ func Get() Info {
 		Compiler:   runtime.Compiler,
 		Platform:   fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
 	}
+}
+
+// Error is an error for versions in case it is desired to check an error for this type
+type Error struct {
+	Component       string
+	ExpectedVersion string
+	Version         string
+}
+
+// Error is a required function for type Error
+func (e Error) Error() string {
+	return fmt.Sprintf("expected version: %s, found vresion: %s", e.ExpectedVersion, e.Version)
+}
+
+//Valid returns nil if expected version is meet by actual using solely Major.Minor
+func Valid(component string, actual *semver.Version, expected *semver.Version) error {
+	if actual.Major() < expected.Major() || actual.Minor() < expected.Minor() {
+		return Error{
+			Component:       component,
+			ExpectedVersion: expected.String(),
+			Version:         actual.String(),
+		}
+	}
+
+	return nil
+}
+
+// Clean returns version without a prefixed v if it exists
+func Clean(ver string) string {
+	if strings.HasPrefix(ver, "v") {
+		return ver[1:]
+	}
+	return ver
 }

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -1,0 +1,48 @@
+package version
+
+import (
+	"testing"
+
+	"github.com/Masterminds/semver"
+	"github.com/magiconair/properties/assert"
+)
+
+func Test_validVersion(t *testing.T) {
+
+	tests := []struct {
+		name     string
+		actual   *semver.Version
+		expected *semver.Version
+		wantErr  bool
+	}{
+		{"expect early version", semver.MustParse("1.5"), semver.MustParse("1.4"), false},
+		{"expect same version", semver.MustParse("1.5"), semver.MustParse("1.5"), false},
+		{"expect newer version", semver.MustParse("1.5"), semver.MustParse("1.6"), true},
+		{"full semver is not a factor", semver.MustParse("1.5.8"), semver.MustParse("1.5.0"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := Valid("test", tt.actual, tt.expected); (err != nil) != tt.wantErr {
+				t.Errorf("validVersionExpectations() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestClean(t *testing.T) {
+	tests := []struct {
+		name     string
+		actual   string
+		expected string
+	}{
+		{"clean ver", "1.0.0", "1.0.0"},
+		{"clean ver", "v1.0.0", "1.0.0"},
+		{"short ver", "v1.0", "1.0"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := Clean(tt.actual)
+			assert.Equal(t, result, tt.expected)
+		})
+	}
+}

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -3,7 +3,6 @@ package version
 import (
 	"testing"
 
-	"github.com/Masterminds/semver"
 	"github.com/magiconair/properties/assert"
 )
 
@@ -11,20 +10,19 @@ func Test_validVersion(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		actual   *semver.Version
-		expected *semver.Version
-		wantErr  bool
+		actual   *Version
+		expected *Version
+		val      int
 	}{
-		{"expect early version", semver.MustParse("1.5"), semver.MustParse("1.4"), false},
-		{"expect same version", semver.MustParse("1.5"), semver.MustParse("1.5"), false},
-		{"expect newer version", semver.MustParse("1.5"), semver.MustParse("1.6"), true},
-		{"full semver is not a factor", semver.MustParse("1.5.8"), semver.MustParse("1.5.0"), false},
+		{"expect early version", MustParse("1.5"), MustParse("1.4"), -1},
+		{"expect same version", MustParse("1.5"), MustParse("1.5"), 0},
+		{"expect newer version", MustParse("1.5"), MustParse("1.6"), 1},
+		{"full semver is not a factor", MustParse("1.5.8"), MustParse("1.5.0"), 0},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := Valid("test", tt.actual, tt.expected); (err != nil) != tt.wantErr {
-				t.Errorf("validVersionExpectations() error = %v, wantErr %v", err, tt.wantErr)
-			}
+			val := tt.expected.CompareMajorMinor(tt.actual)
+			assert.Equal(t, tt.val, val)
 		})
 	}
 }

--- a/test/integration/upgrade-command/first-operator/operator.yaml
+++ b/test/integration/upgrade-command/first-operator/operator.yaml
@@ -1,5 +1,6 @@
 name: "upgrade-operator"
 version: "0.1.0"
+kubernetesVersion: 1.13
 maintainers:
   - name: Your name
     email: <your@email.com>

--- a/test/integration/upgrade-command/second-operator/operator.yaml
+++ b/test/integration/upgrade-command/second-operator/operator.yaml
@@ -1,5 +1,6 @@
 name: "upgrade-operator"
 version: "0.2.0"
+kubernetesVersion: 1.13
 maintainers:
   - name: Your name
     email: <your@email.com>


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Adding check of operator requested kubernete version against the server.  
`kubernetesVersion` is now a required field for operators

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
kubernetesVersion is a required operator field
```
