### PR TITLE
Negotiate Docker API version before attempting to create node volumes in tests.

### DIFF
--- a/pkg/test/harness.go
+++ b/pkg/test/harness.go
@@ -154,6 +154,9 @@ func (h *Harness) addNodeCaches(kindCfg *kindConfig.Cluster) error {
 		return err
 	}
 
+	// Determine the correct API version to use with the user's Docker client.
+	dockerClient.NegotiateAPIVersion(context.TODO())
+
 	// add a default node if there are none specified.
 	if len(kindCfg.Nodes) == 0 {
 		kindCfg.Nodes = append(kindCfg.Nodes, kindConfig.Node{})

--- a/pkg/test/harness_test.go
+++ b/pkg/test/harness_test.go
@@ -28,6 +28,8 @@ func (d *dockerMock) VolumeCreate(ctx context.Context, body volumetypes.VolumeCr
 	}, nil
 }
 
+func (d *dockerMock) NegotiateAPIVersion(ctx context.Context) {}
+
 func TestAddNodeCaches(t *testing.T) {
 	h := Harness{
 		T:      t,

--- a/pkg/test/utils/docker.go
+++ b/pkg/test/utils/docker.go
@@ -9,5 +9,6 @@ import (
 
 // DockerClient is a wrapper interface for the Docker library to support unit testing.
 type DockerClient interface {
+	NegotiateAPIVersion(context.Context)
 	VolumeCreate(context.Context, volumetypes.VolumeCreateBody) (dockertypes.Volume, error)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kudo/blob/master/CONTRIBUTING.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kudobuilder/kudo/blob/master/RELEASE.md
3. Ensure you have added or ran the appropriate tests for your PR
4. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What this PR does / why we need it**:

This adds a call to `NegotiateAPIVersion()` when initializing our Docker API client so that it will work with any Docker version:

```
harness.go:172: error creating volume for node Error response from daemon: client version 1.41 is too new. Maximum supported API version is 1.39
```