### PR TITLE
Proper io.Closing around Packages

### DIFF
--- a/pkg/kudoctl/cmd/package_test.go
+++ b/pkg/kudoctl/cmd/package_test.go
@@ -16,8 +16,8 @@ var packageCmdArgs = []struct {
 	errorMessage string
 }{
 	{"expect exactly one argument", []string{}, "expecting exactly one argument - directory of the operator to package"}, // 1
-	{"empty string argument", []string{""}, "invalid operator in path: "},                                                // 2
-	{"invalid operator", []string{"foo"}, "invalid operator in path: foo"},                                               // 3
+	{"empty string argument", []string{""}, "invalid operator in path:  error: path must be specified"},                  // 2
+	{"invalid operator", []string{"foo"}, "invalid operator in path: foo error: open foo: file does not exist"},          // 3
 	{"valid operator", []string{"/opt/zk"}, ""},                                                                          // 4
 }
 

--- a/pkg/kudoctl/packages/finder/package_finder.go
+++ b/pkg/kudoctl/packages/finder/package_finder.go
@@ -1,11 +1,12 @@
 package finder
 
 import (
+	"bytes"
 	"fmt"
-	"io"
 
 	"github.com/kudobuilder/kudo/pkg/kudoctl/http"
 	"github.com/kudobuilder/kudo/pkg/kudoctl/packages"
+
 	"github.com/spf13/afero"
 )
 
@@ -71,14 +72,14 @@ func (f *URLFinder) GetPackage(name string, version string) (packages.Package, e
 	if !http.IsValidURL(name) {
 		return nil, fmt.Errorf("finder: url %v invalid", name)
 	}
-	reader, err := f.getPackageByURL(name)
+	buf, err := f.getPackageByURL(name)
 	if err != nil {
 		return nil, err
 	}
-	return packages.NewPackageFromReader(reader), nil
+	return packages.NewPackageFromBytes(buf), nil
 }
 
-func (f *URLFinder) getPackageByURL(url string) (io.Reader, error) {
+func (f *URLFinder) getPackageByURL(url string) (*bytes.Buffer, error) {
 	resp, err := f.client.Get(url)
 	if err != nil {
 		return nil, fmt.Errorf("finder: unable to get get reader from url %v", url)

--- a/pkg/kudoctl/packages/finder/package_finder.go
+++ b/pkg/kudoctl/packages/finder/package_finder.go
@@ -76,7 +76,7 @@ func (f *URLFinder) GetPackage(name string, version string) (packages.Package, e
 	if err != nil {
 		return nil, err
 	}
-	return packages.NewPackageFromBytes(buf), nil
+	return packages.NewFromBytes(buf), nil
 }
 
 func (f *URLFinder) getPackageByURL(url string) (*bytes.Buffer, error) {

--- a/pkg/kudoctl/packages/package.go
+++ b/pkg/kudoctl/packages/package.go
@@ -1,8 +1,10 @@
 package packages
 
 import (
+	"bytes"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"regexp"
 	"strconv"
 	"strings"
@@ -263,8 +265,12 @@ func pathToOperator(fs afero.Fs, path string) (pfd *PackageFilesDigest, err erro
 	if err != nil {
 		return nil, err
 	}
+	b, err := ioutil.ReadAll(reader)
+	if err != nil {
+		return nil, err
+	}
 
-	pkg, err := readerToOperator(reader)
+	pkg, err := readerToOperator(bytes.NewBuffer(b))
 	pfd = &PackageFilesDigest{
 		pkg,
 		digest,
@@ -272,8 +278,8 @@ func pathToOperator(fs afero.Fs, path string) (pfd *PackageFilesDigest, err erro
 	return pfd, err
 }
 
-func readerToOperator(r io.Reader) (*PackageFiles, error) {
-	b := NewPackageFromReader(r)
+func readerToOperator(buf *bytes.Buffer) (*PackageFiles, error) {
+	b := NewPackageFromBytes(buf)
 	pkg, err := b.GetPkgFiles()
 	if err != nil {
 		return nil, err

--- a/pkg/kudoctl/packages/package.go
+++ b/pkg/kudoctl/packages/package.go
@@ -279,7 +279,7 @@ func pathToOperator(fs afero.Fs, path string) (pfd *PackageFilesDigest, err erro
 }
 
 func bufferToPackageFiles(buf *bytes.Buffer) (*PackageFiles, error) {
-	b := NewPackageFromBytes(buf)
+	b := NewFromBytes(buf)
 	pkg, err := b.GetPkgFiles()
 	if err != nil {
 		return nil, err

--- a/pkg/kudoctl/packages/package.go
+++ b/pkg/kudoctl/packages/package.go
@@ -270,7 +270,7 @@ func pathToOperator(fs afero.Fs, path string) (pfd *PackageFilesDigest, err erro
 		return nil, err
 	}
 
-	pkg, err := readerToOperator(bytes.NewBuffer(b))
+	pkg, err := bufferToPackageFiles(bytes.NewBuffer(b))
 	pfd = &PackageFilesDigest{
 		pkg,
 		digest,
@@ -278,7 +278,7 @@ func pathToOperator(fs afero.Fs, path string) (pfd *PackageFilesDigest, err erro
 	return pfd, err
 }
 
-func readerToOperator(buf *bytes.Buffer) (*PackageFiles, error) {
+func bufferToPackageFiles(buf *bytes.Buffer) (*PackageFiles, error) {
 	b := NewPackageFromBytes(buf)
 	pkg, err := b.GetPkgFiles()
 	if err != nil {

--- a/pkg/kudoctl/packages/package_manager.go
+++ b/pkg/kudoctl/packages/package_manager.go
@@ -134,7 +134,7 @@ func packageVersionedName(pkg *PackageFiles) string {
 // fromFolder walks the path provided and returns CRD package files or an error
 func fromFolder(fs afero.Fs, packagePath string) (*PackageFiles, error) {
 	if packagePath == "" {
-		return nil, clog.Errorf("path must be specified")
+		return nil, errors.New("path must be specified")
 	}
 	result := newPackageFiles()
 
@@ -163,10 +163,10 @@ func fromFolder(fs afero.Fs, packagePath string) (*PackageFiles, error) {
 	}
 	// final check
 	if result.Operator == nil {
-		return nil, clog.Errorf("operator package missing operator.yaml")
+		return nil, errors.New("operator package missing operator.yaml")
 	}
 	if result.Params == nil {
-		return nil, clog.Errorf("operator package missing params.yaml")
+		return nil, errors.New("operator package missing params.yaml")
 	}
 	return &result, nil
 }

--- a/pkg/kudoctl/packages/package_manager.go
+++ b/pkg/kudoctl/packages/package_manager.go
@@ -65,8 +65,8 @@ func ReadPackage(fs afero.Fs, path string) (Package, error) {
 	}
 }
 
-// NewPackageFromBytes is a package from a reader.  This should only be used when a file cache isn't used.
-func NewPackageFromBytes(buf *bytes.Buffer) Package {
+// NewFromBytes creates a package from a byte Buffer
+func NewFromBytes(buf *bytes.Buffer) Package {
 	return tarPackage{buf}
 }
 

--- a/pkg/kudoctl/util/repo/repo_operator.go
+++ b/pkg/kudoctl/util/repo/repo_operator.go
@@ -129,5 +129,5 @@ func (r *Client) GetPackage(name string, version string) (packages.Package, erro
 	if err != nil {
 		return nil, err
 	}
-	return packages.NewPackageFromBytes(reader), nil
+	return packages.NewFromBytes(reader), nil
 }

--- a/pkg/kudoctl/util/repo/repo_operator.go
+++ b/pkg/kudoctl/util/repo/repo_operator.go
@@ -1,8 +1,8 @@
 package repo
 
 import (
+	"bytes"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"net/url"
 	"strings"
@@ -82,8 +82,7 @@ func (r *Client) DownloadIndexFile() (*IndexFile, error) {
 // The PackageVersion is a package configuration from the index file which has a list of urls where
 // the package can be pulled from.  This will cycle through the list of urls and will return the reader
 // from the first successful url.  If all urls fail, the last error will be returned.
-func (r *Client) getPackageReaderByAPackageURL(pkg *PackageVersion) (io.Reader, error) {
-
+func (r *Client) getPackageReaderByAPackageURL(pkg *PackageVersion) (*bytes.Buffer, error) {
 	var pkgErr error
 	for _, u := range pkg.URLs {
 		r, err := r.getPackageReaderByURL(u)
@@ -97,7 +96,7 @@ func (r *Client) getPackageReaderByAPackageURL(pkg *PackageVersion) (io.Reader, 
 	return nil, pkgErr
 }
 
-func (r *Client) getPackageReaderByURL(packageURL string) (io.Reader, error) {
+func (r *Client) getPackageReaderByURL(packageURL string) (*bytes.Buffer, error) {
 	clog.V(4).Printf("attempt to retrieve package from url: %v", packageURL)
 	resp, err := r.Client.Get(packageURL)
 	if err != nil {
@@ -108,7 +107,7 @@ func (r *Client) getPackageReaderByURL(packageURL string) (io.Reader, error) {
 }
 
 // GetPackageReader provides an io.Reader for a provided package name and optional version
-func (r *Client) GetPackageReader(name string, version string) (io.Reader, error) {
+func (r *Client) GetPackageReader(name string, version string) (*bytes.Buffer, error) {
 	clog.V(4).Printf("getting package reader for %v, %v", name, version)
 	clog.V(5).Printf("repository using: %v", r.Config)
 	// Construct the package name and download the index file from the remote repo
@@ -131,7 +130,7 @@ func (r *Client) GetPackage(name string, version string) (packages.Package, erro
 	if err != nil {
 		return nil, err
 	}
-	return packages.NewPackageFromReader(reader), nil
+	return packages.NewPackageFromBytes(reader), nil
 }
 
 // GetOperatorVersionDependencies helper method returns a slice of strings that contains the names of all

--- a/pkg/kudoctl/util/repo/repo_operator.go
+++ b/pkg/kudoctl/util/repo/repo_operator.go
@@ -7,7 +7,6 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/kudobuilder/kudo/pkg/apis/kudo/v1alpha1"
 	"github.com/kudobuilder/kudo/pkg/kudoctl/clog"
 	"github.com/kudobuilder/kudo/pkg/kudoctl/http"
 	"github.com/kudobuilder/kudo/pkg/kudoctl/kudohome"
@@ -85,7 +84,7 @@ func (r *Client) DownloadIndexFile() (*IndexFile, error) {
 func (r *Client) getPackageReaderByAPackageURL(pkg *PackageVersion) (*bytes.Buffer, error) {
 	var pkgErr error
 	for _, u := range pkg.URLs {
-		r, err := r.getPackageReaderByURL(u)
+		r, err := r.getPackageBytesByURL(u)
 		if err == nil {
 			return r, nil
 		}
@@ -96,7 +95,7 @@ func (r *Client) getPackageReaderByAPackageURL(pkg *PackageVersion) (*bytes.Buff
 	return nil, pkgErr
 }
 
-func (r *Client) getPackageReaderByURL(packageURL string) (*bytes.Buffer, error) {
+func (r *Client) getPackageBytesByURL(packageURL string) (*bytes.Buffer, error) {
 	clog.V(4).Printf("attempt to retrieve package from url: %v", packageURL)
 	resp, err := r.Client.Get(packageURL)
 	if err != nil {
@@ -106,8 +105,8 @@ func (r *Client) getPackageReaderByURL(packageURL string) (*bytes.Buffer, error)
 	return resp, nil
 }
 
-// GetPackageReader provides an io.Reader for a provided package name and optional version
-func (r *Client) GetPackageReader(name string, version string) (*bytes.Buffer, error) {
+// GetPackageBytes provides an io.Reader for a provided package name and optional version
+func (r *Client) GetPackageBytes(name string, version string) (*bytes.Buffer, error) {
 	clog.V(4).Printf("getting package reader for %v, %v", name, version)
 	clog.V(5).Printf("repository using: %v", r.Config)
 	// Construct the package name and download the index file from the remote repo
@@ -126,21 +125,9 @@ func (r *Client) GetPackageReader(name string, version string) (*bytes.Buffer, e
 
 // GetPackage provides an Package for a provided package name and optional version
 func (r *Client) GetPackage(name string, version string) (packages.Package, error) {
-	reader, err := r.GetPackageReader(name, version)
+	reader, err := r.GetPackageBytes(name, version)
 	if err != nil {
 		return nil, err
 	}
 	return packages.NewPackageFromBytes(reader), nil
-}
-
-// GetOperatorVersionDependencies helper method returns a slice of strings that contains the names of all
-// dependency Operators
-func GetOperatorVersionDependencies(ov *v1alpha1.OperatorVersion) ([]string, error) {
-	var dependencyOperators []string
-	if ov.Spec.Dependencies != nil {
-		for _, v := range ov.Spec.Dependencies {
-			dependencyOperators = append(dependencyOperators, v.Name)
-		}
-	}
-	return dependencyOperators, nil
 }


### PR DESCRIPTION

**What this PR does / why we need it**:
* `io.Reader` was used for 2 things, buffers and files.  Buffers were fine, but were obfuscated as to when a buffer was used or a file.  Additionally leaving as a Reader left the opportunity for future confusion.  It is now a byte.Buffer.  In the one case where a file was passed the file is read to buffer.
This fixes this comment: // FIXME: Implement 'io.Closer' and make sure that it is called. 'tarPackage' will leak a file descriptor otherwise.

* Additionally the hastily merged refactor of bundle left confusing variables in places which are resolved.

* tests were modified for changes

* clog used in places for verbose logging

* refactored method names to match changes
