### PR TITLE
adding init --crd-only flag

### DIFF
--- a/pkg/kudoctl/cmd/init.go
+++ b/pkg/kudoctl/cmd/init.go
@@ -41,6 +41,10 @@ To dump a manifest containing the KUDO deployment YAML, combine the '--dry-run' 
   kubectl kudo init --client-only
   # init client for non-default home
   kubectl kudo init --client-only --home /opt/home2
+  # install kudo crds only
+  kubectl kudo init --crd-only
+  # delete crds
+  kubectl kudo init --crd-only --dry-run --output yaml | kubectl delete -f -
 `
 )
 
@@ -54,6 +58,7 @@ type initCmd struct {
 	wait       bool
 	timeout    int64
 	clientOnly bool
+	crdOnly    bool
 	home       kudohome.Home
 	client     *kube.Client
 }
@@ -85,6 +90,7 @@ func newInitCmd(fs afero.Fs, out io.Writer) *cobra.Command {
 	f.StringVarP(&i.version, "version", "", "", "Override KUDO controller version of the KUDO image")
 	f.StringVarP(&i.output, "output", "o", "", "Output format")
 	f.BoolVar(&i.dryRun, "dry-run", false, "Do not install local or remote")
+	f.BoolVar(&i.crdOnly, "crd-only", false, "Create KUDO CRDs when generating the server-side configurations")
 	f.BoolVarP(&i.wait, "wait", "w", false, "Block until KUDO manager is running and ready to receive requests")
 	f.Int64Var(&i.timeout, "wait-timeout", 300, "Wait timeout to be used")
 
@@ -110,23 +116,30 @@ func (initCmd *initCmd) run() error {
 	//TODO: implement output=yaml|json (define a type for output to constrain)
 	//define an Encoder to replace YAMLWriter
 	if strings.ToLower(initCmd.output) == "yaml" {
-		mans, err := cmdInit.PrereqManifests(opts)
-		if err != nil {
-			return err
+
+		var mans []string
+		if !initCmd.crdOnly {
+			prereq, err := cmdInit.PrereqManifests(opts)
+			if err != nil {
+				return err
+			}
+			mans = prereq
 		}
 
 		crd, err := cmdInit.CRDManifests()
 		if err != nil {
 			return err
 		}
+		mans = append(mans, crd...)
 
-		deploy, err := cmdInit.ManagerManifests(opts)
-		if err != nil {
-			return err
+		if !initCmd.crdOnly {
+			deploy, err := cmdInit.ManagerManifests(opts)
+			if err != nil {
+				return err
+			}
+			mans = append(mans, deploy...)
 		}
 
-		mans = append(mans, crd...)
-		mans = append(mans, deploy...)
 		if err := initCmd.YAMLWriter(initCmd.out, mans); err != nil {
 			return err
 		}
@@ -153,7 +166,7 @@ func (initCmd *initCmd) run() error {
 			initCmd.client = client
 		}
 
-		if err := cmdInit.Install(initCmd.client, opts); err != nil {
+		if err := cmdInit.Install(initCmd.client, opts, initCmd.crdOnly); err != nil {
 			if apierrors.IsAlreadyExists(err) {
 				clog.Printf("Warning: KUDO is already installed in the cluster.\n" +
 					"(Use --client-only to suppress this message)")

--- a/pkg/kudoctl/cmd/init/manager.go
+++ b/pkg/kudoctl/cmd/init/manager.go
@@ -57,18 +57,22 @@ func NewOptions(v string) Options {
 }
 
 // Install uses Kubernetes client to install KUDO.
-func Install(client *kube.Client, opts Options) error {
-	clog.V(4).Printf("installing prereqs")
-	if err := installPrereqs(client.KubeClient, opts); err != nil {
-		return err
+func Install(client *kube.Client, opts Options, crdOnly bool) error {
+	if !crdOnly {
+		clog.V(4).Printf("installing prereqs")
+		if err := installPrereqs(client.KubeClient, opts); err != nil {
+			return err
+		}
 	}
 	clog.V(4).Printf("installing crds")
 	if err := installCrds(client.ExtClient); err != nil {
 		return err
 	}
-	clog.V(4).Printf("installing kudo controller")
-	if err := installManager(client.KubeClient, opts); err != nil {
-		return err
+	if !crdOnly {
+		clog.V(4).Printf("installing kudo controller")
+		if err := installManager(client.KubeClient, opts); err != nil {
+			return err
+		}
 	}
 	return nil
 }


### PR DESCRIPTION

**What this PR does / why we need it**:
Feature for kudo init for `--crd-only`.  This is useful a number of situations.  We test and need CRDs created.  We need the ability to delete the crds.   The following is now possible.

`kubectl kudo init --crd-only` will not add namespaces or prereqs nor will it launch the kudo controller.  It will simply install the kudo CRDs.
it is also possible to `kubectl kudo init --crd-only --output yaml --dry-run| kubectl apply -f -` 
equally import it is possible to delete the crds `kubectl kudo init --crd-only --output yaml --dry-run| kubectl delete -f -` 


Fixes #784 
