### PR TITLE
Removal of Struct Elements Based on Agreements for YAML Changes

### DIFF
--- a/pkg/kudoctl/packages/package.go
+++ b/pkg/kudoctl/packages/package.go
@@ -46,17 +46,16 @@ type PackageFiles struct {
 
 // Operator is a representation of the KEP-9 Operator YAML
 type Operator struct {
-	Name              string                        `json:"name"`
-	Description       string                        `json:"description,omitempty"`
-	Version           string                        `json:"version"`
-	AppVersion        string                        `json:"appVersion,omitempty"`
-	KUDOVersion       string                        `json:"kudoVersion,omitempty"`
-	KubernetesVersion string                        `json:"kubernetesVersion,omitempty"`
-	Maintainers       []*v1alpha1.Maintainer        `json:"maintainers,omitempty"`
-	URL               string                        `json:"url,omitempty"`
-	Tasks             map[string]v1alpha1.TaskSpec  `json:"tasks"`
-	Plans             map[string]v1alpha1.Plan      `json:"plans"`
-	Dependencies      []v1alpha1.OperatorDependency `json:"dependencies,omitempty"`
+	Name              string                       `json:"name"`
+	Description       string                       `json:"description,omitempty"`
+	Version           string                       `json:"version"`
+	AppVersion        string                       `json:"appVersion,omitempty"`
+	KUDOVersion       string                       `json:"kudoVersion,omitempty"`
+	KubernetesVersion string                       `json:"kubernetesVersion,omitempty"`
+	Maintainers       []*v1alpha1.Maintainer       `json:"maintainers,omitempty"`
+	URL               string                       `json:"url,omitempty"`
+	Tasks             map[string]v1alpha1.TaskSpec `json:"tasks"`
+	Plans             map[string]v1alpha1.Plan     `json:"plans"`
 }
 
 // PackageFilesDigest is a tuple of data used to return the package files AND the digest of a tarball
@@ -194,7 +193,6 @@ func (p *PackageFiles) getCRDs() (*PackageCRDs, error) {
 			Tasks:          p.Operator.Tasks,
 			Parameters:     p.Params,
 			Plans:          p.Operator.Plans,
-			Dependencies:   p.Operator.Dependencies,
 			UpgradableFrom: nil,
 		},
 		Status: v1alpha1.OperatorVersionStatus{},

--- a/pkg/kudoctl/util/repo/index_test.go
+++ b/pkg/kudoctl/util/repo/index_test.go
@@ -113,10 +113,7 @@ func getTestPackageVersion(name string, version string) PackageVersion {
 			Name:        name,
 			Version:     version,
 			AppVersion:  "0.7.0",
-			Home:        "kudo.dev",
-			Sources:     []string{"https://github.com/kudobuilder/kudo"},
 			Description: "fancy description is here",
-			Deprecated:  false,
 			Maintainers: []*v1alpha1.Maintainer{
 				&v1alpha1.Maintainer{Name: "Fabian Baier", Email: "<fabian@mesosphere.io>"},
 				&v1alpha1.Maintainer{Name: "Tom Runyon", Email: "<runyontr@gmail.com>"},

--- a/pkg/kudoctl/util/repo/repo.go
+++ b/pkg/kudoctl/util/repo/repo.go
@@ -162,18 +162,9 @@ type Metadata struct {
 	// AppVersion is the underlying service version (the format is not in our control)
 	AppVersion string `json:"appVersion,omitempty"`
 
-	// The URL to a relevant project page, git repo, or contact person.
-	Home string `json:"home,omitempty"`
-
-	// Source is the URL to the source code of this operator.
-	Sources []string `json:"sources,omitempty"`
-
 	// Description is a one-sentence description of the operator.
 	Description string `json:"description,omitempty"`
 
 	// Maintainers is a list of name and URL/email addresses of the maintainer(s).
 	Maintainers []*v1alpha1.Maintainer `json:"maintainers,omitempty"`
-
-	// Deprecated reflects whether this operator is deprecated.
-	Deprecated bool `json:"deprecated,omitempty"`
 }

--- a/pkg/kudoctl/util/repo/testdata/flink-index.yaml.golden
+++ b/pkg/kudoctl/util/repo/testdata/flink-index.yaml.golden
@@ -4,7 +4,6 @@ entries:
   - appVersion: 0.7.0
     description: fancy description is here
     digest: 0787a078e64c73064287751b833d63ca3d1d284b4f494ebf670443683d5b96dd
-    home: kudo.dev
     maintainers:
     - email: <fabian@mesosphere.io>
       name: Fabian Baier
@@ -13,8 +12,6 @@ entries:
     - email: <kensipe@gmail.com>
       name: Ken Sipe
     name: flink
-    sources:
-    - https://github.com/kudobuilder/kudo
     urls:
     - http://kudo.dev/flink
     version: 0.3.0


### PR DESCRIPTION

**What this PR does / why we need it**:
removing fields from structs for which we do not want to expose thru yaml

This should be consistent with the discussion and agreements reached when discussing #847 

Fixes #
