### PR TITLE
Log test timeout only once, not per file

### DIFF
--- a/pkg/test/harness.go
+++ b/pkg/test/harness.go
@@ -60,13 +60,13 @@ func (h *Harness) LoadTests(dir string) ([]*Case, error) {
 
 	tests := []*Case{}
 
+	timeout := h.GetTimeout()
+	h.T.Logf("Going to run test suite with timeout of %d seconds for each step", timeout)
+
 	for _, file := range files {
 		if !file.IsDir() {
 			continue
 		}
-
-		timeout := h.GetTimeout()
-		h.T.Logf("Going to run test suite with timeout of %d seconds for each step", timeout)
 
 		tests = append(tests, &Case{
 			Timeout:    timeout,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kudo/blob/master/CONTRIBUTING.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kudobuilder/kudo/blob/master/RELEASE.md
3. Ensure you have added or ran the appropriate tests for your PR
4. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What this PR does / why we need it**:
The logging now happens many times because it's inside the for cycle. This fixes that.
