### PR TITLE
Add 'errors' file handling to test harness

### DIFF
--- a/pkg/test/step_test.go
+++ b/pkg/test/step_test.go
@@ -188,26 +188,26 @@ func TestCheckResource(t *testing.T) {
 
 func TestCheckResourceAbsent(t *testing.T) {
 	for _, test := range []struct {
-		name string
-		actual runtime.Object
-		expected runtime.Object
+		name        string
+		actual      runtime.Object
+		expected    runtime.Object
 		shouldError bool
 	}{
 		{
-			name: "resource matches",
-			actual: testutils.NewPod("hello", ""),
-			expected: testutils.NewPod("hello", ""),
+			name:        "resource matches",
+			actual:      testutils.NewPod("hello", ""),
+			expected:    testutils.NewPod("hello", ""),
 			shouldError: true,
 		},
 		{
-			name: "resource mis-match",
-			actual:      testutils.NewPod("hello", ""),
-			expected:    testutils.WithSpec(testutils.NewPod("hello", ""), map[string]interface{}{"invalid": "key"}),
+			name:     "resource mis-match",
+			actual:   testutils.NewPod("hello", ""),
+			expected: testutils.WithSpec(testutils.NewPod("hello", ""), map[string]interface{}{"invalid": "key"}),
 		},
 		{
-			name:    "resource does not exist",
-			actual:      testutils.NewPod("other", ""),
-			expected:    testutils.NewPod("hello", ""),
+			name:     "resource does not exist",
+			actual:   testutils.NewPod("other", ""),
+			expected: testutils.NewPod("hello", ""),
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -218,8 +218,8 @@ func TestCheckResourceAbsent(t *testing.T) {
 			assert.Nil(t, err)
 
 			step := Step{
-				Logger: testutils.NewTestLogger(t, ""),
-				Client: func(bool) (client.Client, error) { return fake.NewFakeClient(test.actual), nil },
+				Logger:          testutils.NewTestLogger(t, ""),
+				Client:          func(bool) (client.Client, error) { return fake.NewFakeClient(test.actual), nil },
 				DiscoveryClient: func() (discovery.DiscoveryInterface, error) { return fakeDiscovery, nil },
 			}
 

--- a/pkg/test/step_test.go
+++ b/pkg/test/step_test.go
@@ -186,6 +186,54 @@ func TestCheckResource(t *testing.T) {
 	}
 }
 
+func TestCheckResourceAbsent(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		actual runtime.Object
+		expected runtime.Object
+		shouldError bool
+	}{
+		{
+			name: "resource matches",
+			actual: testutils.NewPod("hello", ""),
+			expected: testutils.NewPod("hello", ""),
+			shouldError: true,
+		},
+		{
+			name: "resource mis-match",
+			actual:      testutils.NewPod("hello", ""),
+			expected:    testutils.WithSpec(testutils.NewPod("hello", ""), map[string]interface{}{"invalid": "key"}),
+		},
+		{
+			name:    "resource does not exist",
+			actual:      testutils.NewPod("other", ""),
+			expected:    testutils.NewPod("hello", ""),
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			fakeDiscovery := testutils.FakeDiscoveryClient()
+			namespace := "world"
+
+			_, _, err := testutils.Namespaced(fakeDiscovery, test.actual, namespace)
+			assert.Nil(t, err)
+
+			step := Step{
+				Logger: testutils.NewTestLogger(t, ""),
+				Client: func(bool) (client.Client, error) { return fake.NewFakeClient(test.actual), nil },
+				DiscoveryClient: func() (discovery.DiscoveryInterface, error) { return fakeDiscovery, nil },
+			}
+
+			error := step.CheckResourceAbsent(test.expected, namespace)
+
+			if test.shouldError {
+				assert.NotNil(t, error)
+			} else {
+				assert.Nil(t, error)
+			}
+		})
+	}
+}
+
 func TestRun(t *testing.T) {
 	for _, test := range []struct {
 		testName     string

--- a/test/integration/first-operator-test/01-errors.yaml
+++ b/test/integration/first-operator-test/01-errors.yaml
@@ -1,0 +1,7 @@
+apiVersion: kudo.dev/v1alpha1
+kind: Instance
+metadata:
+  name: first-operator
+spec:
+  parameters:
+    replicas: "2"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kudo/blob/master/CONTRIBUTING.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kudobuilder/kudo/blob/master/RELEASE.md
3. Ensure you have added or ran the appropriate tests for your PR
4. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What this PR does / why we need it**:
YAML files ending with 'errors' list objects that aren't expected in a
cluster's state. Tests will fail if any of these objects is found as part of a
test step.

<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Needed for integration tests of https://github.com/kudobuilder/kudo/pull/856
