### PR TITLE
Fix kudo init on Kubernetes 1.16

### DIFF
--- a/pkg/kudoctl/cmd/init.go
+++ b/pkg/kudoctl/cmd/init.go
@@ -171,8 +171,8 @@ func (initCmd *initCmd) run() error {
 			if apierrors.IsAlreadyExists(err) {
 				clog.Printf("Warning: KUDO is already installed in the cluster.\n" +
 					"(Use --client-only to suppress this message)")
-				return clog.Errorf("error installing: %s", err)
 			}
+			return clog.Errorf("error installing: %s", err)
 		}
 
 		if initCmd.wait {


### PR DESCRIPTION
StatefulSets were being created using the v1beta2 APIs, which have been removed from Kubernetes 1.16, causing this command to silently fail. The err value is being set correctly - this PR doesn't address that it's being swallowed. To make it even better, --dry-run and -o yaml work because "apps/v1" is being set correctly for the pretty printer.