### PR TITLE
Fix health checks by passing in the resolved remote resource

### DIFF
--- a/pkg/controller/instance/plan_execution_engine.go
+++ b/pkg/controller/instance/plan_execution_engine.go
@@ -173,7 +173,7 @@ func executeStep(step v1alpha1.Step, state *v1alpha1.StepStatus, resources []run
 					}
 				}
 
-				err = health.IsHealthy(c, r)
+				err = health.IsHealthy(c, existingResource)
 				if err != nil {
 					allHealthy = false
 					log.Printf("PlanExecution: Obj is NOT healthy: %s", prettyPrint(key))


### PR DESCRIPTION
This was a nasty, subtle one.

Health checks were getting a zero value status because we were passing in the locally made object into the health checker, rather than the fully resolved one from the client.