### PR TITLE
Add shorthand `-n` for `--namespace`

### DIFF
--- a/pkg/kudoctl/cmd/plan.go
+++ b/pkg/kudoctl/cmd/plan.go
@@ -41,7 +41,6 @@ func NewPlanHistoryCmd() *cobra.Command {
 	}
 
 	listCmd.Flags().StringVar(&options.Instance, "instance", "", "The instance name.")
-	listCmd.Flags().StringVar(&options.Namespace, "namespace", "default", "The namespace where the instance is running.")
 
 	return listCmd
 }
@@ -59,7 +58,6 @@ func NewPlanStatusCmd() *cobra.Command {
 	}
 
 	statusCmd.Flags().StringVar(&options.Instance, "instance", "", "The instance name available from 'kubectl get instances'")
-	statusCmd.Flags().StringVar(&options.Namespace, "namespace", "default", "The namespace where the instance is running.")
 
 	return statusCmd
 }

--- a/pkg/kudoctl/env/environoment.go
+++ b/pkg/kudoctl/env/environoment.go
@@ -37,8 +37,8 @@ var envMap = map[string]string{
 // AddFlags binds flags to the given flagset.
 func (s *Settings) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar((*string)(&s.Home), "home", DefaultKudoHome, "location of your KUDO config.")
-	fs.StringVar(&s.KubeConfig, "kubeconfig", os.Getenv("HOME")+"/.kube/config", "Path to your Kubernetes configuration file")
-	fs.StringVar(&s.Namespace, "namespace", "default", "The namespace used for the package installation. (default \"default\"")
+	fs.StringVar(&s.KubeConfig, "kubeconfig", os.Getenv("HOME")+"/.kube/config", "Path to your Kubernetes configuration file.")
+	fs.StringVarP(&s.Namespace, "namespace", "n", "default", "Target namespace for the object.")
 }
 
 // Init sets values from the environment.


### PR DESCRIPTION
**What this PR does / why we need it**:
This commit adds the `-n` shorthand option for the `--namespace` global flag, mirroring the behaviour of `kubectl`.

It also removes the redundant flag definition elsewhere since `--namespace` is global, and tidies the help default for another.

Fixes #874
