### PR TITLE
Delete kubebuilder markers

### DIFF
--- a/pkg/controller/instance/instance_controller.go
+++ b/pkg/controller/instance/instance_controller.go
@@ -117,8 +117,6 @@ func (r *Reconciler) SetupWithManager(
 //   +-------------------------------+
 //
 // Automatically generate RBAC rules to allow the Controller to read and write Deployments
-// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=kudo.dev,resources=instances,verbs=get;list;watch;create;update;patch;delete
 func (r *Reconciler) Reconcile(request ctrl.Request) (ctrl.Result, error) {
 	// ---------- 1. Query the current state ----------
 

--- a/pkg/controller/operator/operator_controller.go
+++ b/pkg/controller/operator/operator_controller.go
@@ -42,8 +42,6 @@ func (r *Reconciler) SetupWithManager(
 // Reconcile reads that state of the cluster for an Operator object and makes changes based on the state read
 // and what is in the Operator.Spec
 // Automatically generate RBAC rules to allow the Controller to read and write Deployments
-// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=kudo.dev,resources=operators,verbs=get;list;watch;create;update;patch;delete
 func (r *Reconciler) Reconcile(request ctrl.Request) (ctrl.Result, error) {
 	// Fetch the operator
 	operator := &kudov1alpha1.Operator{}

--- a/pkg/controller/operatorversion/operatorversion_controller.go
+++ b/pkg/controller/operatorversion/operatorversion_controller.go
@@ -43,8 +43,6 @@ func (r *Reconciler) SetupWithManager(
 // and what is in the OperatorVersion.Spec.
 //
 // Automatically generate RBAC rules to allow the Controller to read and write Deployments
-// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=kudo.dev,resources=operatorversions,verbs=get;list;watch;create;update;patch;delete
 func (r *Reconciler) Reconcile(request ctrl.Request) (ctrl.Result, error) {
 	// Fetch the operator version
 	operatorVersion := &kudov1alpha1.OperatorVersion{}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kudo/blob/master/CONTRIBUTING.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kudobuilder/kudo/blob/master/RELEASE.md
3. Ensure you have added or ran the appropriate tests for your PR
4. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What this PR does / why we need it**:
Last week we were wondering if one of the bug was introduced by one of these annotations actually going away so I went and investigate how these actually work right now in our codebase and surprise, surprise - they don't do anything. 

We removed `make manifests` in this PR https://github.com/kudobuilder/kudo/commit/f513b1a3972669817d9a638e2ae50fe738f945bd#diff-d78b6f30225cdc811adfe8d4e7c9fd34 and that was the last usage of `controller-gen` which is the tool used to process these. We don't really generate rbac or crds or webhook anymore anyway so droping these markers as well is the way to go.

Documentation if someone is interested https://book.kubebuilder.io/reference/markers.html
