### PR TITLE
Remove remaining mentions/usages of PlanExecution in code

### DIFF
--- a/pkg/controller/instance/apply_conventions.go
+++ b/pkg/controller/instance/apply_conventions.go
@@ -31,7 +31,6 @@ type metadata struct {
 	Namespace       string
 	OperatorName    string
 	OperatorVersion string
-	PlanExecution   string
 	PlanName        string
 	PhaseName       string
 	StepName        string
@@ -73,7 +72,6 @@ func (k *kustomizeEnhancer) applyConventionsToTemplates(templates map[string]str
 			kudo.InstanceLabel: metadata.InstanceName,
 		},
 		CommonAnnotations: map[string]string{
-			kudo.PlanExecutionAnnotation:   metadata.PlanExecution,
 			kudo.PlanAnnotation:            metadata.PlanName,
 			kudo.PhaseAnnotation:           metadata.PhaseName,
 			kudo.StepAnnotation:            metadata.StepName,

--- a/pkg/controller/instance/plan_execution_engine.go
+++ b/pkg/controller/instance/plan_execution_engine.go
@@ -46,8 +46,6 @@ type executionMetadata struct {
 	operatorVersionName string
 	operatorVersion     string
 
-	planExecutionID string // TODO will be removed when PE CRD is removed
-
 	// the object that will own all the resources created by this execution
 	resourcesOwner metav1.Object
 }
@@ -290,7 +288,6 @@ func prepareKubeResources(plan *activePlan, meta *executionMetadata, renderer ku
 						Namespace:       meta.instanceNamespace,
 						OperatorName:    meta.operatorName,
 						OperatorVersion: meta.operatorVersion,
-						PlanExecution:   meta.planExecutionID,
 						PlanName:        plan.Name,
 						PhaseName:       phase.Name,
 						StepName:        step.Name,
@@ -300,7 +297,7 @@ func prepareKubeResources(plan *activePlan, meta *executionMetadata, renderer ku
 						phaseState.Status = v1alpha1.ErrorStatus
 						stepState.Status = v1alpha1.ErrorStatus
 
-						log.Printf("Error creating Kubernetes objects from step %v in phase %v of plan %v: %v", step.Name, phase.Name, meta.planExecutionID, err)
+						log.Printf("Error creating Kubernetes objects from step %v in phase %v of plan %v and instance %s/%s: %v", step.Name, phase.Name, plan.Name, meta.instanceNamespace, meta.instanceName, err)
 						return nil, &executionError{err, false, nil}
 					}
 					resources = append(resources, resourcesWithConventions...)

--- a/pkg/controller/instance/plan_execution_engine_test.go
+++ b/pkg/controller/instance/plan_execution_engine_test.go
@@ -21,7 +21,6 @@ import (
 func TestExecutePlan(t *testing.T) {
 	defaultMetadata := &executionMetadata{
 		instanceName:        "Instance",
-		planExecutionID:     "pid",
 		instanceNamespace:   "default",
 		operatorVersion:     "ov-1.0",
 		operatorName:        "operator",

--- a/pkg/util/kudo/labels.go
+++ b/pkg/util/kudo/labels.go
@@ -10,8 +10,6 @@ const (
 	// HeritageLabel is k8s label key for heritage
 	HeritageLabel = "heritage" // this is not specific to KUDO
 
-	// PlanExecutionAnnotation is k8s annotation key for planexecution that created this object
-	PlanExecutionAnnotation = "kudo.dev/plan-execution"
 	// PlanAnnotation is k8s annotation key for plan name that created this object
 	PlanAnnotation = "kudo.dev/plan"
 	// PhaseAnnotation is k8s annotation key for phase that created this object

--- a/test/integration/instance-controller-param-change-custom-trigger/00-setup.yaml
+++ b/test/integration/instance-controller-param-change-custom-trigger/00-setup.yaml
@@ -1,7 +1,7 @@
 # Create an OperatorVersion with a parameter and its corresponding trigger.
 #
 # The next step will update the parameter and verify that it triggers the
-# creation of a `PlanExecution` for the plan defined as a trigger.
+# execution for the plan defined as a trigger.
 apiVersion: kudo.dev/v1alpha1
 kind: OperatorVersion
 metadata:

--- a/test/integration/instance-controller-upgrade/00-setup.yaml
+++ b/test/integration/instance-controller-upgrade/00-setup.yaml
@@ -6,7 +6,7 @@
 #
 # The next step will then create new OperatorVersion which will include an
 # "upgrade" plan, update the instance, and finally verify that the right
-# PlanExecution was created.
+# plan executed.
 apiVersion: kudo.dev/v1alpha1
 kind: Operator
 metadata:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kudo/blob/master/CONTRIBUTING.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kudobuilder/kudo/blob/master/RELEASE.md
3. Ensure you have added or ran the appropriate tests for your PR
4. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What this PR does / why we need it**:
This is remaining cleanup from the PE/I controller refactoring. There were some leftover fields that should have been deleted in that PR but were left behind. Now nothing should reference PlanExecution hopefully.
