### PR TITLE
KUDO Operator versioning scheme suggestion with regards to base technology versions

### DIFF
--- a/keps/0010-package-manager.md
+++ b/keps/0010-package-manager.md
@@ -73,6 +73,7 @@ As an Operator Developer I, ...
 
 * would like to be able to host validation/testing plans and resources as part of the Package
 * would like to update my Package version
+* would like to be able to provide operator package versions based on multiple base technology versions, with the same operator version
 
 #### Cluster Administrator
 

--- a/keps/0010-package-manager.md
+++ b/keps/0010-package-manager.md
@@ -145,10 +145,10 @@ In the long term it will conform with KEP-0009 and have the following structure:
 
 The advantage of having a flat structure withing the hosted repo environment is, that for distribution the opinionated structure within the `.tgz` file is not much of importance and can be subject to change without breaking other assumptions.
 
-For example, the `/kafka/2.2.0` folder (with whatever underlying structure) is zipped to `kafka-2.2.0.tgz`, where `2.2.0` is the current SemVer version of the Package. 
+For example, the `/kafka/2.2.0` folder (with whatever underlying structure) is zipped to `kafka-2.2.0.tgz`, where `2.2.0` is the current SemVer version of the Package.
 
 The version of a Package (e.g., `kafka-0.1.0` or `kafka-0.2.0`) does not have to match the current version of KUDO itself but it follows its own SemVer timeline. The zipped Operator, called Package, is made available through any HTTP Server.
- 
+
 Our official repository is hosted on Google Cloud Storage and following a flat structure:
 
 ```bash
@@ -167,7 +167,7 @@ Our official repository is hosted on Google Cloud Storage and following a flat s
 
 We rely on just an HTTP Server, e.g. the out-of-the-box solution that Google Cloud Storage provides, that serves operator `tgz` files and makes them available to users.
 
-The logic for keeping the operators in sync should live in the CLI and is not defined on this KEP . That way the HTTP server only has to serve the index and the Package `tgz` files, without having to implement any business logic. 
+The logic for keeping the operators in sync should live in the CLI and is not defined on this KEP . That way the HTTP server only has to serve the index and the Package `tgz` files, without having to implement any business logic.
 
 The proposed structure is fairly easy to replicate and highly customizable.
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds a new operator developer request to the package manager KEP.

This new request might require that we reconsider the operator versioning scheme.

What I'm thinking of is: assume a KUDO Operator for Cassandra. Apache Cassandra is about to get a 4.x release. 3.x will probably still be maintained and be released even after 4.x comes out.

If the operator developer plans to release the KUDO Cassandra Operator package Cassandra 4.x first and Cassandra 3.x afterwards, how should that reflect in the current proposed KUDO Operator versioning scheme? It seems that it would require that the KUDO Cassandra Operator version for the operator based on Cassandra 3.x would have a higher version than the one based on Cassandra 4.x, since the operator based on 3.x was released afterwards.

Another problem is, base technology versions before the latest will keep getting new minor and patch releases.

An example timeline of releases:

| KUDO Cassandra Operator version | Apache Cassandra version | KUDO Cassandra Operator release date |
| ------------------------------- | ------------------------ | ------------------------------------ |
|                           0.1.0 |                    4.0.0 |                           2019-10-01 |
|                           0.2.0 |                   3.11.4 |                           2019-11-01 |
|                           0.3.0 |                    4.1.0 |                           2019-12-01 |
|                           0.4.0 |                   3.12.0 |                           2020-01-01 |

As one can see, a one-dimensional versioning scheme for KUDO Operators (and their packages, by extension) might be confusing.
