### PR TITLE
Removed the references of Prow in CICD.

### DIFF
--- a/keps/0004-add-testing-infrastructure.md
+++ b/keps/0004-add-testing-infrastructure.md
@@ -124,7 +124,7 @@ These clusters can be started either as a part of CI jobs or maintained long ter
 
 ### CICD
 
-We will use a [Prow](https://github.com/kubernetes/test-infra/tree/master/prow) cluster to run jobs for pull requests and merges. The Prow cluster configuration will live in the `kudobuilder/test-infra` repository, it will be hosted on GKE, and it will be reachable at https://prow.kudo.dev/.
+CICD is accomplished by a combination of CircleCI and Github Actions enabled for the KUDO repo.
 
 #### Pull Requests
 

--- a/keps/0014-pull-request-process.md
+++ b/keps/0014-pull-request-process.md
@@ -8,7 +8,7 @@ owners:
   - "@orsenthil"
 editor: TBD
 creation-date: 2019-07-16
-last-updated: 2019-07-16
+last-updated: 2019-10-02
 status: rejected
 see-also:
   - KEP-0004
@@ -35,6 +35,9 @@ see-also:
 ## Summary
 
 In order to ensure that contributors to the KUDO project have a good experience, we have a streamlined pull request review and merging process using Prow.
+
+After analyzing prow for few iterations, the team decided to reject prow, and decided to adopt Github Actions for Pull Request Process.
+Github Actions provided the desired goal as a service, and it was easier to administer for the project team members. The status of this proposal was changed to rejected.
 
 ## Goals
 


### PR DESCRIPTION

**What this PR does / why we need it**:

* Removed the references of Prow in CICD.
* Added the reason for rejecting Prow.


Fixes #767
