### PR TITLE
Make AppVersion templatable from the operator.yaml.

### DIFF
--- a/pkg/apis/kudo/v1alpha1/operatorversion_types.go
+++ b/pkg/apis/kudo/v1alpha1/operatorversion_types.go
@@ -45,6 +45,9 @@ type OperatorVersionSpec struct {
 
 	// UpgradableFrom lists all OperatorVersions that can upgrade to this OperatorVersion.
 	UpgradableFrom []OperatorVersion `json:"upgradableFrom,omitempty"`
+
+	// AppVersion available as templatable value from operator.yaml
+	AppVersion string `json:"appVersion,omitempty"`
 }
 
 // Ordering specifies how the subitems in this plan/phase should be rolled out.

--- a/pkg/controller/instance/instance_controller.go
+++ b/pkg/controller/instance/instance_controller.go
@@ -216,6 +216,7 @@ func preparePlanExecution(instance *kudov1alpha1.Instance, ov *kudov1alpha1.Oper
 			operatorName:        ov.Spec.Operator.Name,
 			instanceNamespace:   instance.Namespace,
 			instanceName:        instance.Name,
+			appVersion:          ov.Spec.AppVersion,
 		}, nil
 }
 

--- a/pkg/controller/instance/plan_execution_engine.go
+++ b/pkg/controller/instance/plan_execution_engine.go
@@ -45,6 +45,7 @@ type executionMetadata struct {
 	operatorName        string
 	operatorVersionName string
 	operatorVersion     string
+	appVersion          string
 
 	planExecutionID string // TODO will be removed when PE CRD is removed
 
@@ -238,6 +239,8 @@ func prepareKubeResources(plan *activePlan, meta *executionMetadata, renderer ku
 	configs["OperatorName"] = meta.operatorName
 	configs["Name"] = meta.instanceName
 	configs["Namespace"] = meta.instanceNamespace
+	configs["AppVersion"] = meta.appVersion
+	configs["Version"] = meta.operatorVersion
 	configs["Params"] = plan.params
 
 	result := &planResources{

--- a/pkg/controller/instance/plan_execution_engine_test.go
+++ b/pkg/controller/instance/plan_execution_engine_test.go
@@ -27,6 +27,7 @@ func TestExecutePlan(t *testing.T) {
 		operatorName:        "operator",
 		resourcesOwner:      getJob("pod2", "default"),
 		operatorVersionName: "ovname",
+		appVersion:          "3.4.10-test_version",
 	}
 	tests := []struct {
 		name           string

--- a/pkg/kudoctl/packages/package.go
+++ b/pkg/kudoctl/packages/package.go
@@ -174,6 +174,8 @@ func (p *PackageFiles) getCRDs() (*PackageCRDs, error) {
 		Status: v1alpha1.OperatorStatus{},
 	}
 
+	fmt.Println("Print AppVersion: ", p.Operator.AppVersion)
+
 	fv := &v1alpha1.OperatorVersion{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "OperatorVersion",
@@ -193,6 +195,7 @@ func (p *PackageFiles) getCRDs() (*PackageCRDs, error) {
 			Tasks:          p.Operator.Tasks,
 			Parameters:     p.Params,
 			Plans:          p.Operator.Plans,
+			AppVersion:     p.Operator.AppVersion,
 			UpgradableFrom: nil,
 		},
 		Status: v1alpha1.OperatorVersionStatus{},

--- a/pkg/kudoctl/packages/package.go
+++ b/pkg/kudoctl/packages/package.go
@@ -174,8 +174,6 @@ func (p *PackageFiles) getCRDs() (*PackageCRDs, error) {
 		Status: v1alpha1.OperatorStatus{},
 	}
 
-	fmt.Println("Print AppVersion: ", p.Operator.AppVersion)
-
 	fv := &v1alpha1.OperatorVersion{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "OperatorVersion",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kudo/blob/master/CONTRIBUTING.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kudobuilder/kudo/blob/master/RELEASE.md
3. Ensure you have added or ran the appropriate tests for your PR
4. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What this PR does / why we need it**:
https://github.com/kudobuilder/kudo/issues/871
Make the version and appVersion variables in operator.yaml as a template to statefulset.yaml. This is still a WIP, and creating this PR as I need guidance in completing this.

<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #871 
