### PR TITLE
Add API Extensions v1beta1 to scheme

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/kudobuilder/kudo/pkg/controller/operator"
 	"github.com/kudobuilder/kudo/pkg/controller/operatorversion"
 	"github.com/kudobuilder/kudo/pkg/version"
+	apiextenstionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -48,8 +49,13 @@ func main() {
 	log.Info("Registering Components.")
 
 	log.Info("setting up scheme")
+
 	if err := apis.AddToScheme(mgr.GetScheme()); err != nil {
 		log.Error(err, "unable add APIs to scheme")
+	}
+
+	if err := apiextenstionsv1beta1.AddToScheme(mgr.GetScheme()); err != nil {
+		log.Error(err, "unable to add extension APIs to scheme")
 	}
 
 	// Setup all Controllers


### PR DESCRIPTION
This enables operator developers to use CRDs. This scheme isn't explicitly added by core APIs. @kensipe when we go to CRDv1 we'll need to add that to the scheme as well. We won't want to remove this one because we don't necessarily mind if someone wants to manage CRD/v1beta1 CRDs via KUDO.

This is blocking someone, so I'd like to cherry pick this to 0.7.3 as well and ship it tomorrow.