### PR TITLE
Attempt to fix 'TestCheckResourceIntegration' flaky test

### DIFF
--- a/pkg/test/step_integration_test.go
+++ b/pkg/test/step_integration_test.go
@@ -6,8 +6,10 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"math/rand"
 	"os"
 	"testing"
+	"time"
 
 	petname "github.com/dustinkirkland/golang-petname"
 
@@ -38,6 +40,8 @@ func TestMain(m *testing.M) {
 }
 
 func TestCheckResourceIntegration(t *testing.T) {
+	rand.Seed(time.Now().UnixNano())
+
 	for _, test := range []struct {
 		testName    string
 		actual      []runtime.Object

--- a/pkg/test/step_integration_test.go
+++ b/pkg/test/step_integration_test.go
@@ -47,7 +47,7 @@ func TestCheckResourceIntegration(t *testing.T) {
 		{
 			testName: "match object by labels, first in list matches",
 			actual: []runtime.Object{
-				testutils.WithSpec(testutils.WithLabels(testutils.NewPod("aa", ""), map[string]string{
+				testutils.WithSpec(testutils.WithLabels(testutils.NewPod("labels-match-pod", ""), map[string]string{
 					"app": "nginx",
 				}), map[string]interface{}{
 					"containers": []interface{}{
@@ -91,7 +91,7 @@ func TestCheckResourceIntegration(t *testing.T) {
 		{
 			testName: "match object by labels, last in list matches",
 			actual: []runtime.Object{
-				testutils.WithSpec(testutils.WithLabels(testutils.NewPod("aa", ""), map[string]string{
+				testutils.WithSpec(testutils.WithLabels(testutils.NewPod("last-in-list", ""), map[string]string{
 					"app": "not-match",
 				}), map[string]interface{}{
 					"containers": []interface{}{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kudo/blob/master/CONTRIBUTING.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kudobuilder/kudo/blob/master/RELEASE.md
3. Ensure you have added or ran the appropriate tests for your PR
4. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What this PR does / why we need it**:
I spent quite some time investigating this flake and I must admit my defeat :) All my hunches proved not to be true. Anyway it looks like all the tests run correctly in their own namespace, I was not able to reproduce locally.

The only thing that looked suspicious was that petname generator library uses the same seed (but the default source should be safe for concurrent use so that looks right).

So this PR is just an attempt. It renames the other pod that was also named 'aa' in case those somehow end up running in the same namespace, even though I did not prove that to be true.

We'll see if this helped at all :)

<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Relates to #829
