### PR TITLE
Fix deep copy and don't modify original state

### DIFF
--- a/pkg/controller/instance/plan_execution_engine_test.go
+++ b/pkg/controller/instance/plan_execution_engine_test.go
@@ -118,6 +118,37 @@ func TestExecutePlan(t *testing.T) {
 	}
 }
 
+func TestExecutePlanWithEnhancerError(t *testing.T) {
+	testClient := fake.NewFakeClientWithScheme(scheme.Scheme)
+	newStatus, err := executePlan(&activePlan{
+		name: "test",
+		PlanStatus: &v1alpha1.PlanStatus{
+			Status: v1alpha1.ExecutionPending,
+			Name:   "test",
+			Phases: []v1alpha1.PhaseStatus{{Name: "phase", Status: v1alpha1.ExecutionPending, Steps: []v1alpha1.StepStatus{{Status: v1alpha1.ExecutionPending, Name: "step"}}}},
+		},
+		spec: &v1alpha1.Plan{
+			Strategy: "serial",
+			Phases: []v1alpha1.Phase{
+				{Name: "phase", Strategy: "serial", Steps: []v1alpha1.Step{{Name: "step", Tasks: []string{"task"}}}},
+			},
+		},
+		tasks:     map[string]v1alpha1.TaskSpec{"task": {Resources: []string{"job"}}},
+		templates: map[string]string{"job": getResourceAsString(getJob("job1", "default"))},
+	}, &engineMetadata{
+		instanceName:        "Instance",
+		instanceNamespace:   "default",
+		operatorVersion:     "ov-1.0",
+		operatorName:        "operator",
+		resourcesOwner:      getJob("pod2", "default"),
+		operatorVersionName: "ovname",
+	}, testClient, &errKubernetesObjectEnhancer{})
+
+	if err == nil || newStatus == nil || newStatus.Status != v1alpha1.ErrorStatus || newStatus.Phases[0].Status != v1alpha1.ErrorStatus || newStatus.Phases[0].Steps[0].Status != v1alpha1.ErrorStatus {
+		t.Fatalf("Expecting to get an error with fatal error in status for error in using enhancer, got %w, %v", err, newStatus)
+	}
+}
+
 func getJob(name string, namespace string) *batchv1.Job {
 	job := &batchv1.Job{
 		TypeMeta: metav1.TypeMeta{
@@ -165,4 +196,10 @@ func (k *testKubernetesObjectEnhancer) applyConventionsToTemplates(templates map
 		result = append(result, objsToAdd[0])
 	}
 	return result, nil
+}
+
+type errKubernetesObjectEnhancer struct{}
+
+func (k *errKubernetesObjectEnhancer) applyConventionsToTemplates(templates map[string]string, metadata ExecutionMetadata) ([]runtime.Object, error) {
+	return nil, errors.New("Always error")
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kudo/blob/master/CONTRIBUTING.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kudobuilder/kudo/blob/master/RELEASE.md
3. Ensure you have added or ran the appropriate tests for your PR
4. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What this PR does / why we need it**:
Fixes two issues:
- we were using shallow copy and it was wrong because struct contains slices
- we modified the original state in `prepareKubernetesResources` which worked exactly because the shallow copy was a wrong choice but it's not what we want to do
