### PR TITLE
More consistent logging for install

### DIFF
--- a/pkg/kudoctl/cmd/install/install.go
+++ b/pkg/kudoctl/cmd/install/install.go
@@ -225,7 +225,7 @@ func installSingleOperatorToCluster(name, namespace string, o *v1alpha1.Operator
 	if _, err := kc.InstallOperatorObjToCluster(o, namespace); err != nil {
 		return errors.Wrapf(err, "installing %s-operator.yaml", name)
 	}
-	clog.Printf("operator.%s/%s created\n", o.APIVersion, o.Name)
+	clog.Printf("operator.%s/%s created", o.APIVersion, o.Name)
 	return nil
 }
 
@@ -235,7 +235,7 @@ func installSingleOperatorVersionToCluster(name, namespace string, kc *kudo.Clie
 	if _, err := kc.InstallOperatorVersionObjToCluster(ov, namespace); err != nil {
 		return errors.Wrapf(err, "installing %s-operatorversion.yaml", name)
 	}
-	clog.Printf("operatorversion.%s/%s created\n", ov.APIVersion, ov.Name)
+	clog.Printf("operatorversion.%s/%s created", ov.APIVersion, ov.Name)
 	return nil
 }
 
@@ -245,7 +245,7 @@ func installSingleInstanceToCluster(name string, instance *v1alpha1.Instance, kc
 	if _, err := kc.InstallInstanceObjToCluster(instance, settings.Namespace); err != nil {
 		return errors.Wrapf(err, "installing instance %s", name)
 	}
-	clog.Printf("instance.%s/%s created\n", instance.APIVersion, instance.Name)
+	clog.Printf("instance.%s/%s created", instance.APIVersion, instance.Name)
 	return nil
 }
 

--- a/pkg/kudoctl/cmd/install/install.go
+++ b/pkg/kudoctl/cmd/install/install.go
@@ -225,7 +225,7 @@ func installSingleOperatorToCluster(name, namespace string, o *v1alpha1.Operator
 	if _, err := kc.InstallOperatorObjToCluster(o, namespace); err != nil {
 		return errors.Wrapf(err, "installing %s-operator.yaml", name)
 	}
-	clog.V(2).Printf("operator.%s/%s created\n", o.APIVersion, o.Name)
+	clog.Printf("operator.%s/%s created\n", o.APIVersion, o.Name)
 	return nil
 }
 
@@ -235,7 +235,7 @@ func installSingleOperatorVersionToCluster(name, namespace string, kc *kudo.Clie
 	if _, err := kc.InstallOperatorVersionObjToCluster(ov, namespace); err != nil {
 		return errors.Wrapf(err, "installing %s-operatorversion.yaml", name)
 	}
-	clog.V(2).Printf("operatorversion.%s/%s created\n", ov.APIVersion, ov.Name)
+	clog.Printf("operatorversion.%s/%s created\n", ov.APIVersion, ov.Name)
 	return nil
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kudo/blob/master/CONTRIBUTING.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kudobuilder/kudo/blob/master/RELEASE.md
3. Ensure you have added or ran the appropriate tests for your PR
4. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What this PR does / why we need it**:
Before this change, we just printed out instance was created but we did not do that for the other CRDs which can be confusing.
```
./bin/kubectl-kudo install ./config/samples/first-operator
instance.kudo.dev/v1alpha1/first-operator-zljnmj created
```

After

```
./bin/kubectl-kudo install ./config/samples/first-operator
operator.kudo.dev/v1alpha1/first-operator created
operatorversion.kudo.dev/v1alpha1/first-operator-0.1.0 created
instance.kudo.dev/v1alpha1/first-operator-ztrwtp created
```
