### PR TITLE
Better logging for init

### DIFF
--- a/pkg/kudoctl/cmd/init.go
+++ b/pkg/kudoctl/cmd/init.go
@@ -184,7 +184,7 @@ func (initCmd *initCmd) run() error {
 		}
 
 		if initCmd.wait {
-			clog.V(4).Printf("waiting for kudo at server init")
+			clog.Printf("Waiting for KUDO controller to be ready in your cluster...")
 			finished := cmdInit.WatchKUDOUntilReady(initCmd.client.KubeClient, opts, initCmd.timeout)
 			if !finished {
 				return errors.New("watch timed out, readiness uncertain")

--- a/pkg/kudoctl/cmd/init.go
+++ b/pkg/kudoctl/cmd/init.go
@@ -184,7 +184,7 @@ func (initCmd *initCmd) run() error {
 		}
 
 		if initCmd.wait {
-			clog.Printf("Waiting for KUDO controller to be ready in your cluster...")
+			clog.Printf("⌛Waiting for KUDO controller to be ready in your cluster...")
 			finished := cmdInit.WatchKUDOUntilReady(initCmd.client.KubeClient, opts, initCmd.timeout)
 			if !finished {
 				return errors.New("watch timed out, readiness uncertain")

--- a/pkg/kudoctl/cmd/init/manager.go
+++ b/pkg/kudoctl/cmd/init/manager.go
@@ -66,7 +66,7 @@ func Install(client *kube.Client, opts Options, crdOnly bool) error {
 	if crdOnly {
 		return nil
 	}
-	clog.Printf("✓ installing prereqs")
+	clog.Printf("✅ installing prereqs")
 	if err := installPrereqs(client.KubeClient, opts); err != nil {
 		return err
 	}

--- a/pkg/kudoctl/cmd/init/manager.go
+++ b/pkg/kudoctl/cmd/init/manager.go
@@ -59,7 +59,7 @@ func NewOptions(v string) Options {
 // Install uses Kubernetes client to install KUDO.
 func Install(client *kube.Client, opts Options, crdOnly bool) error {
 
-	clog.Printf("installing crds")
+	clog.Printf("✓ installing crds")
 	if err := installCrds(client.ExtClient); err != nil {
 		return err
 	}

--- a/pkg/kudoctl/cmd/init/manager.go
+++ b/pkg/kudoctl/cmd/init/manager.go
@@ -71,7 +71,7 @@ func Install(client *kube.Client, opts Options, crdOnly bool) error {
 		return err
 	}
 
-	clog.Printf("✓ installing kudo controller")
+	clog.Printf("✅ installing kudo controller")
 	if err := installManager(client.KubeClient, opts); err != nil {
 		return err
 	}

--- a/pkg/kudoctl/cmd/init/manager.go
+++ b/pkg/kudoctl/cmd/init/manager.go
@@ -59,19 +59,19 @@ func NewOptions(v string) Options {
 // Install uses Kubernetes client to install KUDO.
 func Install(client *kube.Client, opts Options, crdOnly bool) error {
 
-	clog.Printf("✓ installing crds")
+	clog.Printf("✅  installing crds")
 	if err := installCrds(client.ExtClient); err != nil {
 		return err
 	}
 	if crdOnly {
 		return nil
 	}
-	clog.Printf("✅ installing prereqs")
+	clog.Printf("✅  preparing service accounts and other requirements for controller to run")
 	if err := installPrereqs(client.KubeClient, opts); err != nil {
 		return err
 	}
 
-	clog.Printf("✅ installing kudo controller")
+	clog.Printf("✅  installing kudo controller")
 	if err := installManager(client.KubeClient, opts); err != nil {
 		return err
 	}

--- a/pkg/kudoctl/cmd/init/manager.go
+++ b/pkg/kudoctl/cmd/init/manager.go
@@ -66,7 +66,7 @@ func Install(client *kube.Client, opts Options, crdOnly bool) error {
 	if crdOnly {
 		return nil
 	}
-	clog.Printf("installing prereqs")
+	clog.Printf("✓ installing prereqs")
 	if err := installPrereqs(client.KubeClient, opts); err != nil {
 		return err
 	}

--- a/pkg/kudoctl/cmd/init/manager.go
+++ b/pkg/kudoctl/cmd/init/manager.go
@@ -59,19 +59,19 @@ func NewOptions(v string) Options {
 // Install uses Kubernetes client to install KUDO.
 func Install(client *kube.Client, opts Options, crdOnly bool) error {
 
-	clog.Printf("✅  installing crds")
+	clog.Printf("✅ installing crds")
 	if err := installCrds(client.ExtClient); err != nil {
 		return err
 	}
 	if crdOnly {
 		return nil
 	}
-	clog.Printf("✅  preparing service accounts and other requirements for controller to run")
+	clog.Printf("✅ preparing service accounts and other requirements for controller to run")
 	if err := installPrereqs(client.KubeClient, opts); err != nil {
 		return err
 	}
 
-	clog.Printf("✅  installing kudo controller")
+	clog.Printf("✅ installing kudo controller")
 	if err := installManager(client.KubeClient, opts); err != nil {
 		return err
 	}

--- a/pkg/kudoctl/cmd/init/manager.go
+++ b/pkg/kudoctl/cmd/init/manager.go
@@ -59,19 +59,19 @@ func NewOptions(v string) Options {
 // Install uses Kubernetes client to install KUDO.
 func Install(client *kube.Client, opts Options, crdOnly bool) error {
 
-	clog.V(4).Printf("installing crds")
+	clog.Printf("installing crds")
 	if err := installCrds(client.ExtClient); err != nil {
 		return err
 	}
 	if crdOnly {
 		return nil
 	}
-	clog.V(4).Printf("installing prereqs")
+	clog.Printf("installing prereqs")
 	if err := installPrereqs(client.KubeClient, opts); err != nil {
 		return err
 	}
 
-	clog.V(4).Printf("installing kudo controller")
+	clog.Printf("installing kudo controller")
 	if err := installManager(client.KubeClient, opts); err != nil {
 		return err
 	}

--- a/pkg/kudoctl/cmd/init/manager.go
+++ b/pkg/kudoctl/cmd/init/manager.go
@@ -71,7 +71,7 @@ func Install(client *kube.Client, opts Options, crdOnly bool) error {
 		return err
 	}
 
-	clog.Printf("installing kudo controller")
+	clog.Printf("✓ installing kudo controller")
 	if err := installManager(client.KubeClient, opts); err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kudo/blob/master/CONTRIBUTING.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kudobuilder/kudo/blob/master/RELEASE.md
3. Ensure you have added or ran the appropriate tests for your PR
4. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What this PR does / why we need it**:
Right now when you run init and you're initializing the server side as well as local environment, the only thing the command prints out is that local was initialized. This PR adds more logging to make it obvious that server side is being initialized as well.

This is output of init before this change

```
➜  kudo git:(av/maintainers-array) ✗ ./bin/kubectl-kudo init
$KUDO_HOME has been configured at /Users/alenavarkockova/.kudo
```

After

```
➜  kudo git:(av/init-logging) ✗ ./bin/kubectl-kudo init
$KUDO_HOME has been configured at /Users/alenavarkockova/.kudo
✅ installing crds
✅ preparing service accounts and other requirements for controller to run
✅ installing kudo controller
```