### PR TITLE
Repo Configurations with Stringer for dereferencing in logs

### DIFF
--- a/pkg/kudoctl/cmd/repo_index.go
+++ b/pkg/kudoctl/cmd/repo_index.go
@@ -112,7 +112,6 @@ func (ri *repoIndexCmd) run() error {
 		if config == nil {
 			return fmt.Errorf("configuration for repositories does not contain %s", ri.urlRepoName)
 		}
-		fmt.Printf("url: %v", config.URL)
 		ri.url = config.URL
 	}
 
@@ -167,7 +166,6 @@ func merge(index *repo.IndexFile, mergeIndex *repo.IndexFile) {
 
 func (ri *repoIndexCmd) mergeRepoConfig() (*repo.Configuration, error) {
 	if ri.mergeRepoName != "" {
-		fmt.Printf("repo name %q\n", ri.mergeRepoName)
 		return ri.repoConfig(ri.mergeRepoName)
 	}
 

--- a/pkg/kudoctl/util/repo/repo.go
+++ b/pkg/kudoctl/util/repo/repo.go
@@ -70,7 +70,6 @@ func NewRepositories() *Repositories {
 
 // GetConfiguration returns a RepoName Config for a name or nil
 func (r *Repositories) GetConfiguration(name string) *Configuration {
-	fmt.Printf("%v\n", r.Repositories)
 	for _, repo := range r.Repositories {
 		if repo.Name == name {
 			return repo

--- a/pkg/kudoctl/util/repo/repo.go
+++ b/pkg/kudoctl/util/repo/repo.go
@@ -28,11 +28,29 @@ type Configuration struct {
 	Name string `json:"name"`
 }
 
+// Configurations is a collection of Configuration for Stringer
+type Configurations []*Configuration
+
 // Repositories represents the repositories.yaml file usually in the $KUDO_HOME
 type Repositories struct {
-	RepoVersion  string           `json:"repoVersion"`
-	Context      string           `json:"context"`
-	Repositories []*Configuration `json:"repositories"`
+	RepoVersion  string         `json:"repoVersion"`
+	Context      string         `json:"context"`
+	Repositories Configurations `json:"repositories"`
+}
+
+// String is a stringer function for Configuration
+func (c *Configuration) String() string {
+	return fmt.Sprintf("{ name:%v, url:%v }", c.Name, c.URL)
+}
+
+// String is a stringer function for Configurations
+func (c Configurations) String() string {
+	s := "repo configs: "
+	for _, config := range c {
+		s = fmt.Sprintf("%v %v,", s, config)
+	}
+
+	return s
 }
 
 // Default initialized repository.


### PR DESCRIPTION

**What this PR does / why we need it**:
Repo Configurations with Stringer for dereferencing in logs

Fixes #928 
