### PR TITLE
Handle already exists in flaky test

### DIFF
--- a/pkg/test/step_integration_test.go
+++ b/pkg/test/step_integration_test.go
@@ -234,7 +234,11 @@ func TestCheckResourceIntegration(t *testing.T) {
 		t.Run(test.testName, func(t *testing.T) {
 			namespace := fmt.Sprintf("kudo-test-%s", petname.Generate(2, "-"))
 
-			assert.Nil(t, testenv.Client.Create(context.TODO(), testutils.NewResource("v1", "Namespace", namespace, "")))
+			err := testenv.Client.Create(context.TODO(), testutils.NewResource("v1", "Namespace", namespace, ""))
+			if !k8serrors.IsAlreadyExists(err) {
+				// we are ignoring already exists here because in tests we by default use retry client so this can happen
+				assert.Nil(t, err)
+			}
 
 			for _, actual := range test.actual {
 				_, _, err := testutils.Namespaced(testenv.DiscoveryClient, actual, namespace)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kudo/blob/master/CONTRIBUTING.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kudobuilder/kudo/blob/master/RELEASE.md
3. Ensure you have added or ran the appropriate tests for your PR
4. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What this PR does / why we need it**:
This is another attempt to fix this flaky test. I believe this one has better chance of succeeding :)

As I found out, we're using retry client in tests (whether it's right or not, I started a discussion in kudo channel). Anyway since that is the case right now, create can be retried and run two times so hitting already exists can happen.

<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #829 
