### PR TITLE
Fix flaky GetLastExecutedPlanStatus

### DIFF
--- a/pkg/apis/kudo/v1alpha1/instance_types.go
+++ b/pkg/apis/kudo/v1alpha1/instance_types.go
@@ -159,7 +159,8 @@ func (i *Instance) GetLastExecutedPlanStatus() *PlanStatus {
 		return activePlan
 	}
 	var lastExecutedPlan *PlanStatus
-	for _, p := range i.Status.PlanStatus {
+	for n, _ := range i.Status.PlanStatus {
+		p := i.Status.PlanStatus[n]
 		if p.Status == ExecutionNeverRun {
 			continue // only interested in plans that run
 		}
@@ -177,7 +178,7 @@ func wasRunAfter(p1 PlanStatus, p2 PlanStatus) bool {
 	if p1.Status == ExecutionNeverRun || p2.Status == ExecutionNeverRun {
 		return false
 	}
-	return !p1.LastFinishedRun.Before(&p2.LastFinishedRun)
+	return p1.LastFinishedRun.Time.After(p2.LastFinishedRun.Time)
 }
 
 // NoPlanEverExecuted returns true is this is new instance for which we never executed any plan

--- a/pkg/apis/kudo/v1alpha1/instance_types.go
+++ b/pkg/apis/kudo/v1alpha1/instance_types.go
@@ -159,7 +159,7 @@ func (i *Instance) GetLastExecutedPlanStatus() *PlanStatus {
 		return activePlan
 	}
 	var lastExecutedPlan *PlanStatus
-	for n, _ := range i.Status.PlanStatus {
+	for n := range i.Status.PlanStatus {
 		p := i.Status.PlanStatus[n]
 		if p.Status == ExecutionNeverRun {
 			continue // only interested in plans that run

--- a/pkg/apis/kudo/v1alpha1/instance_types_test.go
+++ b/pkg/apis/kudo/v1alpha1/instance_types_test.go
@@ -23,6 +23,8 @@ import (
 )
 
 func TestGetLastExecutedPlanStatus(t *testing.T) {
+	testTime := time.Date(
+		2019, 10, 17, 1, 1, 1, 1, time.UTC)
 	tests := []struct {
 		name             string
 		planStatus       map[string]PlanStatus
@@ -48,13 +50,13 @@ func TestGetLastExecutedPlanStatus(t *testing.T) {
 			"test": {
 				Status:          ExecutionComplete,
 				Name:            "test",
-				LastFinishedRun: v1.Time{Time: time.Now()},
+				LastFinishedRun: v1.Time{Time: testTime},
 				Phases:          []PhaseStatus{{Name: "phase", Status: ExecutionComplete, Steps: []StepStatus{{Status: ExecutionComplete, Name: "step"}}}},
 			},
 			"test2": {
 				Status:          ExecutionComplete,
 				Name:            "test2",
-				LastFinishedRun: v1.Time{Time: time.Now().Add(time.Hour)},
+				LastFinishedRun: v1.Time{Time: testTime.Add(time.Hour)},
 				Phases:          []PhaseStatus{{Name: "phase", Status: ExecutionComplete, Steps: []StepStatus{{Status: ExecutionComplete, Name: "step"}}}},
 			}}, "test2"},
 	}

--- a/pkg/controller/instance/instance_controller_test.go
+++ b/pkg/controller/instance/instance_controller_test.go
@@ -26,9 +26,9 @@ const tick = time.Millisecond * 500
 func TestRestartController(t *testing.T) {
 	stopMgr, mgrStopped, c := startTestManager(t)
 
-	log.Printf("Given an existing instance 'restart-instance' and operator 'foo-operator'")
+	log.Printf("Given an existing instance 'foo-instance' and operator 'foo-operator'")
 	in := &v1alpha1.Instance{
-		ObjectMeta: metav1.ObjectMeta{Name: "restart-instance", Namespace: "default", Labels: map[string]string{kudo.OperatorLabel: "foo-operator"}},
+		ObjectMeta: metav1.ObjectMeta{Name: "foo-instance", Namespace: "default", Labels: map[string]string{kudo.OperatorLabel: "foo-operator"}},
 		Spec: v1alpha1.InstanceSpec{
 			OperatorVersion: v1.ObjectReference{
 				Name:      "foo-operator",

--- a/pkg/controller/instance/instance_controller_test.go
+++ b/pkg/controller/instance/instance_controller_test.go
@@ -26,9 +26,9 @@ const tick = time.Millisecond * 500
 func TestRestartController(t *testing.T) {
 	stopMgr, mgrStopped, c := startTestManager(t)
 
-	log.Printf("Given an existing instance 'foo-instance' and operator 'foo-operator'")
+	log.Printf("Given an existing instance 'restart-instance' and operator 'foo-operator'")
 	in := &v1alpha1.Instance{
-		ObjectMeta: metav1.ObjectMeta{Name: "foo-instance", Namespace: "default", Labels: map[string]string{kudo.OperatorLabel: "foo-operator"}},
+		ObjectMeta: metav1.ObjectMeta{Name: "restart-instance", Namespace: "default", Labels: map[string]string{kudo.OperatorLabel: "foo-operator"}},
 		Spec: v1alpha1.InstanceSpec{
 			OperatorVersion: v1.ObjectReference{
 				Name:      "foo-operator",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kudo/blob/master/CONTRIBUTING.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kudobuilder/kudo/blob/master/RELEASE.md
3. Ensure you have added or ran the appropriate tests for your PR
4. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What this PR does / why we need it**:
🤦‍♀ pointers in for-cycle. Again.

Look at like 167, where I take pointer of p. Then in the second iteration I was comparing p and lastExecuted, which was &p which was the same thing.

<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #947
