### PR TITLE
Make Instance name deterministic

### DIFF
--- a/pkg/kudoctl/cmd/install.go
+++ b/pkg/kudoctl/cmd/install.go
@@ -50,10 +50,10 @@ func newInstallCmd(fs afero.Fs) *cobra.Command {
 		},
 	}
 
-	installCmd.Flags().StringVar(&options.InstanceName, "instance", "", "The instance name. (defaults to operator name plus some random string)")
+	installCmd.Flags().StringVar(&options.InstanceName, "instance", "", "The Instance name. (defaults to Operator name appended with -instance)")
 	installCmd.Flags().StringArrayVarP(&parameters, "parameter", "p", nil, "The parameter name and value separated by '='")
 	installCmd.Flags().StringVar(&options.RepoName, "repo", "", "Name of repository configuration to use. (default defined by context)")
 	installCmd.Flags().StringVar(&options.PackageVersion, "version", "", "A specific package version on the official GitHub repo. (default to the most recent)")
-	installCmd.Flags().BoolVar(&options.SkipInstance, "skip-instance", false, "If set, install will install the Operator and OperatorVersion, but not an instance. (default \"false\")")
+	installCmd.Flags().BoolVar(&options.SkipInstance, "skip-instance", false, "If set, install will install the Operator and OperatorVersion, but not an Instance. (default \"false\")")
 	return installCmd
 }

--- a/pkg/kudoctl/packages/package.go
+++ b/pkg/kudoctl/packages/package.go
@@ -19,7 +19,6 @@ import (
 	"github.com/spf13/afero"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/rand"
 	"sigs.k8s.io/yaml"
 )
 
@@ -224,7 +223,7 @@ func (p *PackageFiles) getCRDs() (*PackageCRDs, error) {
 			APIVersion: apiVersion,
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   fmt.Sprintf("%s-%s", p.Operator.Name, rand.String(6)),
+			Name:   fmt.Sprintf("%s-instance", p.Operator.Name),
 			Labels: map[string]string{"controller-tools.k8s.io": "1.0", kudo.OperatorLabel: p.Operator.Name},
 		},
 		Spec: v1alpha1.InstanceSpec{

--- a/pkg/kudoctl/packages/package_test.go
+++ b/pkg/kudoctl/packages/package_test.go
@@ -9,8 +9,6 @@ import (
 	"strings"
 	"testing"
 
-	"k8s.io/apimachinery/pkg/util/rand"
-
 	"github.com/go-test/deep"
 	"github.com/kudobuilder/kudo/pkg/apis/kudo/v1alpha1"
 	"github.com/pkg/errors"
@@ -19,17 +17,14 @@ import (
 )
 
 func TestReadFileSystemPackage(t *testing.T) {
-	// Set Kubernetes random seed for deterministic test results on the name
-	rand.Seed(1)
-
 	tests := []struct {
 		name         string
 		instanceName string
 		path         string
 		goldenFiles  string
 	}{
-		{"zookeeper", "zookeeper-xn8fg", "testdata/zk", "testdata/zk-crd-golden1"},
-		{"zookeeper", "zookeeper-txhzt", "testdata/zk.tgz", "testdata/zk-crd-golden2"},
+		{"zookeeper", "zk1", "testdata/zk", "testdata/zk-crd-golden1"},
+		{"zookeeper", "zk2", "testdata/zk.tgz", "testdata/zk-crd-golden2"},
 	}
 	var fs = afero.NewOsFs()
 

--- a/pkg/kudoctl/packages/testdata/zk-crd-golden1/instance.golden
+++ b/pkg/kudoctl/packages/testdata/zk-crd-golden1/instance.golden
@@ -4,7 +4,7 @@ metadata:
   labels:
     controller-tools.k8s.io: "1.0"
     kudo.dev/operator: zookeeper
-  name: zookeeper-xn8fg
+  name: zk1
 spec:
   operatorVersion:
     name: zookeeper-0.1.0

--- a/pkg/kudoctl/packages/testdata/zk-crd-golden2/instance.golden
+++ b/pkg/kudoctl/packages/testdata/zk-crd-golden2/instance.golden
@@ -4,7 +4,7 @@ metadata:
   labels:
     controller-tools.k8s.io: "1.0"
     kudo.dev/operator: zookeeper
-  name: zookeeper-txhzt
+  name: zk2
 spec:
   operatorVersion:
     name: zookeeper-0.1.0


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove the random string suffixed onto the end of instance names, instead using a suffix of 
`-instance`.  Users can use the `--instance` option to provide a unique name if they so wish.

Fixes #948 
