### PR TITLE
Fix plan history bug

### DIFF
--- a/pkg/kudoctl/cmd/plan/plan_history.go
+++ b/pkg/kudoctl/cmd/plan/plan_history.go
@@ -57,7 +57,7 @@ func planHistory(options *Options, settings *env.Settings) error {
 
 		if !p.LastFinishedRun.IsZero() { // plan already finished
 			t := p.LastFinishedRun.Format(timeLayout)
-			msg = fmt.Sprintf("last run at %s", t)
+			msg = fmt.Sprintf("last finished run at %s (%s)", t, string(p.Status))
 		} else if p.Status.IsRunning() {
 			msg = "is running"
 		} else if p.Status != "" {

--- a/pkg/kudoctl/cmd/plan/plan_history.go
+++ b/pkg/kudoctl/cmd/plan/plan_history.go
@@ -3,10 +3,8 @@ package plan
 import (
 	"fmt"
 
-	"github.com/kudobuilder/kudo/pkg/kudoctl/util/kudo"
-	"k8s.io/apimachinery/pkg/api/errors"
-
 	"github.com/kudobuilder/kudo/pkg/kudoctl/env"
+	"github.com/kudobuilder/kudo/pkg/kudoctl/util/kudo"
 	"github.com/spf13/cobra"
 	"github.com/xlab/treeprint"
 )
@@ -44,23 +42,26 @@ func planHistory(options *Options, settings *env.Settings) error {
 		return err
 	}
 	instance, err := kc.GetInstance(options.Instance, namespace)
-	if errors.IsNotFound(err) {
-		fmt.Printf("Instance %s/%s does not exist", instance.Namespace, instance.Name)
-	}
 	if err != nil {
 		return err
+	}
+	if instance == nil {
+		return fmt.Errorf("instance %s/%s does not exist", options.Instance, namespace)
 	}
 
 	tree := treeprint.New()
 	timeLayout := "2006-01-02"
 
 	for _, p := range instance.Status.PlanStatus {
-		msg := "never run"
-		if p.Status != "" && !p.LastFinishedRun.IsZero() { // plan already finished
+		msg := "never run" // this is for the cases when status was not yet populated
+
+		if !p.LastFinishedRun.IsZero() { // plan already finished
 			t := p.LastFinishedRun.Format(timeLayout)
 			msg = fmt.Sprintf("last run at %s", t)
 		} else if p.Status.IsRunning() {
 			msg = "is running"
+		} else if p.Status != "" {
+			msg = string(p.Status)
 		}
 		historyDisplay := fmt.Sprintf("%s (%s)", p.Name, msg)
 		tree.AddBranch(historyDisplay)

--- a/pkg/kudoctl/cmd/plan/plan_history.go
+++ b/pkg/kudoctl/cmd/plan/plan_history.go
@@ -46,11 +46,11 @@ func planHistory(options *Options, settings *env.Settings) error {
 		return err
 	}
 	if instance == nil {
-		return fmt.Errorf("instance %s/%s does not exist", options.Instance, namespace)
+		return fmt.Errorf("instance %s/%s does not exist", namespace, options.Instance)
 	}
 
 	tree := treeprint.New()
-	timeLayout := "2006-01-02"
+	timeLayout := "2006-01-02T15:04:05"
 
 	for _, p := range instance.Status.PlanStatus {
 		msg := "never run" // this is for the cases when status was not yet populated


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kudo/blob/master/CONTRIBUTING.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kudobuilder/kudo/blob/master/RELEASE.md
3. Ensure you have added or ran the appropriate tests for your PR
4. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What this PR does / why we need it**:
This fixes a bug in reporting of history for non-existent instances and also polishes the output.

```
kudo git:(av/plan-history-fix) ✗ ./bin/kubectl-kudo plan history --instance nonexistent
Error: client Error: instance default/nonexistent does not exist
```

```
 kudo git:(av/plan-history-fix) ✗ ./bin/kubectl-kudo plan history --instance first
.
└── deploy (last finished run at 2019-10-17T14:11:14 (COMPLETE))
```

<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #915 #940
