### PR TITLE
User-configurable request timeouts

### DIFF
--- a/pkg/kudoctl/cmd/get/get.go
+++ b/pkg/kudoctl/cmd/get/get.go
@@ -19,7 +19,7 @@ func Run(args []string, settings *env.Settings) error {
 		return err
 	}
 
-	kc, err := kudo.NewClient(settings.Namespace, settings.KubeConfig)
+	kc, err := env.GetClient(settings)
 	if err != nil {
 		return errors.Wrap(err, "creating kudo client")
 	}

--- a/pkg/kudoctl/cmd/install/install.go
+++ b/pkg/kudoctl/cmd/install/install.go
@@ -29,6 +29,7 @@ type Options struct {
 	Parameters     map[string]string
 	PackageVersion string
 	SkipInstance   bool
+	RequestTimeout int64
 }
 
 // DefaultOptions initializes the install command options to its defaults
@@ -102,7 +103,7 @@ func installOperator(operatorArgument string, options *Options, fs afero.Fs, set
 	}
 	clog.V(4).Printf("repository used %s", repository)
 
-	kc, err := kudo.NewClient(settings.Namespace, settings.KubeConfig)
+	kc, err := env.GetClient(settings)
 	clog.V(3).Printf("acquiring kudo client")
 	if err != nil {
 		clog.V(3).Printf("failed to acquire client")

--- a/pkg/kudoctl/cmd/plan/plan_history.go
+++ b/pkg/kudoctl/cmd/plan/plan_history.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/kudobuilder/kudo/pkg/kudoctl/env"
-	"github.com/kudobuilder/kudo/pkg/kudoctl/util/kudo"
 	"github.com/spf13/cobra"
 	"github.com/xlab/treeprint"
 )
@@ -36,7 +35,7 @@ func RunHistory(cmd *cobra.Command, options *Options, settings *env.Settings) er
 func planHistory(options *Options, settings *env.Settings) error {
 	namespace := settings.Namespace
 
-	kc, err := kudo.NewClient(settings.Namespace, settings.KubeConfig)
+	kc, err := env.GetClient(settings)
 	if err != nil {
 		fmt.Printf("Unable to create kudo client to talk to kubernetes API server %v", err)
 		return err

--- a/pkg/kudoctl/cmd/uninstall.go
+++ b/pkg/kudoctl/cmd/uninstall.go
@@ -21,7 +21,7 @@ type uninstallOptions struct {
 type uninstallCmd struct{}
 
 func (cmd *uninstallCmd) run(options uninstallOptions, settings *env.Settings) error {
-	kc, err := kudo.NewClient(settings.Namespace, settings.KubeConfig)
+	kc, err := env.GetClient(settings)
 	clog.V(3).Printf("acquiring kudo client")
 	if err != nil {
 		clog.V(3).Printf("failed to acquire kudo client: %v", err)

--- a/pkg/kudoctl/cmd/update.go
+++ b/pkg/kudoctl/cmd/update.go
@@ -76,7 +76,7 @@ func runUpdate(args []string, options *updateOptions, settings *env.Settings) er
 	}
 	instanceToUpdate := options.InstanceName
 
-	kc, err := kudo.NewClient(settings.Namespace, settings.KubeConfig)
+	kc, err := env.GetClient(settings)
 	if err != nil {
 		return errors.Wrap(err, "creating kudo client")
 	}

--- a/pkg/kudoctl/cmd/upgrade.go
+++ b/pkg/kudoctl/cmd/upgrade.go
@@ -86,7 +86,7 @@ func runUpgrade(args []string, options *options, fs afero.Fs, settings *env.Sett
 	}
 	packageToUpgrade := args[0]
 
-	kc, err := kudo.NewClient(settings.Namespace, settings.KubeConfig)
+	kc, err := env.GetClient(settings)
 	if err != nil {
 		return errors.Wrap(err, "creating kudo client")
 	}

--- a/pkg/kudoctl/env/environment.go
+++ b/pkg/kudoctl/env/environment.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 
 	"github.com/kudobuilder/kudo/pkg/kudoctl/kudohome"
+	"github.com/kudobuilder/kudo/pkg/kudoctl/util/kudo"
 
 	"github.com/spf13/pflag"
 	"k8s.io/client-go/util/homedir"
@@ -21,11 +22,14 @@ type Settings struct {
 	Home kudohome.Home
 	// Namespace used when working with Kubernetes
 	Namespace string
+	// RequestTimeout is the timeout value (in seconds) when making API calls via the KUDO client
+	RequestTimeout int64
 }
 
 // DefaultSettings initializes the settings to its defaults
 var DefaultSettings = &Settings{
-	Namespace: "default",
+	Namespace:      "default",
+	RequestTimeout: 0,
 }
 
 // envMap maps flag names to envvars
@@ -39,6 +43,7 @@ func (s *Settings) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar((*string)(&s.Home), "home", DefaultKudoHome, "location of your KUDO config.")
 	fs.StringVar(&s.KubeConfig, "kubeconfig", os.Getenv("HOME")+"/.kube/config", "Path to your Kubernetes configuration file.")
 	fs.StringVarP(&s.Namespace, "namespace", "n", "default", "Target namespace for the object.")
+	fs.Int64Var(&s.RequestTimeout, "request-timeout", 0, "Request timeout value, in seconds.  Defaults to 0 (unlimited)")
 }
 
 // Init sets values from the environment.
@@ -61,4 +66,9 @@ func setFlagFromEnv(name, envar string, fs *pflag.FlagSet) {
 			panic(err)
 		}
 	}
+}
+
+// GetClient is a helper function that takes the Settings struct and returns a new KUDO Client
+func GetClient(s *Settings) (*kudo.Client, error) {
+	return kudo.NewClient(s.Namespace, s.KubeConfig, s.RequestTimeout)
 }

--- a/pkg/kudoctl/env/environment_test.go
+++ b/pkg/kudoctl/env/environment_test.go
@@ -19,7 +19,8 @@ func TestEnvSettings(t *testing.T) {
 		envars map[string]string
 
 		// expected values
-		home, kconfig string
+		home, kconfig  string
+		requesttimeout int64
 	}{
 		{
 			name:    "defaults",
@@ -46,6 +47,13 @@ func TestEnvSettings(t *testing.T) {
 			envars:  map[string]string{"KUDO_HOME": "/bar", "KUBECONFIG": "/foo"},
 			home:    "/foo",
 			kconfig: "/bar",
+		},
+		{
+			name:           "with request timeout set",
+			args:           []string{"--request-timeout", "5"},
+			home:           DefaultKudoHome,
+			kconfig:        os.Getenv("HOME") + "/.kube/config",
+			requesttimeout: 5,
 		},
 	}
 
@@ -77,7 +85,9 @@ func TestEnvSettings(t *testing.T) {
 			if settings.KubeConfig != tt.kconfig {
 				t.Errorf("expected kubeconfig %q, got %q", tt.kconfig, settings.KubeConfig)
 			}
-
+			if settings.RequestTimeout != tt.requesttimeout {
+				t.Errorf("expected request-timeout %d, got %d", tt.requesttimeout, settings.RequestTimeout)
+			}
 			resetEnv(tt.envars)
 		})
 	}

--- a/pkg/kudoctl/util/kudo/kudo.go
+++ b/pkg/kudoctl/util/kudo/kudo.go
@@ -30,7 +30,7 @@ type Client struct {
 }
 
 // NewClient creates new KUDO Client
-func NewClient(namespace, kubeConfigPath string) (*Client, error) {
+func NewClient(namespace, kubeConfigPath string, requestTimeout int64) (*Client, error) {
 
 	// use the current context in kubeconfig
 	config, err := clientcmd.BuildConfigFromFlags("", kubeConfigPath)
@@ -39,7 +39,7 @@ func NewClient(namespace, kubeConfigPath string) (*Client, error) {
 	}
 
 	// set default configs
-	config.Timeout = time.Second * 3
+	config.Timeout = time.Duration(requestTimeout) * time.Second
 
 	// create the clientset
 	kudoClientset, err := versioned.NewForConfig(config)

--- a/pkg/kudoctl/util/kudo/kudo_test.go
+++ b/pkg/kudoctl/util/kudo/kudo_test.go
@@ -27,7 +27,7 @@ func TestNewK2oClient(t *testing.T) {
 
 	for _, tt := range tests {
 		// Just interested in errors
-		_, err := NewClient("default", "")
+		_, err := NewClient("default", "", 0)
 		if err.Error() != tt.err {
 			t.Errorf("non existing test:\nexpected: %v\n     got: %v", tt.err, err.Error())
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
Add an option (`--request-timeout`) to allow the user to specify the KUDO client's request
timeout.  The hardcoded default of 3 seconds causes problems for users whose connectivity to a target service involves relatively significant amounts of latency. 

Mirror the behaviour of `kubectl` by copying the option itself and setting this to by default to 0 (no timeout).

Fixes #955 
