### PR TITLE
Remove error-wrapping from log messages

### DIFF
--- a/pkg/controller/instance/instance_controller_test.go
+++ b/pkg/controller/instance/instance_controller_test.go
@@ -84,7 +84,7 @@ func instancePlanFinished(key client.ObjectKey, planName string, c client.Client
 	i := &v1alpha1.Instance{}
 	err := c.Get(context.TODO(), key, i)
 	if err != nil {
-		fmt.Printf("%w", err)
+		fmt.Printf("%v", err)
 		return false
 	}
 	return i.Status.PlanStatus[planName].Status.IsFinished()

--- a/pkg/kudoctl/cmd/plan/plan_history.go
+++ b/pkg/kudoctl/cmd/plan/plan_history.go
@@ -38,7 +38,7 @@ func planHistory(options *Options, settings *env.Settings) error {
 
 	kc, err := kudo.NewClient(settings.Namespace, settings.KubeConfig)
 	if err != nil {
-		fmt.Printf("Unable to create kudo client to talk to kubernetes API server %w", err)
+		fmt.Printf("Unable to create kudo client to talk to kubernetes API server %v", err)
 		return err
 	}
 	instance, err := kc.GetInstance(options.Instance, namespace)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kudo/blob/master/CONTRIBUTING.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kudobuilder/kudo/blob/master/RELEASE.md
3. Ensure you have added or ran the appropriate tests for your PR
4. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What this PR does / why we need it**:
Wrapping errors in log messages results in structs showing up in the printed
text. Instead of '%w', '%v' is used instead which gives the expected results.

<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #940
