### PR TITLE
Fix e2e-tests

### DIFF
--- a/hack/run-e2e-tests.sh
+++ b/hack/run-e2e-tests.sh
@@ -16,6 +16,8 @@ then
 
 	rm -rf operators
 	git clone https://github.com/kudobuilder/operators
+	# KUDO e2e tests are executed against operators dev branch, which is held compatible with KUDOs bleeding edge
+	git checkout ad/tasker
 	mkdir operators/bin/
 	cp ./bin/kubectl-kudo operators/bin/
 	cd operators && go run ../cmd/kubectl-kudo test 2>&1 |tee /dev/fd/2 |go-junit-report -set-exit-code > ../reports/kudo_operators_test_report.xml

--- a/hack/run-e2e-tests.sh
+++ b/hack/run-e2e-tests.sh
@@ -16,7 +16,7 @@ then
 
 	rm -rf operators
 	# KUDO e2e tests are executed against operators dev branch, which is held compatible with KUDOs bleeding edge
-	git clone --branch ad/tasker https://github.com/kudobuilder/operators
+	git clone --branch dev https://github.com/kudobuilder/operators
 	mkdir operators/bin/
 	cp ./bin/kubectl-kudo operators/bin/
 	cd operators && go run ../cmd/kubectl-kudo test 2>&1 |tee /dev/fd/2 |go-junit-report -set-exit-code > ../reports/kudo_operators_test_report.xml
@@ -26,7 +26,7 @@ else
     go run ./cmd/kubectl-kudo test --config kudo-e2e-test.yaml
 
 	rm -rf operators
-	git clone --branch ad/tasker https://github.com/kudobuilder/operators
+	git clone --branch dev https://github.com/kudobuilder/operators
 	mkdir operators/bin/
 	cp ./bin/kubectl-kudo operators/bin/
 	cd operators && go run ../cmd/kubectl-kudo test

--- a/hack/run-e2e-tests.sh
+++ b/hack/run-e2e-tests.sh
@@ -15,9 +15,8 @@ then
     go run ./cmd/kubectl-kudo test --config kudo-e2e-test.yaml 2>&1 |tee /dev/fd/2 |go-junit-report -set-exit-code > reports/kudo_e2e_test_report.xml
 
 	rm -rf operators
-	git clone https://github.com/kudobuilder/operators
 	# KUDO e2e tests are executed against operators dev branch, which is held compatible with KUDOs bleeding edge
-	git checkout ad/tasker
+	git clone --branch ad/tasker https://github.com/kudobuilder/operators
 	mkdir operators/bin/
 	cp ./bin/kubectl-kudo operators/bin/
 	cd operators && go run ../cmd/kubectl-kudo test 2>&1 |tee /dev/fd/2 |go-junit-report -set-exit-code > ../reports/kudo_operators_test_report.xml
@@ -27,7 +26,7 @@ else
     go run ./cmd/kubectl-kudo test --config kudo-e2e-test.yaml
 
 	rm -rf operators
-	git clone https://github.com/kudobuilder/operators
+	git clone --branch ad/tasker https://github.com/kudobuilder/operators
 	mkdir operators/bin/
 	cp ./bin/kubectl-kudo operators/bin/
 	cd operators && go run ../cmd/kubectl-kudo test


### PR DESCRIPTION
by running them against the `dev` branch of the operators repo which is held compatible with KUDOs bleeding-edge development including breaking API changes etc.
