### PR TITLE
Fix `make generate` on clean repository

### DIFF
--- a/hack/update_codegen.sh
+++ b/hack/update_codegen.sh
@@ -15,7 +15,7 @@ if [ -d "$CODE_GEN_DIR" ]; then
     echo "Using cached code generator version: $VERSION"
 else
     git clone https://github.com/kubernetes/code-generator.git "${CODE_GEN_DIR}"
-    cd "${CODE_GEN_DIR}" && git reset --hard "${VERSION}" && go mod init
+    cd "${CODE_GEN_DIR}" && git reset --hard "${VERSION}" && go mod init && cd -
 fi
 
 "${CODE_GEN_DIR}"/generate-groups.sh \


### PR DESCRIPTION
**What this PR does / why we need it**:

Running `make generate` on freshly cloned repo results in error. Running `make generate` second time works fine.

Steps to reproduce:

1. Clone the repo

2. Run `make generate`

```bash
❯ make generate
./hack/update_codegen.sh
Cloning into 'hack/code-gen/c2090bec4d9b'...
remote: Enumerating objects: 185, done.
remote: Counting objects: 100% (185/185), done.
remote: Compressing objects: 100% (125/125), done.
remote: Total 7425 (delta 86), reused 137 (delta 56), pack-reused 7240
Receiving objects: 100% (7425/7425), 4.40 MiB | 2.11 MiB/s, done.
Resolving deltas: 100% (3615/3615), done.
HEAD is now at c2090be Merge remote-tracking branch 'origin/master' into release-1.13
go: creating new go.mod: module k8s.io/code-generator
go: copying requirements from Godeps/Godeps.json
./hack/update_codegen.sh: line 22: hack/code-gen/c2090bec4d9b/generate-groups.sh: No such file or directory
make: *** [generate] Error 127
```

This commit fixes the issue by `cd`-ing back to the working directory.