### PR TITLE
init: handle only "kudo-system" namespace

### DIFF
--- a/pkg/kudoctl/cmd/init_integration_test.go
+++ b/pkg/kudoctl/cmd/init_integration_test.go
@@ -18,6 +18,7 @@ import (
 	testutils "github.com/kudobuilder/kudo/pkg/test/utils"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -103,8 +104,20 @@ func TestIntegInitWithNameSpace(t *testing.T) {
 		client: kclient,
 		ns:     namespace,
 	}
+
+	// On first attempt, the namespace does not exist, so the error is expected.
 	err = cmd.run()
-	assert.Nil(t, err)
+	require.Error(t, err)
+	assert.Equal(t, err.Error(), `error installing: namespace integration-test does not exist - KUDO expects that any namespace except the default kudo-system is created beforehand`)
+
+	// Then we manually create the namespace.
+	ns := testutils.NewResource("v1", "Namespace", namespace, "")
+	assert.NoError(t, testClient.Create(context.TODO(), ns))
+	defer testClient.Delete(context.TODO(), ns)
+
+	// On second attempt run should succeed.
+	err = cmd.run()
+	assert.NoError(t, err)
 
 	// WaitForCRDs to be created... the init cmd did NOT wait
 	assert.Nil(t, testutils.WaitForCRDs(testenv.DiscoveryClient, crds))

--- a/pkg/kudoctl/cmd/testdata/deploy-kudo-ns-default.yaml.golden
+++ b/pkg/kudoctl/cmd/testdata/deploy-kudo-ns-default.yaml.golden
@@ -1,0 +1,325 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  labels:
+    app: kudo-manager
+    controller-tools.k8s.io: "1.0"
+  name: operators.kudo.dev
+spec:
+  group: kudo.dev
+  names:
+    kind: Operator
+    plural: operators
+    singular: operator
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        meta:
+          type: object
+        spec:
+          properties:
+            description:
+              type: string
+            kubernetesVersion:
+              type: string
+            kudoVersion:
+              type: string
+            maintainers:
+              items:
+                properties:
+                  email:
+                    type: string
+                  name:
+                    type: string
+                type: object
+              type: array
+            url:
+              type: string
+          type: object
+        status:
+          type: object
+      type: object
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  labels:
+    app: kudo-manager
+    controller-tools.k8s.io: "1.0"
+  name: operatorversions.kudo.dev
+spec:
+  group: kudo.dev
+  names:
+    kind: OperatorVersion
+    plural: operatorversions
+    singular: operatorversion
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        meta:
+          type: object
+        spec:
+          properties:
+            connectionString:
+              description: ConnectionString defines a mustached string that can be
+                used to connect to an instance of the Operator
+              type: string
+            crdVersion:
+              type: string
+            operator:
+              type: object
+            parameters:
+              items:
+                properties:
+                  default:
+                    description: Default is a default value if no parameter is provided
+                      by the instance
+                    type: string
+                  description:
+                    description: Description captures a longer description of how
+                      the variable will be used
+                    type: string
+                  displayName:
+                    description: Human friendly crdVersion of the parameter name
+                    type: string
+                  name:
+                    description: 'Name is the string that should be used in the template
+                      file for example, if `name: COUNT` then using the variable `.Params.COUNT`'
+                    type: string
+                  required:
+                    description: Required specifies if the parameter is required to
+                      be provided by all instances, or whether a default can suffice
+                    type: boolean
+                  trigger:
+                    description: Trigger identifies the plan that gets executed when
+                      this parameter changes in the Instance object. Default is `update`
+                      if present, or `deploy` if not present
+                    type: string
+                type: object
+              type: array
+            plans:
+              description: Plans specify a map a plans that specify how to
+              type: object
+            tasks:
+              description: List of all tasks available in this OperatorVersions
+              items:
+                properties:
+                  kind:
+                    type: string
+                  name:
+                    type: string
+                  spec:
+                    type: object
+                type: object
+              type: array
+            templates:
+              description: List of go templates YAML files that define the application
+                operator instance
+              type: object
+            upgradableFrom:
+              description: UpgradableFrom lists all OperatorVersions that can upgrade
+                to this OperatorVersion
+              items:
+                type: object
+              type: array
+          type: object
+        status:
+          type: object
+      type: object
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  labels:
+    app: kudo-manager
+    controller-tools.k8s.io: "1.0"
+  name: instances.kudo.dev
+spec:
+  group: kudo.dev
+  names:
+    kind: Instance
+    plural: instances
+    singular: instance
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        meta:
+          type: object
+        spec:
+          properties:
+            OperatorVersion:
+              description: Operator specifies a reference to a specific Operator object
+              type: object
+            parameters:
+              type: object
+          type: object
+        status:
+          properties:
+            aggregatedStatus:
+              type: object
+            planStatus:
+              type: object
+          type: object
+      type: object
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    app: kudo-manager
+  name: kudo-manager
+  namespace: default
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  name: kudo-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: kudo-manager
+  namespace: default
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  creationTimestamp: null
+  name: kudo-webhook-server-secret
+  namespace: default
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app: kudo-manager
+    control-plane: controller-manager
+    controller-tools.k8s.io: "1.0"
+  name: kudo-controller-manager-service
+  namespace: default
+spec:
+  ports:
+  - name: kudo
+    port: 443
+    targetPort: webhook-server
+  selector:
+    app: kudo-manager
+    control-plane: controller-manager
+    controller-tools.k8s.io: "1.0"
+status:
+  loadBalancer: {}
+
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  creationTimestamp: null
+  labels:
+    app: kudo-manager
+    control-plane: controller-manager
+    controller-tools.k8s.io: "1.0"
+  name: kudo-controller-manager
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      app: kudo-manager
+      control-plane: controller-manager
+      controller-tools.k8s.io: "1.0"
+  serviceName: kudo-controller-manager-service
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: kudo-manager
+        control-plane: controller-manager
+        controller-tools.k8s.io: "1.0"
+    spec:
+      containers:
+      - command:
+        - /root/manager
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: SECRET_NAME
+          value: kudo-webhook-server-secret
+        image: kudobuilder/controller:vdev
+        imagePullPolicy: Always
+        name: manager
+        ports:
+        - containerPort: 9876
+          name: webhook-server
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 100m
+            memory: 50Mi
+        volumeMounts:
+        - mountPath: /tmp/cert
+          name: cert
+          readOnly: true
+      serviceAccountName: kudo-manager
+      terminationGracePeriodSeconds: 10
+      volumes:
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: kudo-webhook-server-secret
+  updateStrategy: {}
+status:
+  replicas: 0
+
+...


### PR DESCRIPTION
**What this PR does / why we need it**:

Makes `init` command handle only `kudo-system` namespace. Other
namespaces are expected to be created beforehand.

Fixes #972
