### PR TITLE
Remove printf with repo during install

### DIFF
--- a/pkg/kudoctl/util/repo/repo.go
+++ b/pkg/kudoctl/util/repo/repo.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"strings"
 
+	"github.com/kudobuilder/kudo/pkg/kudoctl/clog"
+
 	"github.com/kudobuilder/kudo/pkg/apis/kudo/v1alpha1"
 	"github.com/kudobuilder/kudo/pkg/kudoctl/kudohome"
 
@@ -72,7 +74,7 @@ func NewRepositories() *Repositories {
 
 // GetConfiguration returns a RepoName Config for a name or nil
 func (r *Repositories) GetConfiguration(name string) *Configuration {
-	fmt.Printf("%v\n", r.Repositories)
+	clog.V(4).Printf("%v\n", r.Repositories)
 	for _, repo := range r.Repositories {
 		if repo.Name == name {
 			return repo


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kudo/blob/master/CONTRIBUTING.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kudobuilder/kudo/blob/master/RELEASE.md
3. Ensure you have added or ran the appropriate tests for your PR
4. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What this PR does / why we need it**:
Right now this is output of install

```
kudo git:(master) ✗ ./bin/kubectl-kudo install ./config/samples/first-operator
repo configs: { name:community, url:https://kudo-repository.storage.googleapis.com }
operator.kudo.dev/v1alpha1/first-operator created
operatorversion.kudo.dev/v1alpha1/first-operator-0.1.0 created
instance.kudo.dev/v1alpha1/first-operator-527jgn created
```

This PR removes the first line. I find it very cryptic and not aligned with the rest of messages we try to print out even in terms of format.
