### PR TITLE
Fix typos

### DIFF
--- a/keps/0015-repository-management.md
+++ b/keps/0015-repository-management.md
@@ -24,7 +24,7 @@ status: provisional
       * [Proposal](#proposal)
          * [Create Operator Tarball](#create-operator-tarball)
          * [Create Repository Index](#create-repository-index)
-         * [Create Local Respository](#create-local-respository)
+         * [Create Local Repository](#create-local-repository)
          * [Update a Repository](#update-a-repository)
          * [CLI Repository Help](#cli-repository-help)
          * [User Stories](#user-stories)
@@ -81,7 +81,7 @@ kubectl kudo package docs/examples/zookeeper/ --destination=new-rep
 kubectl kudo repo index new-repo --url https://kudo-repo.storage.googleapis.com
 ```
 
-### Create Local Respository
+### Create Local Repository
 
 For convenience it should be possible to have KUDO start a repository service with a provided path.  `kubectl kudo serve --repo-path ./repo` would create a local http service for the repo in `./repo`
 

--- a/pkg/kudoctl/clog/log.go
+++ b/pkg/kudoctl/clog/log.go
@@ -137,6 +137,6 @@ func Errorf(format string, a ...interface{}) error {
 }
 
 func init() {
-	// expected to be overriden with Init().  This simplifies testing and default behavior
+	// expected to be overridden with Init().  This simplifies testing and default behavior
 	logging.out = os.Stdout
 }

--- a/pkg/kudoctl/cmd/repo_context.go
+++ b/pkg/kudoctl/cmd/repo_context.go
@@ -14,7 +14,7 @@ import (
 const (
 	repoContextDesc = `When using an KUDO operation that requires access to a repository, KUDO needs to know which repository.
 This is defined by the "context". 'kubectl kudo repo list' will provide the list of repositories.  The "*" next to one of the
-names is the current context. 'kubectl kudo repo context local' will change the context to respository named local if it exists.
+names is the current context. 'kubectl kudo repo context local' will change the context to repository named local if it exists.
 `
 )
 

--- a/pkg/kudoctl/util/repo/repo.go
+++ b/pkg/kudoctl/util/repo/repo.go
@@ -102,7 +102,7 @@ func ConfigurationFromSettings(fs afero.Fs, home kudohome.Home, repoName string)
 		config = r.GetConfiguration(repoName)
 	}
 	if config == nil {
-		return nil, fmt.Errorf("unable to find respository for %s", repoName)
+		return nil, fmt.Errorf("unable to find repository for %s", repoName)
 	}
 	return config, nil
 }

--- a/pkg/test/case_test.go
+++ b/pkg/test/case_test.go
@@ -126,11 +126,11 @@ func TestLoadTestSteps(t *testing.T) {
 					Errors: []runtime.Object{},
 				},
 				{
-					Name:  "name-overriden",
+					Name:  "name-overridden",
 					Index: 3,
 					Step: &kudo.TestStep{
 						ObjectMeta: metav1.ObjectMeta{
-							Name: "name-overriden",
+							Name: "name-overridden",
 						},
 						TypeMeta: metav1.TypeMeta{
 							Kind:       "TestStep",

--- a/pkg/test/test_data/with-overrides/03-pod.yaml
+++ b/pkg/test/test_data/with-overrides/03-pod.yaml
@@ -1,7 +1,7 @@
 apiVersion: kudo.dev/v1alpha1
 kind: TestStep
 metadata:
-  name: name-overriden
+  name: name-overridden
 ---
 apiVersion: v1
 kind: Pod


### PR DESCRIPTION
**What this PR does / why we need it**:

Just fixes some typos:

- respository -> repository
- overriden -> overridden

🙂
