### PR TITLE
`make lint` doesn't install `golinter` if found one locally

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,8 +41,6 @@ jobs:
       - restore_cache:
           keys:
             - go-mod-v1-{{ checksum "go.sum" }}
-
-      - run: make install-linter
       - run: make lint
       - save_cache:
           key: go-mod-v1-{{ checksum "go.sum" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
             - go-mod-v1-{{ checksum "go.sum" }}
       - run: curl -sL https://git.io/goreleaser | bash
 
-  code-formatting:
+  lint:
     docker:
       - image: kudobuilder/golang:1.13
     working_directory: /go/src/github.com/kudobuilder/kudo
@@ -42,6 +42,7 @@ jobs:
           keys:
             - go-mod-v1-{{ checksum "go.sum" }}
 
+      - run: make install-linter
       - run: make lint
       - save_cache:
           key: go-mod-v1-{{ checksum "go.sum" }}
@@ -52,7 +53,7 @@ workflows:
   version: 2
   lint:
     jobs:
-      - code-formatting
+      - lint
   integration-test:
     jobs:
       - integration-test

--- a/Makefile
+++ b/Makefile
@@ -39,9 +39,12 @@ integration-test: cli-fast
 test-clean:
 	rm -f cover.out cover-integration.out
 
+.PHONY: install-linter
+install-linter:
+	go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
+
 .PHONY: lint
 lint:
-	go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
 	golangci-lint run
 
 .PHONY: download

--- a/Makefile
+++ b/Makefile
@@ -39,12 +39,11 @@ integration-test: cli-fast
 test-clean:
 	rm -f cover.out cover-integration.out
 
-.PHONY: install-linter
-install-linter:
-	go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
-
 .PHONY: lint
 lint:
+ifeq (, $(shell which golangci-lint))
+	go get github.com/golangci/golangci-lint/cmd/golangci-lint
+endif
 	golangci-lint run
 
 .PHONY: download


### PR DESCRIPTION
Additionally, renamed `code-formatting` CircleCI job to `lint`.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kudo/blob/master/CONTRIBUTING.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kudobuilder/kudo/blob/master/RELEASE.md
3. Ensure you have added or ran the appropriate tests for your PR
4. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->
