### PR TITLE
Remove kustomize from Makefile - we don't use it anymore

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,9 +68,9 @@ run:
 	go run -ldflags "${LDFLAGS}" ./cmd/manager/main.go
 
 .PHONY: deploy
-# Deploy controller in the configured Kubernetes cluster in ~/.kube/config
+# Install KUDO into a cluster via kubectl kudo init
 deploy:
-	@kustomize build config
+	go run -ldflags "${LDFLAGS}" cmd/kubectl-kudo/main.go init
 
 .PHONY: deploy-clean
 deploy-clean:
@@ -115,8 +115,6 @@ docker-build: generate lint
 	--build-arg build_date_arg=${BUILD_DATE_PATH}=${BUILD_DATE} . -t ${DOCKER_IMG}:${DOCKER_TAG}
 	docker tag ${DOCKER_IMG}:${DOCKER_TAG} ${DOCKER_IMG}:v${GIT_VERSION}
 	docker tag ${DOCKER_IMG}:${DOCKER_TAG} ${DOCKER_IMG}:latest
-	@echo "updating kustomize image patch file for manager resource"
-	sed -i'' -e 's@image: .*@image: '"${DOCKER_IMG}:v${GIT_VERSION}"'@' ./config/manager_image_patch.yaml
 
 .PHONY: docker-push
 # Push the docker image


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kudo/blob/master/CONTRIBUTING.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kudobuilder/kudo/blob/master/RELEASE.md
3. Ensure you have added or ran the appropriate tests for your PR
4. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What this PR does / why we need it**:
I just noticed this when reviewing #996

We removed all kustomize handling from config folders, init is the only way to go now.
