### PR TITLE
Remove circleci release job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,17 +21,6 @@ jobs:
       - store_test_results:
           path: reports/
 
-  release:
-    docker:
-      - image: kudobuilder/golang:1.13
-    working_directory: /go/src/github.com/kudobuilder/kudo
-    steps:
-      - checkout
-      - restore_cache:
-          keys:
-            - go-mod-v1-{{ checksum "go.sum" }}
-      - run: curl -sL https://git.io/goreleaser | bash
-
   lint:
     docker:
       - image: kudobuilder/golang:1.13
@@ -58,11 +47,3 @@ workflows:
   e2e-test:
     jobs:
       - e2e-test
-  release:
-    jobs:
-      - release:
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*(-.*)*/


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kudo/blob/master/CONTRIBUTING.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kudobuilder/kudo/blob/master/RELEASE.md
3. Ensure you have added or ran the appropriate tests for your PR
4. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What this PR does / why we need it**:
Everytime we tag a release, this job fails because it's not really set up fully and it does not copy our full release practices. I think we should re-introduce it once we're ready for that, remove it for now.


<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
