### PR TITLE
Deploy clean should remove everything, not just CRD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ deploy:
 
 .PHONY: deploy-clean
 deploy-clean:
-	go run ./cmd/kubectl-kudo  init --crd-only --dry-run --output yaml | kubectl delete -f -
+	go run ./cmd/kubectl-kudo  init --dry-run --output yaml | kubectl delete -f -
 
 .PHONY: generate
 # Generate code


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kudo/blob/master/CONTRIBUTING.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kudobuilder/kudo/blob/master/RELEASE.md
3. Ensure you have added or ran the appropriate tests for your PR
4. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What this PR does / why we need it**:
Since deploy is installing everything into a cluster, deploy-clean should remove everything. Right now it was removing just crds.
