### PR TITLE
Update API server for tests

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,15 +1,15 @@
-ARG GOLANG_VERSION=1.10
+ARG GOLANG_VERSION=1.13
 FROM golang:${GOLANG_VERSION}
 
 
 # Download and install Kubebuilder
 
 # download the release
-RUN curl -L -O https://github.com/kubernetes-sigs/kubebuilder/releases/download/v1.0.8/kubebuilder_1.0.8_linux_amd64.tar.gz
+RUN curl -L -O https://github.com/kubernetes-sigs/kubebuilder/releases/download/v2.1.0/kubebuilder_2.1.0_linux_amd64.tar.gz
 
 # extract the archive
-RUN tar -zxvf kubebuilder_1.0.8_linux_amd64.tar.gz
-RUN mv kubebuilder_1.0.8_linux_amd64 kubebuilder && mv kubebuilder /usr/local/
+RUN tar -zxvf kubebuilder_2.1.0_linux_amd64.tar.gz
+RUN mv kubebuilder_2.1.0_linux_amd64 kubebuilder && mv kubebuilder /usr/local/
 
 # update your PATH to include /usr/local/kubebuilder/bin
 ENV PATH $PATH:/usr/local/kubebuilder/bin

--- a/pkg/test/test_data/create-or-update/00-assert.yaml
+++ b/pkg/test/test_data/create-or-update/00-assert.yaml
@@ -7,12 +7,11 @@ status:
     kind: ProwJob
   # InitialNamesAccepted will change from False -> True once the CRD is ready.
   conditions:
-  - message: no conflicts found
-    reason: NoConflicts
+  - type: NonStructuralSchema
+  - reason: NoConflicts
     status: "True"
     type: NamesAccepted
-  - message: the initial names have been accepted
-    reason: InitialNamesAccepted
+  - reason: InitialNamesAccepted
     status: "True"
     type: Established
   storedVersions:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kudo/blob/master/CONTRIBUTING.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kudobuilder/kudo/blob/master/RELEASE.md
3. Ensure you have added or ran the appropriate tests for your PR
4. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What this PR does / why we need it**:
Kubernetes api server had a race back in 1.13 https://github.com/kubernetes/kubernetes/issues/51353 and we're still seeing this in our tests because we're using api-server from 1.13.1 in tests. We run tests in docker and we use tools provided by kubebuilder release. We depend on 1.0.8 which is kube 1.13.1. By going to 2.X we;re at least moving to 1.15

I looked into ditching kubebuilder altogether because we're really just using api server and etcd but it would be a bit more work :) we could do it as follow-up if people find it meaningful.

If tests locally start to fail for you after this PR, it's because you need to update api server locally as well if you're not running tests inside docker.'

Oh and this is just first step of the fix - the real will be to actually push the golang 1.13 images to docker hub. I'll do it when this one is merged.

<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #683
