### PR TITLE
Improve the check for KUDO CRDs when creating a client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/dustinkirkland/golang-petname v0.0.0-20170921220637-d3c2ba80e75e
 	github.com/go-test/deep v1.0.1
 	github.com/gogo/protobuf v1.3.1 // indirect
-	github.com/golang-collections/collections v0.0.0-20130729185459-604e922904d3
 	github.com/golangci/golangci-lint v1.21.0
 	github.com/google/shlex v0.0.0-20181106134648-c34317bd91bf
 	github.com/gophercloud/gophercloud v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -217,8 +217,6 @@ github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zV
 github.com/gogo/protobuf v1.2.2-0.20190723190241-65acae22fc9d/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/gogo/protobuf v1.3.1 h1:DqDEcV5aeaTmdFBePNpYsp3FlcVH/2ISVVM9Qf8PSls=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
-github.com/golang-collections/collections v0.0.0-20130729185459-604e922904d3 h1:zN2lZNZRflqFyxVaTIU61KNKQ9C0055u9CAfpmqUvo4=
-github.com/golang-collections/collections v0.0.0-20130729185459-604e922904d3/go.mod h1:nPpo7qLxd6XL3hWJG/O60sR8ZKfMCiIoNap5GvD12KU=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=

--- a/pkg/kudoctl/env/environment.go
+++ b/pkg/kudoctl/env/environment.go
@@ -68,5 +68,5 @@ func (s *Settings) OverrideDefault(fs *pflag.FlagSet, name, value string) string
 
 // GetClient is a helper function that takes the Settings struct and returns a new KUDO Client
 func GetClient(s *Settings) (*kudo.Client, error) {
-	return kudo.NewClient(s.Namespace, s.KubeConfig, s.RequestTimeout)
+	return kudo.NewClient(s.KubeConfig, s.RequestTimeout)
 }

--- a/pkg/kudoctl/util/kudo/kudo_test.go
+++ b/pkg/kudoctl/util/kudo/kudo_test.go
@@ -28,7 +28,7 @@ func TestNewK2oClient(t *testing.T) {
 
 	for _, tt := range tests {
 		// Just interested in errors
-		_, err := NewClient("default", "", 0)
+		_, err := NewClient("", 0)
 		assert.ErrorContains(t, err, tt.err)
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kudo/blob/master/CONTRIBUTING.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kudobuilder/kudo/blob/master/RELEASE.md
3. Ensure you have added or ran the appropriate tests for your PR
4. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What this PR does / why we need it**:
CRDs aren't tied to a namespace. By checking for them directly through the 'apiextensions' client is a cleaner approach than checking if listing CRDs objects succeed. This also make the `namespace` parameter of `kudo.NewClient` redundant.
