### PR TITLE
Enable status subresource for instance CRD

### DIFF
--- a/config/crds/kudo_v1beta1_instance.yaml
+++ b/config/crds/kudo_v1beta1_instance.yaml
@@ -13,6 +13,8 @@ spec:
     plural: instances
     singular: instance
   scope: Namespaced
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:

--- a/pkg/apis/kudo/v1beta1/instance_types.go
+++ b/pkg/apis/kudo/v1beta1/instance_types.go
@@ -252,6 +252,7 @@ func (i *Instance) EnsurePlanStatusInitialized(ov *OperatorVersion) {
 }
 
 // StartPlanExecution mark plan as to be executed
+// this modifies the instance.Status as well as instance.Metadata.Annotation (to save snapshot if needed)
 func (i *Instance) StartPlanExecution(planName string, ov *OperatorVersion) error {
 	if i.NoPlanEverExecuted() || isUpgradePlan(planName) {
 		i.EnsurePlanStatusInitialized(ov)

--- a/pkg/kudoctl/cmd/init/crds.go
+++ b/pkg/kudoctl/cmd/init/crds.go
@@ -166,6 +166,8 @@ func instanceCrd() *apiextv1beta1.CustomResourceDefinition {
 			Properties: validationProps,
 		},
 	}
+
+	crd.Spec.Subresources = &apiextv1beta1.CustomResourceSubresources{Status: &apiextv1beta1.CustomResourceSubresourceStatus{}}
 	return crd
 }
 

--- a/pkg/kudoctl/cmd/testdata/deploy-kudo-ns-default.yaml.golden
+++ b/pkg/kudoctl/cmd/testdata/deploy-kudo-ns-default.yaml.golden
@@ -171,6 +171,8 @@ spec:
     plural: instances
     singular: instance
   scope: Namespaced
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:

--- a/pkg/kudoctl/cmd/testdata/deploy-kudo-ns.yaml.golden
+++ b/pkg/kudoctl/cmd/testdata/deploy-kudo-ns.yaml.golden
@@ -171,6 +171,8 @@ spec:
     plural: instances
     singular: instance
   scope: Namespaced
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:

--- a/pkg/kudoctl/cmd/testdata/deploy-kudo.yaml.golden
+++ b/pkg/kudoctl/cmd/testdata/deploy-kudo.yaml.golden
@@ -171,6 +171,8 @@ spec:
     plural: instances
     singular: instance
   scope: Namespaced
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, our Instance CRD contains status but we don't have status subresource enabled. That means that we're vulnerable to this behavior described in API conventions:

```
The PUT and POST verbs on objects MUST ignore the "status" values, to avoid accidentally overwriting the status in read-modify-write scenarios. A /status subresource MUST be provided to enable system components to update statuses of resources they manage.

Otherwise, PUT expects the whole object to be specified. Therefore, if a field is omitted it is assumed that the client wants to clear that field's value. The PUT verb does not accept partial updates. 
```


<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1043
