### PR TITLE
Properly handle `go mod init` failures.

### DIFF
--- a/hack/update_codegen.sh
+++ b/hack/update_codegen.sh
@@ -15,7 +15,12 @@ if [ -d "$CODE_GEN_DIR" ]; then
     echo "Using cached code generator version: $VERSION"
 else
     git clone https://github.com/kubernetes/code-generator.git "${CODE_GEN_DIR}"
-    cd "${CODE_GEN_DIR}" && git reset --hard "${VERSION}" && go mod init && cd -
+    cd "${CODE_GEN_DIR}"
+    git reset --hard "${VERSION}"
+    if [[ ! -f go.mod ]]; then
+        go mod init
+    fi
+    cd -
 fi
 
 "${CODE_GEN_DIR}"/generate-groups.sh \


### PR DESCRIPTION
Also, do no attempt to run it if `go.mod` already exists.

**What this PR does / why we need it**:

See subject.

Fixes #1051 
