### PR TITLE
Wait for CRD to be established.

### DIFF
--- a/pkg/test/test_data/crd-in-step/00-assert.yaml
+++ b/pkg/test/test_data/crd-in-step/00-assert.yaml
@@ -11,3 +11,8 @@ status:
     singular: mycrd
   storedVersions:
   - v1beta1
+  conditions:
+  - type: NamesAccepted
+    status: "True"
+  - type: Established
+    status: "True"


### PR DESCRIPTION
**What this PR does / why we need it**:

Otherwise creation of the custom resource races with CRD establishment,
and fails in case it wins.
