### PR TITLE
Better output when incorrect args in uninstall

### DIFF
--- a/pkg/kudoctl/cmd/uninstall.go
+++ b/pkg/kudoctl/cmd/uninstall.go
@@ -59,7 +59,12 @@ func newUninstallCmd() *cobra.Command {
 		Short:   "Uninstall a KUDO package.",
 		Long:    "Uninstall the instance of a KUDO package. This also removes dependent objects, e.g. deployments, pods",
 		Example: uninstallExample,
-		Args:    cobra.NoArgs,
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 0 {
+				return fmt.Errorf("The command expects no arguments and --instance flag must be provided.\n %s", cmd.UsageString())
+			}
+			return nil
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return uninstall.run(options, &Settings)
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kudo/blob/master/CONTRIBUTING.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kudobuilder/kudo/blob/master/RELEASE.md
3. Ensure you have added or ran the appropriate tests for your PR
4. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What this PR does / why we need it**:
This is the new output. I think that is much more user friendly.


```
./bin/kubectl-kudo uninstall mysql-instance
Error: The command expects no arguments and --instance flag must be provided.
 Usage:
  kubectl-kudo uninstall [flags]

Examples:
kubectl kudo uninstall --instance flink

Flags:
  -h, --help              help for uninstall
      --instance string   The instance name.

Global Flags:
      --home string           location of your KUDO config. (default "/Users/alenavarkockova/.kudo")
      --kubeconfig string     Path to your Kubernetes configuration file. (default "/Users/alenavarkockova/.kube/config")
  -n, --namespace string      Target namespace for the object. (default "default")
      --request-timeout int   Request timeout value, in seconds.  Defaults to 0 (unlimited)
  -v, --v                     log level for V logs
```


<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Partial improvement for #1055
