### PR TITLE
Add build instructions workaround for an issue with code-generator.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,7 @@ Please see [https://git.k8s.io/community/CLA.md](https://git.k8s.io/community/CL
 
 - Get the KUDO repo: `git clone https://github.com/kudobuilder/kudo.git`
 - `cd kudo`
+- Export `GOPATH` (this is necessary because of an issue in [codegenerator](https://github.com/kubernetes/code-generator/issues/87))
 - `make all` to build project
 - [optionally] `make docker-build` to build the Docker images
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds documentation workaround for issue with code-generator that causes `generate-groups.sh` to fail due to a missing `GOPATH`.

See https://github.com/kubernetes/code-generator/issues/87.