### PR TITLE
Stop creating old test images.

### DIFF
--- a/build/test-images.sh
+++ b/build/test-images.sh
@@ -1,15 +1,5 @@
 #!/bin/sh
 
-
-docker build --build-arg GOLANG_VERSION=1.10 -t kudobuilder/golang:1.10 .
-docker push kudobuilder/golang:1.10
-
-docker build --build-arg GOLANG_VERSION=1.11 -t kudobuilder/golang:1.11 .
-docker push kudobuilder/golang:1.11
-
-docker build --build-arg GOLANG_VERSION=1.12 -t kudobuilder/golang:1.12 .
-docker push kudobuilder/golang:1.12
-
 docker build --build-arg GOLANG_VERSION=1.13 -t kudobuilder/golang:1.13 .
 docker push kudobuilder/golang:1.13
 


### PR DESCRIPTION
**What this PR does / why we need it**:

We no longer support Golang < 1.13 nor use these images.