### PR TITLE
Log package origins

### DIFF
--- a/pkg/kudoctl/cmd/package_test.go
+++ b/pkg/kudoctl/cmd/package_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -10,18 +11,20 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var packageCmdArgs = []struct {
-	name         string
-	arg          []string
-	errorMessage string
-}{
-	{"expect exactly one argument", []string{}, "expecting exactly one argument - directory of the operator or name of package"}, // 1
-	{"empty string argument", []string{""}, "path must be specified"},                                                            // 2
-	{"invalid operator", []string{"foo"}, "open foo: file does not exist"},                                                       // 3
-	{"valid operator", []string{"/opt/zk"}, ""},                                                                                  // 4
-}
-
 func TestTableNewPackageCmd(t *testing.T) {
+	fooLocal, _ := filepath.Abs("foo")
+
+	var packageCmdArgs = []struct {
+		name         string
+		arg          []string
+		errorMessage string
+	}{
+		{"expect exactly one argument", []string{}, "expecting exactly one argument - directory of the operator or name of package"}, // 1
+		{"empty string argument", []string{""}, "path must be specified"},                                                            // 2
+		{"invalid operator", []string{"foo"}, fmt.Sprintf("open %s: file does not exist", fooLocal)},                                 // 3
+		{"valid operator", []string{"/opt/zk"}, ""},                                                                                  // 4
+	}
+
 	fs := afero.NewMemMapFs()
 	testdir, _ := filepath.Abs("")
 	if err := fs.Mkdir(testdir, 0777); err != nil {

--- a/pkg/kudoctl/packages/reader/read_dir.go
+++ b/pkg/kudoctl/packages/reader/read_dir.go
@@ -27,13 +27,13 @@ func ReadDir(fs afero.Fs, path string) (*packages.Package, error) {
 	// 1. get files
 	files, err := FromDir(fs, path)
 	if err != nil {
-		return nil, fmt.Errorf("while parsing package files: %w", err)
+		return nil, fmt.Errorf("while parsing package files: %v", err)
 	}
 
 	// 2. get resources
 	resources, err := files.Resources()
 	if err != nil {
-		return nil, fmt.Errorf("while getting package resources: %w", err)
+		return nil, fmt.Errorf("while getting package resources: %v", err)
 	}
 
 	return &packages.Package{
@@ -52,7 +52,7 @@ func FromDir(fs afero.Fs, packagePath string) (*packages.Files, error) {
 		// Normalize package path to provide more meaningful error messages
 		absPackagePath, err := filepath.Abs(packagePath)
 		if err != nil {
-			return nil, fmt.Errorf("failed to normalize package path %s: %w", packagePath, err)
+			return nil, fmt.Errorf("failed to normalize package path %s: %v", packagePath, err)
 		}
 		packagePath = absPackagePath
 	}

--- a/pkg/kudoctl/packages/reader/read_dir.go
+++ b/pkg/kudoctl/packages/reader/read_dir.go
@@ -1,12 +1,12 @@
 package reader
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
 	"github.com/kudobuilder/kudo/pkg/kudoctl/clog"
 	"github.com/kudobuilder/kudo/pkg/kudoctl/packages"
-	"github.com/pkg/errors"
 	"github.com/spf13/afero"
 )
 
@@ -27,13 +27,13 @@ func ReadDir(fs afero.Fs, path string) (*packages.Package, error) {
 	// 1. get files
 	files, err := FromDir(fs, path)
 	if err != nil {
-		return nil, errors.Wrap(err, "while parsing package files")
+		return nil, fmt.Errorf("while parsing package files: %w", err)
 	}
 
 	// 2. get resources
 	resources, err := files.Resources()
 	if err != nil {
-		return nil, errors.Wrap(err, "while getting package resources")
+		return nil, fmt.Errorf("while getting package resources: %w", err)
 	}
 
 	return &packages.Package{
@@ -45,14 +45,14 @@ func ReadDir(fs afero.Fs, path string) (*packages.Package, error) {
 // FromDir walks the path provided and returns package files or an error
 func FromDir(fs afero.Fs, packagePath string) (*packages.Files, error) {
 	if packagePath == "" {
-		return nil, errors.New("path must be specified")
+		return nil, fmt.Errorf("path must be specified")
 	}
 
 	if !filepath.IsAbs(packagePath) {
 		// Normalize package path to provide more meaningful error messages
 		absPackagePath, err := filepath.Abs(packagePath)
 		if err != nil {
-			return nil, errors.Wrapf(err, "Failed to normalize package path %s", packagePath)
+			return nil, fmt.Errorf("failed to normalize package path %s: %w", packagePath, err)
 		}
 		packagePath = absPackagePath
 	}
@@ -84,10 +84,10 @@ func FromDir(fs afero.Fs, packagePath string) (*packages.Files, error) {
 	}
 	// final check
 	if result.Operator == nil {
-		return nil, errors.Errorf("operator package missing operator.yaml in %s", packagePath)
+		return nil, fmt.Errorf("operator package missing operator.yaml in %s", packagePath)
 	}
 	if result.Params == nil {
-		return nil, errors.Errorf("operator package missing params.yaml in %s", packagePath)
+		return nil, fmt.Errorf("operator package missing params.yaml in %s", packagePath)
 	}
 	return &result, nil
 }

--- a/pkg/kudoctl/packages/reader/read_dir.go
+++ b/pkg/kudoctl/packages/reader/read_dir.go
@@ -16,7 +16,7 @@ func ReadDir(fs afero.Fs, path string) (*packages.Package, error) {
 	//	make sure file exists
 	fi, err := fs.Stat(path)
 	if err != nil {
-		clog.V(4).Printf("error reading package directory %v", path)
+		clog.V(4).Printf("error reading package directory %s", path)
 		return nil, err
 	}
 	if !fi.IsDir() {
@@ -52,7 +52,7 @@ func FromDir(fs afero.Fs, packagePath string) (*packages.Files, error) {
 		// Normalize package path to provide more meaningful error messages
 		absPackagePath, err := filepath.Abs(packagePath)
 		if err != nil {
-			return nil, fmt.Errorf("failed to normalize package path %v: %w", packagePath, err)
+			return nil, fmt.Errorf("failed to normalize package path %s: %w", packagePath, err)
 		}
 		packagePath = absPackagePath
 	}
@@ -84,10 +84,10 @@ func FromDir(fs afero.Fs, packagePath string) (*packages.Files, error) {
 	}
 	// final check
 	if result.Operator == nil {
-		return nil, fmt.Errorf("operator package missing operator.yaml in %v", packagePath)
+		return nil, fmt.Errorf("operator package missing operator.yaml in %s", packagePath)
 	}
 	if result.Params == nil {
-		return nil, fmt.Errorf("operator package missing params.yaml in %v", packagePath)
+		return nil, fmt.Errorf("operator package missing params.yaml in %s", packagePath)
 	}
 	return &result, nil
 }

--- a/pkg/kudoctl/packages/reader/read_dir.go
+++ b/pkg/kudoctl/packages/reader/read_dir.go
@@ -16,7 +16,7 @@ func ReadDir(fs afero.Fs, path string) (*packages.Package, error) {
 	//	make sure file exists
 	fi, err := fs.Stat(path)
 	if err != nil {
-		clog.V(4).Printf("error reading package directory %s", path)
+		clog.V(4).Printf("error reading package directory %v", path)
 		return nil, err
 	}
 	if !fi.IsDir() {
@@ -52,7 +52,7 @@ func FromDir(fs afero.Fs, packagePath string) (*packages.Files, error) {
 		// Normalize package path to provide more meaningful error messages
 		absPackagePath, err := filepath.Abs(packagePath)
 		if err != nil {
-			return nil, fmt.Errorf("failed to normalize package path %s: %w", packagePath, err)
+			return nil, fmt.Errorf("failed to normalize package path %v: %w", packagePath, err)
 		}
 		packagePath = absPackagePath
 	}
@@ -84,10 +84,10 @@ func FromDir(fs afero.Fs, packagePath string) (*packages.Files, error) {
 	}
 	// final check
 	if result.Operator == nil {
-		return nil, fmt.Errorf("operator package missing operator.yaml in %s", packagePath)
+		return nil, fmt.Errorf("operator package missing operator.yaml in %v", packagePath)
 	}
 	if result.Params == nil {
-		return nil, fmt.Errorf("operator package missing params.yaml in %s", packagePath)
+		return nil, fmt.Errorf("operator package missing params.yaml in %v", packagePath)
 	}
 	return &result, nil
 }

--- a/pkg/kudoctl/packages/reader/reader_tar.go
+++ b/pkg/kudoctl/packages/reader/reader_tar.go
@@ -23,13 +23,13 @@ func ReadTar(fs afero.Fs, path string) (*packages.Package, error) {
 	// 2. ParseTgz tar files
 	files, err := ParseTgz(buf)
 	if err != nil {
-		return nil, fmt.Errorf("while parsing package files from %v: %w", path, err)
+		return nil, fmt.Errorf("while parsing package files from %s: %w", path, err)
 	}
 
 	// 3. convert to resources
 	resources, err := files.Resources()
 	if err != nil {
-		return nil, fmt.Errorf("while getting package resources from %v: %w", path, err)
+		return nil, fmt.Errorf("while getting package resources from %s: %w", path, err)
 	}
 
 	return &packages.Package{

--- a/pkg/kudoctl/packages/reader/reader_tar.go
+++ b/pkg/kudoctl/packages/reader/reader_tar.go
@@ -24,13 +24,13 @@ func ReadTar(fs afero.Fs, path string) (*packages.Package, error) {
 	// 2. ParseTgz tar files
 	files, err := ParseTgz(buf)
 	if err != nil {
-		return nil, errors.Wrap(err, "while parsing package files")
+		return nil, errors.Wrapf(err, "while parsing package files from %s", path)
 	}
 
 	// 3. convert to resources
 	resources, err := files.Resources()
 	if err != nil {
-		return nil, errors.Wrap(err, "while getting package resources")
+		return nil, errors.Wrapf(err, "while getting package resources from %s", path)
 	}
 
 	return &packages.Package{
@@ -81,7 +81,7 @@ func ParseTgz(r io.Reader) (*packages.Files, error) {
 		case tar.TypeReg:
 			buf, err := ioutil.ReadAll(tr)
 			if err != nil {
-				return nil, errors.Wrapf(err, "while reading file from package tarball %s", header.Name)
+				return nil, errors.Wrapf(err, "while reading file %s from package tarball", header.Name)
 			}
 
 			err = parsePackageFile(header.Name, buf, &result)

--- a/pkg/kudoctl/packages/reader/reader_tar.go
+++ b/pkg/kudoctl/packages/reader/reader_tar.go
@@ -9,7 +9,6 @@ import (
 	"io/ioutil"
 
 	"github.com/kudobuilder/kudo/pkg/kudoctl/packages"
-	"github.com/pkg/errors"
 	"github.com/spf13/afero"
 )
 
@@ -24,13 +23,13 @@ func ReadTar(fs afero.Fs, path string) (*packages.Package, error) {
 	// 2. ParseTgz tar files
 	files, err := ParseTgz(buf)
 	if err != nil {
-		return nil, errors.Wrapf(err, "while parsing package files from %s", path)
+		return nil, fmt.Errorf("while parsing package files from %v: %w", path, err)
 	}
 
 	// 3. convert to resources
 	resources, err := files.Resources()
 	if err != nil {
-		return nil, errors.Wrapf(err, "while getting package resources from %s", path)
+		return nil, fmt.Errorf("while getting package resources from %v: %w", path, err)
 	}
 
 	return &packages.Package{
@@ -81,7 +80,7 @@ func ParseTgz(r io.Reader) (*packages.Files, error) {
 		case tar.TypeReg:
 			buf, err := ioutil.ReadAll(tr)
 			if err != nil {
-				return nil, errors.Wrapf(err, "while reading file %s from package tarball", header.Name)
+				return nil, fmt.Errorf("while reading file %s from package tarball: %w", header.Name, err)
 			}
 
 			err = parsePackageFile(header.Name, buf, &result)

--- a/pkg/kudoctl/packages/reader/reader_tar.go
+++ b/pkg/kudoctl/packages/reader/reader_tar.go
@@ -23,13 +23,13 @@ func ReadTar(fs afero.Fs, path string) (*packages.Package, error) {
 	// 2. ParseTgz tar files
 	files, err := ParseTgz(buf)
 	if err != nil {
-		return nil, fmt.Errorf("while parsing package files from %s: %w", path, err)
+		return nil, fmt.Errorf("while parsing package files from %s: %v", path, err)
 	}
 
 	// 3. convert to resources
 	resources, err := files.Resources()
 	if err != nil {
-		return nil, fmt.Errorf("while getting package resources from %s: %w", path, err)
+		return nil, fmt.Errorf("while getting package resources from %s: %v", path, err)
 	}
 
 	return &packages.Package{
@@ -80,7 +80,7 @@ func ParseTgz(r io.Reader) (*packages.Files, error) {
 		case tar.TypeReg:
 			buf, err := ioutil.ReadAll(tr)
 			if err != nil {
-				return nil, fmt.Errorf("while reading file %s from package tarball: %w", header.Name, err)
+				return nil, fmt.Errorf("while reading file %s from package tarball: %v", header.Name, err)
 			}
 
 			err = parsePackageFile(header.Name, buf, &result)

--- a/pkg/kudoctl/packages/resolver/resolver_local.go
+++ b/pkg/kudoctl/packages/resolver/resolver_local.go
@@ -31,13 +31,13 @@ func (f *LocalResolver) Resolve(name string, version string) (*packages.Package,
 	if err != nil {
 		return nil, err
 	}
-	clog.V(0).Printf("determining package type of %v", name)
+	clog.V(1).Printf("determining package type of %v", name)
 
 	if fi.Mode().IsRegular() && strings.HasSuffix(name, ".tgz") {
-		clog.V(0).Printf("%v is a tgz package", name)
+		clog.V(0).Printf("%v is a local tgz package", name)
 		return reader.ReadTar(f.fs, name)
 	} else if fi.IsDir() {
-		clog.V(0).Printf("%v is a file package", name)
+		clog.V(0).Printf("%v is a local file package", name)
 		return reader.ReadDir(f.fs, name)
 	} else {
 		return nil, fmt.Errorf("unsupported file system format %v. Expect either a *.tgz file or a folder", name)

--- a/pkg/kudoctl/packages/resolver/resolver_url.go
+++ b/pkg/kudoctl/packages/resolver/resolver_url.go
@@ -3,6 +3,7 @@ package resolver
 import (
 	"bytes"
 	"fmt"
+	"github.com/kudobuilder/kudo/pkg/kudoctl/clog"
 
 	"github.com/kudobuilder/kudo/pkg/kudoctl/http"
 	"github.com/kudobuilder/kudo/pkg/kudoctl/packages"
@@ -33,6 +34,8 @@ func (f *URLResolver) Resolve(name string, version string) (*packages.Package, e
 	if err != nil {
 		return nil, err
 	}
+
+	clog.V(0).Printf("%v is a remote tgz package", name)
 
 	return &packages.Package{
 		Resources: resources,

--- a/pkg/kudoctl/packages/resolver/resolver_url.go
+++ b/pkg/kudoctl/packages/resolver/resolver_url.go
@@ -3,8 +3,8 @@ package resolver
 import (
 	"bytes"
 	"fmt"
-	"github.com/kudobuilder/kudo/pkg/kudoctl/clog"
 
+	"github.com/kudobuilder/kudo/pkg/kudoctl/clog"
 	"github.com/kudobuilder/kudo/pkg/kudoctl/http"
 	"github.com/kudobuilder/kudo/pkg/kudoctl/packages"
 	"github.com/kudobuilder/kudo/pkg/kudoctl/packages/reader"

--- a/pkg/kudoctl/util/repo/resolver_repo.go
+++ b/pkg/kudoctl/util/repo/resolver_repo.go
@@ -17,6 +17,8 @@ func (c *Client) Resolve(name string, version string) (*packages.Package, error)
 	if err != nil {
 		return nil, err
 	}
+	clog.V(0).Printf("%v is a repository package from %v", name, c.Config)
+
 	files, err := reader.ParseTgz(buf)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
**What this PR does / why we need it**:
Log package origins when installing
Log local paths with absolute path
Improved error messages

Fixes #1101 

The original error case: User has a directory "kafka" in the cwd:
```
aneumanns-MBP:kudo aneumann$ go run ./cmd/kubectl-kudo/main.go install kafka --instance=kafka
kafka is a local file package
Error: failed to resolve package CRDs for operator: kafka: while parsing package files: operator package missing operator.yaml in /Users/aneumann/git/kudo/kafka
exit status 255
```

New output without "kafka" directory in cwd:
```
aneumanns-MBP:kudo aneumann$ go run ./cmd/kubectl-kudo/main.go install kafka --instance=kafka
kafka is a repository package from { name:community, url:https://kudo-repository.storage.googleapis.com }
instance.kudo.dev/v1beta1/kafka created
```

New output with direct URL:
```
aneumanns-MBP:kudo aneumann$ go run ./cmd/kubectl-kudo/main.go install https://kudo-repository.storage.googleapis.com/kafka-1.0.1.tgz --instance=kafka
https://kudo-repository.storage.googleapis.com/kafka-1.0.1.tgz is a remote tgz package
instance.kudo.dev/v1beta1/kafka created
```

Output with an (invalid) relative local directory
```
aneumanns-MBP:kudo aneumann$ pwd
/Users/aneumann/git/kudo
aneumanns-MBP:kudo aneumann$ go run ./cmd/kubectl-kudo/main.go install ../kafkay --instance=kafka
../kafkay is a local file package
Error: failed to resolve package CRDs for operator: ../kafkay: while parsing package files: unexpected file when reading package from filesystem: /Users/aneumann/git/kafkay/foo
exit status 255
```

