### PR TITLE
Stop calling go mod init in code-generator.

### DIFF
--- a/hack/update_codegen.sh
+++ b/hack/update_codegen.sh
@@ -11,16 +11,11 @@ export GO111MODULE=on
 VERSION=$(go list -m all | grep k8s.io/code-generator | rev | cut -d"-" -f1 | cut -d" " -f1 | rev)
 CODE_GEN_DIR="hack/code-gen/$VERSION"
 
-if [ -d "$CODE_GEN_DIR" ]; then
+if [[ -d ${CODE_GEN_DIR} ]]; then
     echo "Using cached code generator version: $VERSION"
 else
     git clone https://github.com/kubernetes/code-generator.git "${CODE_GEN_DIR}"
-    cd "${CODE_GEN_DIR}"
-    git reset --hard "${VERSION}"
-    if [[ ! -f go.mod ]]; then
-        go mod init
-    fi
-    cd -
+    git -C "${CODE_GEN_DIR}" reset --hard "${VERSION}"
 fi
 
 "${CODE_GEN_DIR}"/generate-groups.sh \


### PR DESCRIPTION
**What this PR does / why we need it**:

go.mod has been a part of code-generator since April 2019 so we don't
need the other code path

I only noticed [Jan's comment about this](https://github.com/kudobuilder/kudo/pull/1052#pullrequestreview-319025672) today.