### PR TITLE
add reconcile resync period to cmd arg to avoid stall resource cachin…

### DIFF
--- a/pkg/kudoctl/env/environment.go
+++ b/pkg/kudoctl/env/environment.go
@@ -3,6 +3,7 @@ package env
 import (
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/kudobuilder/kudo/pkg/kudoctl/kudohome"
 	"github.com/kudobuilder/kudo/pkg/kudoctl/util/kudo"
@@ -16,6 +17,21 @@ import (
 // from what os.UserHomeDir() returns.
 var DefaultKudoHome = filepath.Join(homedir.HomeDir(), ".kudo")
 var DefaultKubeConfig = filepath.Join(homedir.HomeDir(), "/.kube/config")
+
+// DefalutKudoSyncPeriod sets reconcile sync to 10h.
+// SyncPeriod determines the minimum frequency at which watched resources are reconciled.
+var DefalutKudoSyncPeriod = time.Duration(10) * time.Hour
+
+// Func to set kudo sync period.
+func KudoSyncPeriod() time.Duration {
+	if val, ok := os.LookupEnv("KUDO_SYNCPERIOD"); ok {
+		if sync, err := time.ParseDuration(val); err == nil {
+			return sync
+		}
+		return DefalutKudoSyncPeriod
+	}
+	return DefalutKudoSyncPeriod
+}
 
 func kudoHome() string {
 	if val, ok := os.LookupEnv("KUDO_HOME"); ok {


### PR DESCRIPTION
**What would you like to be added**:

To add a cmd arg to kudo-manager to make the kudo-manager reconcile resync period configurable. 

```
bin/manager [-sync-period]
```   

**Why is this needed**:

The default operator generated by kubebuilder has the default SyncPeriod set to 10 hours which sometimes prevents kudo-manager to update instance resource as the cached instance object resourceversion might older than the latest in k8s cluster. 

**Issues we found**:

```
kudo-controller-manager-0 manager 2019/12/02 06:31:21 PlanExecution: default/zk-kudo all phases of the plan deploy are ready
kudo-controller-manager-0 manager 2019/12/02 06:31:21 InstanceController: Error when updating instance state. Operation cannot be fulfilled on instances.kudo.dev "zk-kudo": the object has been modified; please apply your changes to the latest version and try again
```

Fixes #1123
