### PR TITLE
add reconcile resync period to cmd arg to avoid stall resource caching

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -73,7 +73,7 @@ func main() {
 	if syncPeriod != nil {
 		log.Info(fmt.Sprintf("setting up manager, sync-period is %v", syncPeriod))
 	} else {
-		log.Info(fmt.Sprintf("setting up manager"))
+		log.Info("setting up manager")
 	}
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -21,6 +21,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/go-logr/logr"
 	apiextenstionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
@@ -42,6 +43,20 @@ import (
 	"github.com/kudobuilder/kudo/pkg/version"
 )
 
+// parseSyncPeriod determines the minimum frequency at which watched resources are reconciled.
+// If the variable is present in the environment the
+// duration is returned and the boolean is true.
+func parseSyncPeriod() (*time.Duration, error) {
+	if val, ok := os.LookupEnv("KUDO_SYNCPERIOD"); ok {
+		sync, err := time.ParseDuration(val)
+		if err != nil {
+			return nil, err
+		}
+		return &sync, nil
+	}
+	return nil, nil
+}
+
 func main() {
 	logf.SetLogger(zap.New(zap.UseDevMode(false)))
 	log := logf.Log.WithName("entrypoint")
@@ -50,9 +65,18 @@ func main() {
 	log.Info(fmt.Sprintf("KUDO Version: %s", fmt.Sprintf("%#v", version.Get())))
 
 	// create new controller-runtime manager
-	log.Info("setting up manager")
+	syncPeriod, err := parseSyncPeriod()
+	if err != nil {
+		log.Error(err, "unable to parse manager sync period variable, run manager with defaults")
+	} else if syncPeriod != nil {
+		log.Info(fmt.Sprintf("setting up manager, sync-period is %v", syncPeriod))
+	} else {
+		log.Info(fmt.Sprintf("setting up manager"))
+	}
+
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
-		CertDir: "/tmp/cert",
+		CertDir:    "/tmp/cert",
+		SyncPeriod: syncPeriod,
 	})
 	if err != nil {
 		log.Error(err, "unable to start manager")


### PR DESCRIPTION
**What would you like to be added**:

To add a cmd arg to kudo-manager to make the kudo-manager reconcile resync period configurable. 

```
bin/manager [-sync-period]
```   

**Why is this needed**:

The default operator generated by kubebuilder has the default SyncPeriod set to 10 hours which sometimes prevents kudo-manager to update instance resource as the cached instance object resourceversion might older than the latest in k8s cluster. 

**Issues we found**:

```
kudo-controller-manager-0 manager 2019/12/02 06:31:21 PlanExecution: default/zk-kudo all phases of the plan deploy are ready
kudo-controller-manager-0 manager 2019/12/02 06:31:21 InstanceController: Error when updating instance state. Operation cannot be fulfilled on instances.kudo.dev "zk-kudo": the object has been modified; please apply your changes to the latest version and try again
```

Fixes #1123
