### PR TITLE
s/Operator/OperatorVersion/g in the description

### DIFF
--- a/config/crds/README.md
+++ b/config/crds/README.md
@@ -1,0 +1,4 @@
+# CRD manifests
+
+Note that some these files can be auto-generated from the authoritative definition in the `kubectl kudo init`
+implementation by running `go test -tags integration ./pkg/kudoctl/cmd -v -update`.

--- a/config/crds/kudo_v1beta1_instance.yaml
+++ b/config/crds/kudo_v1beta1_instance.yaml
@@ -27,7 +27,7 @@ spec:
         spec:
           properties:
             OperatorVersion:
-              description: Operator specifies a reference to a specific Operator object
+              description: OperatorVersion specifies a reference to a specific OperatorVersion object
               type: object
             parameters:
               type: object

--- a/config/crds/kudo_v1beta1_instance.yaml
+++ b/config/crds/kudo_v1beta1_instance.yaml
@@ -27,7 +27,7 @@ spec:
         spec:
           properties:
             OperatorVersion:
-              description: OperatorVersion specifies a reference to a specific OperatorVersion object
+              description: Operator specifies a reference to a specific Operator object
               type: object
             parameters:
               type: object

--- a/config/crds/kudo_v1beta1_instance.yaml
+++ b/config/crds/kudo_v1beta1_instance.yaml
@@ -27,7 +27,8 @@ spec:
         spec:
           properties:
             OperatorVersion:
-              description: Operator specifies a reference to a specific Operator object
+              description: OperatorVersion specifies a reference to a specific OperatorVersion
+                object
               type: object
             parameters:
               type: object

--- a/pkg/kudoctl/cmd/init/crds.go
+++ b/pkg/kudoctl/cmd/init/crds.go
@@ -159,7 +159,7 @@ func operatorVersionCrd() *apiextv1beta1.CustomResourceDefinition {
 func instanceCrd() *apiextv1beta1.CustomResourceDefinition {
 	crd := generateCrd("Instance", "instances")
 	specProps := map[string]apiextv1beta1.JSONSchemaProps{
-		"OperatorVersion": {Type: "object", Description: "Operator specifies a reference to a specific Operator object"},
+		"OperatorVersion": {Type: "object", Description: "OperatorVersion specifies a reference to a specific OperatorVersion object"},
 		"parameters":      {Type: "object"},
 	}
 	statusProps := map[string]apiextv1beta1.JSONSchemaProps{

--- a/pkg/kudoctl/cmd/init_integration_test.go
+++ b/pkg/kudoctl/cmd/init_integration_test.go
@@ -64,10 +64,10 @@ func TestCrds_Config(t *testing.T) {
 		if err != nil {
 			t.Errorf("OperatorVersion file override failed: %v", err)
 		}
+		err = writeManifest(instanceFileName, crds.Instance)
 		if err != nil {
 			t.Errorf("Instance file override failed: %v", err)
 		}
-		err = writeManifest(instanceFileName, crds.Instance)
 	}
 
 	assertManifestFileMatch(t, operatorFileName, crds.Operator)

--- a/pkg/kudoctl/cmd/init_integration_test.go
+++ b/pkg/kudoctl/cmd/init_integration_test.go
@@ -55,9 +55,7 @@ const (
 func TestCrds_Config(t *testing.T) {
 	crds := cmdinit.CRDs()
 
-	if false {
-		// change this to true if you want to one time override the manifests with new values
-		// this should be used only when the manifests changed in your PR and you want to update to the newly generated values
+	if *updateGolden {
 		err := writeManifest(operatorFileName, crds.Operator)
 		if err != nil {
 			t.Errorf("Operator file override failed: %v", err)

--- a/pkg/kudoctl/cmd/init_test.go
+++ b/pkg/kudoctl/cmd/init_test.go
@@ -147,7 +147,7 @@ func TestInitCmd_yamlOutput(t *testing.T) {
 		gp := filepath.Join("testdata", tt.goldenFile+".golden")
 
 		if *updateGolden {
-			t.Log("update golden file")
+			t.Logf("updating golden file %s", tt.goldenFile)
 			if err := ioutil.WriteFile(gp, out.Bytes(), 0644); err != nil {
 				t.Fatalf("failed to update golden file: %s", err)
 			}

--- a/pkg/kudoctl/cmd/init_test.go
+++ b/pkg/kudoctl/cmd/init_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/kudobuilder/kudo/pkg/kudoctl/util/repo"
 )
 
-var updateGolden = flag.Bool("update", false, "update .golden files")
+var updateGolden = flag.Bool("update", false, "update .golden files and manifests in /config/crd")
 
 func TestInitCmd_dry(t *testing.T) {
 

--- a/pkg/kudoctl/cmd/testdata/deploy-kudo-ns.yaml.golden
+++ b/pkg/kudoctl/cmd/testdata/deploy-kudo-ns.yaml.golden
@@ -185,7 +185,8 @@ spec:
         spec:
           properties:
             OperatorVersion:
-              description: Operator specifies a reference to a specific Operator object
+              description: OperatorVersion specifies a reference to a specific OperatorVersion
+                object
               type: object
             parameters:
               type: object

--- a/pkg/kudoctl/cmd/testdata/deploy-kudo-sa.yaml.golden
+++ b/pkg/kudoctl/cmd/testdata/deploy-kudo-sa.yaml.golden
@@ -185,7 +185,8 @@ spec:
         spec:
           properties:
             OperatorVersion:
-              description: Operator specifies a reference to a specific Operator object
+              description: OperatorVersion specifies a reference to a specific OperatorVersion
+                object
               type: object
             parameters:
               type: object

--- a/pkg/kudoctl/cmd/testdata/deploy-kudo.yaml.golden
+++ b/pkg/kudoctl/cmd/testdata/deploy-kudo.yaml.golden
@@ -185,7 +185,8 @@ spec:
         spec:
           properties:
             OperatorVersion:
-              description: Operator specifies a reference to a specific Operator object
+              description: OperatorVersion specifies a reference to a specific OperatorVersion
+                object
               type: object
             parameters:
               type: object


### PR DESCRIPTION
**What this PR does / why we need it**:

This is the `OperatorVersion` object, so the description should mention that object, and not the `Operator` object.

Also, improved the condition for the generation logic and fixed error handling there, improved a message, and added a `README.md` for future generations.