### PR TITLE
Fixed yaml output for kudo init with custom SA

### DIFF
--- a/pkg/kudoctl/cmd/init/prereqs.go
+++ b/pkg/kudoctl/cmd/init/prereqs.go
@@ -161,12 +161,10 @@ func Prereq(opts Options) []runtime.Object {
 	if opts.Namespace == defaultns {
 		prereqs = append(prereqs, namespace(opts.Namespace))
 	}
-
-	return append(
-		prereqs,
-		serviceAccount(opts),
-		roleBinding(opts),
-	)
+	if opts.ServiceAccount == defaultServiceAccount {
+		prereqs = append(prereqs, serviceAccount(opts), roleBinding(opts))
+	}
+	return prereqs
 }
 
 // roleBinding provides the roleBinding rbac manifest for printing

--- a/pkg/kudoctl/cmd/testdata/deploy-kudo-sa.yaml.golden
+++ b/pkg/kudoctl/cmd/testdata/deploy-kudo-sa.yaml.golden
@@ -208,31 +208,6 @@ status:
 
 ---
 apiVersion: v1
-kind: ServiceAccount
-metadata:
-  creationTimestamp: null
-  labels:
-    app: kudo-manager
-  name: safoo
-  namespace: foo
-
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  creationTimestamp: null
-  name: kudo-manager-rolebinding
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cluster-admin
-subjects:
-- kind: ServiceAccount
-  name: safoo
-  namespace: foo
-
----
-apiVersion: v1
 kind: Service
 metadata:
   creationTimestamp: null


### PR DESCRIPTION
Fixed yaml output for kudo init with custom SA
Fixed integration test that expected the custom SA and RB manifests in yaml output #1165

Fixes #1165 
