### PR TITLE
Wait for the entire assert timeout for resources to be deleted.

### DIFF
--- a/pkg/test/step.go
+++ b/pkg/test/step.go
@@ -139,7 +139,7 @@ func (s *Step) DeleteExisting(namespace string) error {
 	}
 
 	// Wait for resources to be deleted.
-	return wait.PollImmediate(100*time.Millisecond, s.GetTimeout()*time.Second, func() (done bool, err error) {
+	return wait.PollImmediate(100*time.Millisecond, time.Duration(s.GetTimeout())*time.Second, func() (done bool, err error) {
 		for _, obj := range toDelete {
 			err = cl.Get(context.TODO(), testutils.ObjectKey(obj), obj.DeepCopyObject())
 			if err == nil || !k8serrors.IsNotFound(err) {

--- a/pkg/test/step.go
+++ b/pkg/test/step.go
@@ -139,7 +139,7 @@ func (s *Step) DeleteExisting(namespace string) error {
 	}
 
 	// Wait for resources to be deleted.
-	return wait.PollImmediate(100*time.Millisecond, 10*time.Second, func() (done bool, err error) {
+	return wait.PollImmediate(100*time.Millisecond, s.GetTimeout()*time.Second, func() (done bool, err error) {
 		for _, obj := range toDelete {
 			err = cl.Get(context.TODO(), testutils.ObjectKey(obj), obj.DeepCopyObject())
 			if err == nil || !k8serrors.IsNotFound(err) {


### PR DESCRIPTION
**What this PR does / why we need it**:

* Previously, the test timeout was ignored when waiting for resources deleted by a TestStep to disappear. This changes it so that the test assert timeout is respected and used.