### PR TITLE
Include phase strategy in plan status output

### DIFF
--- a/pkg/kudoctl/cmd/plan/plan_status_test.go
+++ b/pkg/kudoctl/cmd/plan/plan_status_test.go
@@ -82,7 +82,7 @@ func TestStatus(t *testing.T) {
 .
 └── test (Operator-Version: "test-1.0" Active-Plan: "deploy")
     └── Plan deploy ( strategy) [FATAL_ERROR]
-        └── Phase deploy [FATAL_ERROR]
+        └── Phase deploy ( strategy) [FATAL_ERROR]
             └── Step deploy [FATAL_ERROR] (error detail)
 
 `},


### PR DESCRIPTION
**What this PR does / why we need it**:
Phase strategy can be defined independently of that for a plan, so this commit includes this in the output so that the Operator behaviour is less confusing to the user.

The output of that command now looks like this:

```
Plan(s) for "zookeeper-instance" in namespace "default":
.
└── zookeeper-instance (Operator-Version: "zookeeper-0.2.0" Active-Plan: "deploy")
    ├── Plan deploy (serial strategy) [COMPLETE]
    │   ├── Phase zookeeper (parallel strategy) [COMPLETE]
    │   │   └── Step deploy [COMPLETE]
    │   └── Phase validation (serial strategy) [COMPLETE]
    │       ├── Step validation [COMPLETE]
    │       └── Step cleanup [COMPLETE]
    └── Plan validation (serial strategy) [NOT ACTIVE]
        └── Phase connection (serial strategy) [NOT ACTIVE]
            ├── Step connection [NOT ACTIVE]
            └── Step cleanup [NOT ACTIVE]
```

Fixes #1171 
