### PR TITLE
Remove some unused labels.

### DIFF
--- a/config/crds/kudo_v1beta1_instance.yaml
+++ b/config/crds/kudo_v1beta1_instance.yaml
@@ -2,9 +2,6 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
-  labels:
-    app: kudo-manager
-    controller-tools.k8s.io: "1.0"
   name: instances.kudo.dev
 spec:
   group: kudo.dev

--- a/config/crds/kudo_v1beta1_operator.yaml
+++ b/config/crds/kudo_v1beta1_operator.yaml
@@ -2,9 +2,6 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
-  labels:
-    app: kudo-manager
-    controller-tools.k8s.io: "1.0"
   name: operators.kudo.dev
 spec:
   group: kudo.dev

--- a/config/crds/kudo_v1beta1_operatorversion.yaml
+++ b/config/crds/kudo_v1beta1_operatorversion.yaml
@@ -2,9 +2,6 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
-  labels:
-    app: kudo-manager
-    controller-tools.k8s.io: "1.0"
   name: operatorversions.kudo.dev
 spec:
   group: kudo.dev

--- a/pkg/kudoctl/cmd/get/get_test.go
+++ b/pkg/kudoctl/cmd/get/get_test.go
@@ -43,8 +43,7 @@ func TestGetInstances(t *testing.T) {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
-				"controller-tools.k8s.io": "1.0",
-				"operator":                "test",
+				"operator": "test",
 			},
 			Name: "test",
 		},

--- a/pkg/kudoctl/cmd/plan/plan_status_test.go
+++ b/pkg/kudoctl/cmd/plan/plan_status_test.go
@@ -20,9 +20,6 @@ func TestStatus(t *testing.T) {
 			Kind:       "OperatorVersion",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Labels: map[string]string{
-				"controller-tools.k8s.io": "1.0",
-			},
 			Name: "test-1.0",
 		},
 		Spec: v1beta1.OperatorVersionSpec{

--- a/pkg/kudoctl/cmd/testdata/deploy-kudo-ns.yaml.golden
+++ b/pkg/kudoctl/cmd/testdata/deploy-kudo-ns.yaml.golden
@@ -3,9 +3,6 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
-  labels:
-    app: kudo-manager
-    controller-tools.k8s.io: "1.0"
   name: operators.kudo.dev
 spec:
   group: kudo.dev
@@ -59,9 +56,6 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
-  labels:
-    app: kudo-manager
-    controller-tools.k8s.io: "1.0"
   name: operatorversions.kudo.dev
 spec:
   group: kudo.dev
@@ -161,9 +155,6 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
-  labels:
-    app: kudo-manager
-    controller-tools.k8s.io: "1.0"
   name: instances.kudo.dev
 spec:
   group: kudo.dev
@@ -241,7 +232,6 @@ metadata:
   labels:
     app: kudo-manager
     control-plane: controller-manager
-    controller-tools.k8s.io: "1.0"
   name: kudo-controller-manager-service
   namespace: foo
 spec:
@@ -252,7 +242,6 @@ spec:
   selector:
     app: kudo-manager
     control-plane: controller-manager
-    controller-tools.k8s.io: "1.0"
 status:
   loadBalancer: {}
 
@@ -264,7 +253,6 @@ metadata:
   labels:
     app: kudo-manager
     control-plane: controller-manager
-    controller-tools.k8s.io: "1.0"
   name: kudo-controller-manager
   namespace: foo
 spec:
@@ -272,7 +260,6 @@ spec:
     matchLabels:
       app: kudo-manager
       control-plane: controller-manager
-      controller-tools.k8s.io: "1.0"
   serviceName: kudo-controller-manager-service
   template:
     metadata:
@@ -280,7 +267,6 @@ spec:
       labels:
         app: kudo-manager
         control-plane: controller-manager
-        controller-tools.k8s.io: "1.0"
     spec:
       containers:
       - command:

--- a/pkg/kudoctl/cmd/testdata/deploy-kudo-sa.yaml.golden
+++ b/pkg/kudoctl/cmd/testdata/deploy-kudo-sa.yaml.golden
@@ -3,9 +3,6 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
-  labels:
-    app: kudo-manager
-    controller-tools.k8s.io: "1.0"
   name: operators.kudo.dev
 spec:
   group: kudo.dev
@@ -59,9 +56,6 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
-  labels:
-    app: kudo-manager
-    controller-tools.k8s.io: "1.0"
   name: operatorversions.kudo.dev
 spec:
   group: kudo.dev
@@ -161,9 +155,6 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
-  labels:
-    app: kudo-manager
-    controller-tools.k8s.io: "1.0"
   name: instances.kudo.dev
 spec:
   group: kudo.dev
@@ -216,7 +207,6 @@ metadata:
   labels:
     app: kudo-manager
     control-plane: controller-manager
-    controller-tools.k8s.io: "1.0"
   name: kudo-controller-manager-service
   namespace: foo
 spec:
@@ -227,7 +217,6 @@ spec:
   selector:
     app: kudo-manager
     control-plane: controller-manager
-    controller-tools.k8s.io: "1.0"
 status:
   loadBalancer: {}
 
@@ -239,7 +228,6 @@ metadata:
   labels:
     app: kudo-manager
     control-plane: controller-manager
-    controller-tools.k8s.io: "1.0"
   name: kudo-controller-manager
   namespace: foo
 spec:
@@ -247,7 +235,6 @@ spec:
     matchLabels:
       app: kudo-manager
       control-plane: controller-manager
-      controller-tools.k8s.io: "1.0"
   serviceName: kudo-controller-manager-service
   template:
     metadata:
@@ -255,7 +242,6 @@ spec:
       labels:
         app: kudo-manager
         control-plane: controller-manager
-        controller-tools.k8s.io: "1.0"
     spec:
       containers:
       - command:

--- a/pkg/kudoctl/cmd/testdata/deploy-kudo-webhook.yaml.golden
+++ b/pkg/kudoctl/cmd/testdata/deploy-kudo-webhook.yaml.golden
@@ -3,9 +3,6 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
-  labels:
-    app: kudo-manager
-    controller-tools.k8s.io: "1.0"
   name: operators.kudo.dev
 spec:
   group: kudo.dev
@@ -59,9 +56,6 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
-  labels:
-    app: kudo-manager
-    controller-tools.k8s.io: "1.0"
   name: operatorversions.kudo.dev
 spec:
   group: kudo.dev
@@ -161,9 +155,6 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
-  labels:
-    app: kudo-manager
-    controller-tools.k8s.io: "1.0"
   name: instances.kudo.dev
 spec:
   group: kudo.dev
@@ -215,7 +206,6 @@ metadata:
   creationTimestamp: null
   labels:
     app: kudo-manager
-    controller-tools.k8s.io: "1.0"
   name: kudo-system
 spec: {}
 status: {}
@@ -307,7 +297,6 @@ metadata:
   labels:
     app: kudo-manager
     control-plane: controller-manager
-    controller-tools.k8s.io: "1.0"
   name: kudo-controller-manager-service
   namespace: kudo-system
 spec:
@@ -318,7 +307,6 @@ spec:
   selector:
     app: kudo-manager
     control-plane: controller-manager
-    controller-tools.k8s.io: "1.0"
 status:
   loadBalancer: {}
 
@@ -330,7 +318,6 @@ metadata:
   labels:
     app: kudo-manager
     control-plane: controller-manager
-    controller-tools.k8s.io: "1.0"
   name: kudo-controller-manager
   namespace: kudo-system
 spec:
@@ -338,7 +325,6 @@ spec:
     matchLabels:
       app: kudo-manager
       control-plane: controller-manager
-      controller-tools.k8s.io: "1.0"
   serviceName: kudo-controller-manager-service
   template:
     metadata:
@@ -346,7 +332,6 @@ spec:
       labels:
         app: kudo-manager
         control-plane: controller-manager
-        controller-tools.k8s.io: "1.0"
     spec:
       containers:
       - command:

--- a/pkg/kudoctl/cmd/testdata/deploy-kudo.yaml.golden
+++ b/pkg/kudoctl/cmd/testdata/deploy-kudo.yaml.golden
@@ -3,9 +3,6 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
-  labels:
-    app: kudo-manager
-    controller-tools.k8s.io: "1.0"
   name: operators.kudo.dev
 spec:
   group: kudo.dev
@@ -59,9 +56,6 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
-  labels:
-    app: kudo-manager
-    controller-tools.k8s.io: "1.0"
   name: operatorversions.kudo.dev
 spec:
   group: kudo.dev
@@ -161,9 +155,6 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
-  labels:
-    app: kudo-manager
-    controller-tools.k8s.io: "1.0"
   name: instances.kudo.dev
 spec:
   group: kudo.dev
@@ -215,7 +206,6 @@ metadata:
   creationTimestamp: null
   labels:
     app: kudo-manager
-    controller-tools.k8s.io: "1.0"
   name: kudo-system
 spec: {}
 status: {}
@@ -253,7 +243,6 @@ metadata:
   labels:
     app: kudo-manager
     control-plane: controller-manager
-    controller-tools.k8s.io: "1.0"
   name: kudo-controller-manager-service
   namespace: kudo-system
 spec:
@@ -264,7 +253,6 @@ spec:
   selector:
     app: kudo-manager
     control-plane: controller-manager
-    controller-tools.k8s.io: "1.0"
 status:
   loadBalancer: {}
 
@@ -276,7 +264,6 @@ metadata:
   labels:
     app: kudo-manager
     control-plane: controller-manager
-    controller-tools.k8s.io: "1.0"
   name: kudo-controller-manager
   namespace: kudo-system
 spec:
@@ -284,7 +271,6 @@ spec:
     matchLabels:
       app: kudo-manager
       control-plane: controller-manager
-      controller-tools.k8s.io: "1.0"
   serviceName: kudo-controller-manager-service
   template:
     metadata:
@@ -292,7 +278,6 @@ spec:
       labels:
         app: kudo-manager
         control-plane: controller-manager
-        controller-tools.k8s.io: "1.0"
     spec:
       containers:
       - command:

--- a/pkg/kudoctl/cmd/uninstall_test.go
+++ b/pkg/kudoctl/cmd/uninstall_test.go
@@ -25,8 +25,7 @@ func TestUninstall(t *testing.T) {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
-				"controller-tools.k8s.io": "1.0",
-				util.OperatorLabel:        "test",
+				util.OperatorLabel: "test",
 			},
 			Name: "test",
 		},

--- a/pkg/kudoctl/cmd/update_test.go
+++ b/pkg/kudoctl/cmd/update_test.go
@@ -47,8 +47,7 @@ func TestUpdate(t *testing.T) {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
-				"controller-tools.k8s.io": "1.0",
-				util.OperatorLabel:        "test",
+				util.OperatorLabel: "test",
 			},
 			Name: "test",
 		},

--- a/pkg/kudoctl/kudoinit/crd/crds.go
+++ b/pkg/kudoctl/kudoinit/crd/crds.go
@@ -247,11 +247,9 @@ func generateCrd(kind string, plural string) *apiextv1beta1.CustomResourceDefini
 	plural = strings.ToLower(plural)
 	name := plural + "." + group
 
-	labels := kudoinit.GenerateLabels(map[string]string{"controller-tools.k8s.io": "1.0"})
 	crd := &apiextv1beta1.CustomResourceDefinition{
 		ObjectMeta: v1.ObjectMeta{
-			Name:   name,
-			Labels: labels,
+			Name: name,
 		},
 		Spec: apiextv1beta1.CustomResourceDefinitionSpec{
 			Group:   group,

--- a/pkg/kudoctl/kudoinit/manager/manager.go
+++ b/pkg/kudoctl/kudoinit/manager/manager.go
@@ -101,7 +101,7 @@ func (m Initializer) AsYamlManifests() ([]string, error) {
 
 // GenerateLabels returns the labels used by deployment and service
 func GenerateLabels() labels.Set {
-	return kudoinit.GenerateLabels(map[string]string{"control-plane": "controller-manager", "controller-tools.k8s.io": "1.0"})
+	return kudoinit.GenerateLabels(map[string]string{"control-plane": "controller-manager"})
 }
 
 func generateDeployment(opts kudoinit.Options) *appsv1.StatefulSet {

--- a/pkg/kudoctl/kudoinit/prereq/namespace.go
+++ b/pkg/kudoctl/kudoinit/prereq/namespace.go
@@ -62,7 +62,7 @@ func (o kudoNamespace) AsRuntimeObjs() []runtime.Object {
 
 // generateSysNamespace builds the system namespace
 func generateSysNamespace(namespace string) *v1.Namespace {
-	labels := kudoinit.GenerateLabels(map[string]string{"controller-tools.k8s.io": "1.0"})
+	labels := kudoinit.GenerateLabels(map[string]string{})
 	return &v1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: labels,

--- a/pkg/kudoctl/packages/package.go
+++ b/pkg/kudoctl/packages/package.go
@@ -36,8 +36,7 @@ func (p *Files) Resources() (*Resources, error) {
 			APIVersion: APIVersion,
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   p.Operator.Name,
-			Labels: map[string]string{"controller-tools.k8s.io": "1.0"},
+			Name: p.Operator.Name,
 		},
 		Spec: v1beta1.OperatorSpec{
 			Description:       p.Operator.Description,
@@ -55,8 +54,7 @@ func (p *Files) Resources() (*Resources, error) {
 			APIVersion: APIVersion,
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   fmt.Sprintf("%s-%s", p.Operator.Name, p.Operator.Version),
-			Labels: map[string]string{"controller-tools.k8s.io": "1.0"},
+			Name: fmt.Sprintf("%s-%s", p.Operator.Name, p.Operator.Version),
 		},
 		Spec: v1beta1.OperatorVersionSpec{
 			Operator: v1.ObjectReference{
@@ -81,7 +79,7 @@ func (p *Files) Resources() (*Resources, error) {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   fmt.Sprintf("%s-instance", p.Operator.Name),
-			Labels: map[string]string{"controller-tools.k8s.io": "1.0", kudo.OperatorLabel: p.Operator.Name},
+			Labels: map[string]string{kudo.OperatorLabel: p.Operator.Name},
 		},
 		Spec: v1beta1.InstanceSpec{
 			OperatorVersion: v1.ObjectReference{

--- a/pkg/kudoctl/packages/testdata/zk-crd-golden1/instance.golden
+++ b/pkg/kudoctl/packages/testdata/zk-crd-golden1/instance.golden
@@ -2,7 +2,6 @@ apiVersion: kudo.dev/v1beta1
 kind: Instance
 metadata:
   labels:
-    controller-tools.k8s.io: "1.0"
     kudo.dev/operator: zookeeper
   name: zk1
 spec:

--- a/pkg/kudoctl/packages/testdata/zk-crd-golden1/operator.golden
+++ b/pkg/kudoctl/packages/testdata/zk-crd-golden1/operator.golden
@@ -1,8 +1,6 @@
 apiVersion: kudo.dev/v1beta1
 kind: Operator
 metadata:
-  labels:
-    controller-tools.k8s.io: "1.0"
   name: zookeeper
 spec:
   url: https://zookeeper.apache.org/

--- a/pkg/kudoctl/packages/testdata/zk-crd-golden1/operatorversion.golden
+++ b/pkg/kudoctl/packages/testdata/zk-crd-golden1/operatorversion.golden
@@ -1,8 +1,6 @@
 apiVersion: kudo.dev/v1beta1
 kind: OperatorVersion
 metadata:
-  labels:
-    controller-tools.k8s.io: "1.0"
   name: zookeeper-0.1.0
 spec:
   operator:

--- a/pkg/kudoctl/packages/testdata/zk-crd-golden2/instance.golden
+++ b/pkg/kudoctl/packages/testdata/zk-crd-golden2/instance.golden
@@ -2,7 +2,6 @@ apiVersion: kudo.dev/v1beta1
 kind: Instance
 metadata:
   labels:
-    controller-tools.k8s.io: "1.0"
     kudo.dev/operator: zookeeper
   name: zk2
 spec:

--- a/pkg/kudoctl/packages/testdata/zk-crd-golden2/operator.golden
+++ b/pkg/kudoctl/packages/testdata/zk-crd-golden2/operator.golden
@@ -1,8 +1,6 @@
 apiVersion: kudo.dev/v1beta1
 kind: Operator
 metadata:
-  labels:
-    controller-tools.k8s.io: "1.0"
   name: zookeeper
 spec:
   url: https://zookeeper.apache.org/

--- a/pkg/kudoctl/packages/testdata/zk-crd-golden2/operatorversion.golden
+++ b/pkg/kudoctl/packages/testdata/zk-crd-golden2/operatorversion.golden
@@ -1,8 +1,6 @@
 apiVersion: kudo.dev/v1beta1
 kind: OperatorVersion
 metadata:
-  labels:
-    controller-tools.k8s.io: "1.0"
   name: zookeeper-0.1.0
 spec:
   operator:

--- a/pkg/kudoctl/util/kudo/install_test.go
+++ b/pkg/kudoctl/util/kudo/install_test.go
@@ -24,9 +24,6 @@ func Test_InstallPackage(t *testing.T) {
 				Kind:       "Operator",
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Labels: map[string]string{
-					"controller-tools.k8s.io": "1.0",
-				},
 				Name: "test",
 			},
 			Spec: v1beta1.OperatorSpec{
@@ -40,8 +37,7 @@ func Test_InstallPackage(t *testing.T) {
 			},
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
-					"controller-tools.k8s.io": "1.0",
-					"operator":                "test",
+					"operator": "test",
 				},
 				Name: "test",
 			},
@@ -57,9 +53,6 @@ func Test_InstallPackage(t *testing.T) {
 				Kind:       "OperatorVersion",
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Labels: map[string]string{
-					"controller-tools.k8s.io": "1.0",
-				},
 				Name: fmt.Sprintf("%s-1.0", "operator"),
 			},
 			Spec: v1beta1.OperatorVersionSpec{

--- a/pkg/kudoctl/util/kudo/kudo.go
+++ b/pkg/kudoctl/util/kudo/kudo.go
@@ -101,7 +101,6 @@ func (c *Client) OperatorExistsInCluster(name, namespace string) bool {
 //    		creationTimestamp: "2019-02-28T14:39:20Z"
 //    		generation: 1
 //    		labels:
-//      		controller-tools.k8s.io: "1.0"
 //      		kudo.dev/operator: kafka
 // This function also just returns true if the Instance matches a specific OperatorVersion of an Operator
 func (c *Client) InstanceExistsInCluster(operatorName, namespace, version, instanceName string) (bool, error) {

--- a/pkg/kudoctl/util/kudo/kudo_test.go
+++ b/pkg/kudoctl/util/kudo/kudo_test.go
@@ -40,9 +40,6 @@ func TestKudoClient_OperatorExistsInCluster(t *testing.T) {
 			Kind:       "Operator",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Labels: map[string]string{
-				"controller-tools.k8s.io": "1.0",
-			},
 			Name: "test",
 		},
 	}
@@ -89,8 +86,7 @@ func TestKudoClient_InstanceExistsInCluster(t *testing.T) {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
-				"controller-tools.k8s.io": "1.0",
-				kudo.OperatorLabel:        "test",
+				kudo.OperatorLabel: "test",
 			},
 			Name: "test",
 		},
@@ -108,8 +104,7 @@ func TestKudoClient_InstanceExistsInCluster(t *testing.T) {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
-				"controller-tools.k8s.io": "1.0",
-				kudo.OperatorLabel:        "test",
+				kudo.OperatorLabel: "test",
 			},
 			Name: "test",
 		},
@@ -163,8 +158,7 @@ func TestKudoClient_ListInstances(t *testing.T) {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
-				"controller-tools.k8s.io": "1.0",
-				kudo.OperatorLabel:        "test",
+				kudo.OperatorLabel: "test",
 			},
 			Name: "test",
 		},
@@ -213,9 +207,6 @@ func TestKudoClient_OperatorVersionsInstalled(t *testing.T) {
 			Kind:       "OperatorVersion",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Labels: map[string]string{
-				"controller-tools.k8s.io": "1.0",
-			},
 			Name: fmt.Sprintf("%s-1.0", operatorName),
 		},
 		Spec: v1beta1.OperatorVersionSpec{
@@ -261,9 +252,6 @@ func TestKudoClient_InstallOperatorObjToCluster(t *testing.T) {
 			Kind:       "Operator",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Labels: map[string]string{
-				"controller-tools.k8s.io": "1.0",
-			},
 			Name: "test",
 		},
 	}
@@ -304,9 +292,6 @@ func TestKudoClient_InstallOperatorVersionObjToCluster(t *testing.T) {
 			Kind:       "OperatorVersion",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Labels: map[string]string{
-				"controller-tools.k8s.io": "1.0",
-			},
 			Name: "test",
 		},
 	}
@@ -347,9 +332,6 @@ func TestKudoClient_InstallInstanceObjToCluster(t *testing.T) {
 			Kind:       "OperatorVersion",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Labels: map[string]string{
-				"controller-tools.k8s.io": "1.0",
-			},
 			Name: "test",
 		},
 	}
@@ -391,8 +373,7 @@ func TestKudoClient_GetInstance(t *testing.T) {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
-				"controller-tools.k8s.io": "1.0",
-				kudo.OperatorLabel:        "test",
+				kudo.OperatorLabel: "test",
 			},
 			Name: "test",
 		},
@@ -442,9 +423,6 @@ func TestKudoClient_GetOperatorVersion(t *testing.T) {
 			Kind:       "OperatorVersion",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Labels: map[string]string{
-				"controller-tools.k8s.io": "1.0",
-			},
 			Name: fmt.Sprintf("%s-1.0", operatorName),
 		},
 		Spec: v1beta1.OperatorVersionSpec{
@@ -491,8 +469,7 @@ func TestKudoClient_UpdateOperatorVersion(t *testing.T) {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
-				"controller-tools.k8s.io": "1.0",
-				kudo.OperatorLabel:        "test",
+				kudo.OperatorLabel: "test",
 			},
 			Name: "test",
 		},
@@ -570,9 +547,6 @@ func TestKudoClient_DeleteInstance(t *testing.T) {
 			Kind:       "Instance",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Labels: map[string]string{
-				"controller-tools.k8s.io": "1.0",
-			},
 			Name: "test",
 		},
 		Spec: v1beta1.InstanceSpec{

--- a/pkg/kudoctl/util/kudo/upgrade_test.go
+++ b/pkg/kudoctl/util/kudo/upgrade_test.go
@@ -20,9 +20,6 @@ func Test_UpgradeOperatorVersion(t *testing.T) {
 			Kind:       "OperatorVersion",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Labels: map[string]string{
-				"controller-tools.k8s.io": "1.0",
-			},
 			Name: "test-1.0",
 		},
 		Spec: v1beta1.OperatorVersionSpec{
@@ -40,8 +37,7 @@ func Test_UpgradeOperatorVersion(t *testing.T) {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
-				"controller-tools.k8s.io": "1.0",
-				util.OperatorLabel:        "test",
+				util.OperatorLabel: "test",
 			},
 			Name: "test",
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:

- remove the "app: kudo-manager" from CRDs, since it is not really used
  by anything, and will be hard to convince controller-gen to generate
  it when we switch to it
- remove the controller-tools.k8s.io label, (which is not even used by
  controller-tools upstream any more) from EVERYWHERE

This is another baby step towards #862