### PR TITLE
Use empty json tags to please controller-gen.

### DIFF
--- a/pkg/apis/kudo/v1beta1/operatorversion_types.go
+++ b/pkg/apis/kudo/v1beta1/operatorversion_types.go
@@ -119,9 +119,9 @@ type Task struct {
 // with the same json names as it would become ambiguous for the default parser. We might revisit this approach in the
 // future should this become an issue.
 type TaskSpec struct {
-	ResourceTaskSpec
-	DummyTaskSpec
-	PipeTaskSpec
+	ResourceTaskSpec `json:",inline"`
+	DummyTaskSpec    `json:",inline"`
+	PipeTaskSpec     `json:",inline"`
 }
 
 // ResourceTaskSpec is referencing a list of resources
@@ -184,8 +184,8 @@ func init() {
 // OperatorDependency references a defined operator.
 type OperatorDependency struct {
 	// Name specifies the name of the dependency. Referenced via defaults.config.
-	ReferenceName string `json:"referenceName"`
-	corev1.ObjectReference
+	ReferenceName          string `json:"referenceName"`
+	corev1.ObjectReference `json:",inline"`
 
 	// Version captures the requirements for what versions of the above object
 	// are allowed.

--- a/pkg/apis/kudo/v1beta1/test_types.go
+++ b/pkg/apis/kudo/v1beta1/test_types.go
@@ -90,7 +90,7 @@ type TestAssert struct {
 type ObjectReference struct {
 	corev1.ObjectReference `json:",inline"`
 	// Labels to match on.
-	Labels map[string]string
+	Labels map[string]string `json:"labels"`
 }
 
 // Command describes a command to run as a part of a test step or suite.


### PR DESCRIPTION
**What this PR does / why we need it**:

This is a re-post of #1181  which was merged into the wrong branch.

Example messages:
```
pkg/apis/kudo/v1beta1/test_types.go:93:2: encountered struct field "Labels" without JSON tag in type "ObjectReference"
Error: not all generators ran successfully
```

This does not seem to have any effect otherwise.

This is another baby step towards #862 