### PR TITLE
Add annotations for controller-gen.

### DIFF
--- a/pkg/apis/kudo/v1beta1/instance_types.go
+++ b/pkg/apis/kudo/v1beta1/instance_types.go
@@ -575,6 +575,7 @@ func (i *Instance) IsDeleting() bool {
 
 // Instance is the Schema for the instances API.
 // +k8s:openapi-gen=true
+// +kubebuilder:subresource:status
 type Instance struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/kudo/v1beta1/test_types.go
+++ b/pkg/apis/kudo/v1beta1/test_types.go
@@ -38,8 +38,10 @@ type TestSuite struct {
 	// If set, do not delete the mocked control plane or kind cluster.
 	SkipClusterDelete bool `json:"skipClusterDelete"`
 	// Override the default timeout of 30 seconds (in seconds).
+	// +kubebuilder:validation:Format:=int64
 	Timeout int `json:"timeout"`
 	// The maximum number of tests to run at once (default: 8).
+	// +kubebuilder:validation:Format:=int64
 	Parallel int `json:"parallel"`
 	// The directory to output artifacts to (current working directory if not specified).
 	ArtifactsDir string `json:"artifactsDir"`
@@ -58,6 +60,7 @@ type TestStep struct {
 	// Override the default metadata. Set labels or override the test step name.
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
+	// +kubebuilder:validation:Format:=int64
 	Index int `json:"index,omitempty"`
 	// Objects to delete at the beginning of the test step.
 	Delete []ObjectReference `json:"delete,omitempty"`


### PR DESCRIPTION
**What this PR does / why we need it**:

These make the output closer to what is defined in kudoinit.

This is a baby-step towards #862.