### PR TITLE
Add appVersion and version to CRD to match the structs.

### DIFF
--- a/config/crds/kudo_v1beta1_operatorversion.yaml
+++ b/config/crds/kudo_v1beta1_operatorversion.yaml
@@ -24,6 +24,8 @@ spec:
           type: object
         spec:
           properties:
+            appVersion:
+              type: string
             connectionString:
               description: ConnectionString defines a templated string that can be
                 used to connect to an instance of the Operator.
@@ -87,6 +89,8 @@ spec:
               items:
                 type: object
               type: array
+            version:
+              type: string
           type: object
         status:
           type: object

--- a/pkg/kudoctl/cmd/testdata/deploy-kudo-ns.yaml.golden
+++ b/pkg/kudoctl/cmd/testdata/deploy-kudo-ns.yaml.golden
@@ -81,6 +81,8 @@ spec:
           type: object
         spec:
           properties:
+            appVersion:
+              type: string
             connectionString:
               description: ConnectionString defines a templated string that can be
                 used to connect to an instance of the Operator.
@@ -144,6 +146,8 @@ spec:
               items:
                 type: object
               type: array
+            version:
+              type: string
           type: object
         status:
           type: object

--- a/pkg/kudoctl/cmd/testdata/deploy-kudo-sa.yaml.golden
+++ b/pkg/kudoctl/cmd/testdata/deploy-kudo-sa.yaml.golden
@@ -81,6 +81,8 @@ spec:
           type: object
         spec:
           properties:
+            appVersion:
+              type: string
             connectionString:
               description: ConnectionString defines a templated string that can be
                 used to connect to an instance of the Operator.
@@ -144,6 +146,8 @@ spec:
               items:
                 type: object
               type: array
+            version:
+              type: string
           type: object
         status:
           type: object

--- a/pkg/kudoctl/cmd/testdata/deploy-kudo-webhook.yaml.golden
+++ b/pkg/kudoctl/cmd/testdata/deploy-kudo-webhook.yaml.golden
@@ -81,6 +81,8 @@ spec:
           type: object
         spec:
           properties:
+            appVersion:
+              type: string
             connectionString:
               description: ConnectionString defines a templated string that can be
                 used to connect to an instance of the Operator.
@@ -144,6 +146,8 @@ spec:
               items:
                 type: object
               type: array
+            version:
+              type: string
           type: object
         status:
           type: object

--- a/pkg/kudoctl/cmd/testdata/deploy-kudo.yaml.golden
+++ b/pkg/kudoctl/cmd/testdata/deploy-kudo.yaml.golden
@@ -81,6 +81,8 @@ spec:
           type: object
         spec:
           properties:
+            appVersion:
+              type: string
             connectionString:
               description: ConnectionString defines a templated string that can be
                 used to connect to an instance of the Operator.
@@ -144,6 +146,8 @@ spec:
               items:
                 type: object
               type: array
+            version:
+              type: string
           type: object
         status:
           type: object

--- a/pkg/kudoctl/kudoinit/crd/crds.go
+++ b/pkg/kudoctl/kudoinit/crd/crds.go
@@ -166,6 +166,7 @@ func operatorVersionCrd() *apiextv1beta1.CustomResourceDefinition {
 		"spec": {Type: "object"},
 	}
 	specProps := map[string]apiextv1beta1.JSONSchemaProps{
+		"appVersion":       {Type: "string"},
 		"connectionString": {Type: "string", Description: "ConnectionString defines a templated string that can be used to connect to an instance of the Operator."},
 		"operator":         {Type: "object"},
 		"parameters": {
@@ -191,6 +192,7 @@ func operatorVersionCrd() *apiextv1beta1.CustomResourceDefinition {
 			Items:       &apiextv1beta1.JSONSchemaPropsOrArray{Schema: &apiextv1beta1.JSONSchemaProps{Type: "object"}, JSONSchemas: []apiextv1beta1.JSONSchemaProps{}},
 		},
 		"crdVersion": {Type: "string"},
+		"version":    {Type: "string"},
 	}
 
 	validationProps := map[string]apiextv1beta1.JSONSchemaProps{


### PR DESCRIPTION
**What this PR does / why we need it**:

The goal is to make CRDs and the api structs match.

I'm not sure whether this is the way to go - are these the fields that the
current ongoing "versioning" discussion is all about?

In that case perhaps we should instead remove these fields (and code which uses
them, if any) from the structs?

This is a baby-step towards #862.