### PR TITLE
Use the correct type for UpgradableFrom.

### DIFF
--- a/pkg/apis/kudo/v1beta1/operatorversion_types.go
+++ b/pkg/apis/kudo/v1beta1/operatorversion_types.go
@@ -45,7 +45,7 @@ type OperatorVersionSpec struct {
 	Dependencies []OperatorDependency `json:"dependencies,omitempty"`
 
 	// UpgradableFrom lists all OperatorVersions that can upgrade to this OperatorVersion.
-	UpgradableFrom []OperatorVersion `json:"upgradableFrom,omitempty"`
+	UpgradableFrom []corev1.ObjectReference `json:"upgradableFrom,omitempty"`
 }
 
 // Ordering specifies how the subitems in this plan/phase should be rolled out.

--- a/pkg/apis/kudo/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/kudo/v1beta1/zz_generated.deepcopy.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	v1 "k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -440,10 +441,8 @@ func (in *OperatorVersionSpec) DeepCopyInto(out *OperatorVersionSpec) {
 	}
 	if in.UpgradableFrom != nil {
 		in, out := &in.UpgradableFrom, &out.UpgradableFrom
-		*out = make([]OperatorVersion, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = make([]v1.ObjectReference, len(*in))
+		copy(*out, *in)
 	}
 	return
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

It seems to me like using the full-blown type with spec, status and all had been a mistake.
This field seems unused in the code, so maybe that is why this was missed.

This is a baby step towards #862.