### PR TITLE
Windows CLI is not currently built for KUDO so do not include in Krew manifest.

### DIFF
--- a/hack/generate_krew.sh
+++ b/hack/generate_krew.sh
@@ -77,7 +77,9 @@ generate_platform linux amd64 ./kubectl-kudo >> kudo.yaml
 generate_platform linux 386 ./kubectl-kudo >> kudo.yaml
 generate_platform darwin amd64 ./kubectl-kudo >> kudo.yaml
 generate_platform darwin 386 ./kubectl-kudo >> kudo.yaml
-generate_platform windows amd64 ./kubectl-kudo.exe >> kudo.yaml
-generate_platform windows 386 ./kubectl-kudo.exe >> kudo.yaml
+
+### KUDO is not currently built for Windows. Uncomment once it is.
+# generate_platform windows amd64 ./kubectl-kudo.exe >> kudo.yaml
+# generate_platform windows 386 ./kubectl-kudo.exe >> kudo.yaml
 
 echo "To publish to the krew index, create a pull request to https://github.com/kubernetes-sigs/krew-index/tree/master/plugins to update kudo.yaml with the newly generated kudo.yaml."


### PR DESCRIPTION
This fixes the build in https://github.com/kubernetes-sigs/krew-index/pull/389