### PR TITLE
Remove obsolete linting steps from the styleguide

### DIFF
--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -28,15 +28,6 @@ All code should pass the linter. For cases of intentional lint deviation, it is 
 
 `make lint`
 
-All code should pass [staticcheck](http://staticcheck.io/).
-
-`make staticcheck`
-
-All code should pass `go vet`.
-
-`make vet`
-
-
 ### import
 
 The general Go approach is to have a line of separation between Go libraries and external packages. We prefer to have an additional line of separation grouping kudo packages separately at the end. Example:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kudo/blob/master/CONTRIBUTING.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kudobuilder/kudo/blob/master/RELEASE.md
3. Ensure you have added or ran the appropriate tests for your PR
4. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What this PR does / why we need it**:
The `staticcheck` and `vet` linters are included in `golanci-lint` and run as part of `make lint`. This has been added in https://github.com/kudobuilder/kudo/pull/994, but didn't update the styleguide accordingly.
