### PR TITLE
Remove the unused crdVersion from CRD.

### DIFF
--- a/config/crds/kudo_v1beta1_operatorversion.yaml
+++ b/config/crds/kudo_v1beta1_operatorversion.yaml
@@ -27,8 +27,6 @@ spec:
               description: ConnectionString defines a templated string that can be
                 used to connect to an instance of the Operator.
               type: string
-            crdVersion:
-              type: string
             operator:
               type: object
             parameters:

--- a/pkg/kudoctl/cmd/testdata/deploy-kudo-ns.yaml.golden
+++ b/pkg/kudoctl/cmd/testdata/deploy-kudo-ns.yaml.golden
@@ -81,8 +81,6 @@ spec:
               description: ConnectionString defines a templated string that can be
                 used to connect to an instance of the Operator.
               type: string
-            crdVersion:
-              type: string
             operator:
               type: object
             parameters:

--- a/pkg/kudoctl/cmd/testdata/deploy-kudo-sa.yaml.golden
+++ b/pkg/kudoctl/cmd/testdata/deploy-kudo-sa.yaml.golden
@@ -81,8 +81,6 @@ spec:
               description: ConnectionString defines a templated string that can be
                 used to connect to an instance of the Operator.
               type: string
-            crdVersion:
-              type: string
             operator:
               type: object
             parameters:

--- a/pkg/kudoctl/cmd/testdata/deploy-kudo-webhook.yaml.golden
+++ b/pkg/kudoctl/cmd/testdata/deploy-kudo-webhook.yaml.golden
@@ -81,8 +81,6 @@ spec:
               description: ConnectionString defines a templated string that can be
                 used to connect to an instance of the Operator.
               type: string
-            crdVersion:
-              type: string
             operator:
               type: object
             parameters:

--- a/pkg/kudoctl/cmd/testdata/deploy-kudo.yaml.golden
+++ b/pkg/kudoctl/cmd/testdata/deploy-kudo.yaml.golden
@@ -81,8 +81,6 @@ spec:
               description: ConnectionString defines a templated string that can be
                 used to connect to an instance of the Operator.
               type: string
-            crdVersion:
-              type: string
             operator:
               type: object
             parameters:

--- a/pkg/kudoctl/kudoinit/crd/crds.go
+++ b/pkg/kudoctl/kudoinit/crd/crds.go
@@ -191,7 +191,7 @@ func operatorVersionCrd() *apiextv1beta1.CustomResourceDefinition {
 			Description: "UpgradableFrom lists all OperatorVersions that can upgrade to this OperatorVersion.",
 			Items:       &apiextv1beta1.JSONSchemaPropsOrArray{Schema: &apiextv1beta1.JSONSchemaProps{Type: "object"}, JSONSchemas: []apiextv1beta1.JSONSchemaProps{}},
 		},
-		"version":    {Type: "string"},
+		"version": {Type: "string"},
 	}
 
 	validationProps := map[string]apiextv1beta1.JSONSchemaProps{

--- a/pkg/kudoctl/kudoinit/crd/crds.go
+++ b/pkg/kudoctl/kudoinit/crd/crds.go
@@ -191,7 +191,6 @@ func operatorVersionCrd() *apiextv1beta1.CustomResourceDefinition {
 			Description: "UpgradableFrom lists all OperatorVersions that can upgrade to this OperatorVersion.",
 			Items:       &apiextv1beta1.JSONSchemaPropsOrArray{Schema: &apiextv1beta1.JSONSchemaProps{Type: "object"}, JSONSchemas: []apiextv1beta1.JSONSchemaProps{}},
 		},
-		"crdVersion": {Type: "string"},
 		"version":    {Type: "string"},
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Result of discussion in #1198.

It was never used (verified by eyeballing `git log -p` all the way
down), we don't seem to know what it's for, and it has no counterpart in
the structs.

This is a baby step towards #862.