### PR TITLE
When building binaries, compile the whole package.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,12 +70,12 @@ manager-clean:
 run:
     # for local development, webhooks are disabled by default
     # if you enable them, you have to take care of providing the TLS certs locally
-	ENABLE_WEBHOOKS=${ENABLE_WEBHOOKS} go run -ldflags "${LDFLAGS}" ./cmd/manager/main.go
+	ENABLE_WEBHOOKS=${ENABLE_WEBHOOKS} go run -ldflags "${LDFLAGS}" ./cmd/manager
 
 .PHONY: deploy
 # Install KUDO into a cluster via kubectl kudo init
 deploy:
-	go run -ldflags "${LDFLAGS}" cmd/kubectl-kudo/main.go init
+	go run -ldflags "${LDFLAGS}" ./cmd/kubectl-kudo init
 
 .PHONY: deploy-clean
 deploy-clean:
@@ -93,7 +93,7 @@ generate-clean:
 .PHONY: cli-fast
 # Build CLI but don't lint or run code generation first.
 cli-fast:
-	go build -ldflags "${LDFLAGS}" -o bin/${CLI} cmd/kubectl-kudo/main.go
+	go build -ldflags "${LDFLAGS}" -o bin/${CLI} ./cmd/kubectl-kudo
 
 .PHONY: cli
 # Build CLI


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently we have a single file in each of these, so the effect is the same.

However it will save us some frustration if we ever add more, and this way
reflects the intent better.

This was discovered the [hard way](https://github.com/markbates/pkger/issues/57) trying to get `pkger`
working for #862.