### PR TITLE
Improve test transparency.

### DIFF
--- a/hack/run-e2e-tests.sh
+++ b/hack/run-e2e-tests.sh
@@ -3,6 +3,7 @@
 set -o errexit
 set -o nounset
 set -o pipefail
+set -o xtrace
 
 INTEGRATION_OUTPUT_JUNIT=${INTEGRATION_OUTPUT_JUNIT:-false}
 

--- a/hack/run-integration-tests.sh
+++ b/hack/run-integration-tests.sh
@@ -3,6 +3,7 @@
 set -o errexit
 set -o nounset
 set -o pipefail
+set -o xtrace
 
 INTEGRATION_OUTPUT_JUNIT=${INTEGRATION_OUTPUT_JUNIT:-false}
 

--- a/pkg/test/utils/kubernetes.go
+++ b/pkg/test/utils/kubernetes.go
@@ -942,7 +942,7 @@ func RunCommands(logger Logger, namespace string, command string, commands []kud
 		stdout := &bytes.Buffer{}
 		stderr := &bytes.Buffer{}
 
-		logger.Log("Running command:", cmd)
+		logger.Logf("Running command: %s %s", command, cmd)
 
 		err := RunCommand(context.TODO(), namespace, command, cmd, workdir, stdout, stderr)
 		if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

-   Show what commands are being run.

    This makes it easier to get the most focused command for the thing that is
    failing.

-   Show the actual binary which is run.