### PR TITLE
Proposal to drop release blogposts

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -29,7 +29,6 @@ The official binaries for KUDO are created using [goreleaser](https://goreleaser
 1. Invoke goreleaser `goreleaser --rm-dist`.
 1. Update the GH release with Release highlights and a changelog.
 1. Send an announcement email to `kudobuilder@googlegroups.com` with the subject `[ANNOUNCE] Kudo $VERSION is released`
-1. Create a PR against [kudobuilder/kudo.dev](https://github.com/kudobuilder/kudo.dev) with an according [blog post](https://kudo.dev/internal-docs/blog-index.html#release-posts).
 1. Run `./hack/generate_krew.sh` and submit the generated `kudo.yaml` to https://github.com/kubernetes-sigs/krew-index/.
 1. Update KUDO_VERSION [in the Makefile](https://github.com/kudobuilder/operators/blob/master/Makefile#L2) of operators repo
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kudo/blob/master/CONTRIBUTING.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kudobuilder/kudo/blob/master/RELEASE.md
3. Ensure you have added or ran the appropriate tests for your PR
4. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What this PR does / why we need it**:
Since the blogposts were pretty much 1:1 to our releases https://github.com/kudobuilder/kudo/releases I think they don't add much value and I would rather link directly to the release page.

This is just a proposal, feel free to reject if you see a reason to keep doing the blogposts.
