### PR TITLE
Refactor KinD usage in test harness and allow to add (local) containers

### DIFF
--- a/pkg/apis/kudo/v1beta1/test_types.go
+++ b/pkg/apis/kudo/v1beta1/test_types.go
@@ -31,6 +31,8 @@ type TestSuite struct {
 	// If set, each node defined in the kind configuration will have a docker named volume mounted into it to persist
 	// pulled container images across test runs.
 	KINDNodeCache bool `json:"kindNodeCache"`
+	// Containers to load to each KIND node prior to running the tests.
+	KINDContainers []string `json:"kindContainers"`
 	// Whether or not to start the KUDO controller for the tests.
 	StartKUDO bool `json:"startKUDO"`
 	// If set, do not delete the resources after running the tests (implies SkipClusterDelete).

--- a/pkg/test/kind.go
+++ b/pkg/test/kind.go
@@ -1,0 +1,102 @@
+package test
+
+import (
+	"context"
+
+	"sigs.k8s.io/kind/pkg/apis/config/v1alpha3"
+	"sigs.k8s.io/kind/pkg/cluster"
+	"sigs.k8s.io/kind/pkg/cluster/nodes"
+	"sigs.k8s.io/kind/pkg/cluster/nodeutils"
+
+	testutils "github.com/kudobuilder/kudo/pkg/test/utils"
+)
+
+// kind provides a thin abstraction layer for a KIND cluster.
+type kind struct {
+	Provider     *cluster.Provider
+	context      string
+	explicitPath string
+}
+
+func newKind(kindContext string, explicitPath string) kind {
+	provider := cluster.NewProvider()
+
+	return kind{
+		Provider:     provider,
+		context:      kindContext,
+		explicitPath: explicitPath,
+	}
+}
+
+// Run starts a KIND cluster from a given configuration.
+func (k *kind) Run(config *v1alpha3.Cluster) error {
+	return k.Provider.Create(
+		k.context,
+		cluster.CreateWithV1Alpha3Config(config),
+		cluster.CreateWithKubeconfigPath(k.explicitPath),
+	)
+}
+
+// IsRunning checks if a KIND cluster is already running for the current context.
+func (k *kind) IsRunning() bool {
+	contexts, err := k.Provider.List()
+	if err != nil {
+		panic(err)
+	}
+
+	for _, context := range contexts {
+		if context == k.context {
+			return true
+		}
+	}
+
+	return false
+}
+
+// AddContainers loads the named Docker containers into a KIND cluster.
+// The cluster must be running for this to work.
+func (k *kind) AddContainers(docker testutils.DockerClient, containers []string) error {
+	if !k.IsRunning() {
+		panic("KIND cluster isn't running")
+	}
+
+	nodes, err := k.Provider.ListNodes(k.context)
+	if err != nil {
+		return err
+	}
+
+	for _, node := range nodes {
+		for _, container := range containers {
+			if err := loadContainer(docker, node, container); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// CollectLogs saves the cluster logs to a directory.
+func (k *kind) CollectLogs(dir string) error {
+	return k.Provider.CollectLogs(k.context, dir)
+}
+
+// Stop stops the KIND cluster.
+func (k *kind) Stop() error {
+	return k.Provider.Delete(k.context, k.explicitPath)
+}
+
+func loadContainer(docker testutils.DockerClient, node nodes.Node, container string) error {
+	image, err := docker.ImageSave(context.TODO(), []string{container})
+	if err != nil {
+		return err
+	}
+
+	defer image.Close()
+
+	if err := nodeutils.LoadImageArchive(node, image); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/test/kind_integration_test.go
+++ b/pkg/test/kind_integration_test.go
@@ -1,0 +1,109 @@
+//+build integration
+
+package test
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/docker/docker/api/types"
+	dockerClient "github.com/docker/docker/client"
+	"sigs.k8s.io/kind/pkg/apis/config/v1alpha3"
+	"sigs.k8s.io/kind/pkg/cluster/nodes"
+)
+
+const (
+	kindTestContext = "test"
+	testImage = "busybox:latest"
+)
+
+// Tests that Docker images are added to the nodes of a KIND cluster with the
+// 'AddContainers' method.
+func TestAddContainers(t *testing.T) {
+	ctx := context.Background()
+
+	kind := newKind(kindTestContext, "kubeconfig")
+
+	config := v1alpha3.Cluster{}
+
+	if err := kind.Run(&config); err != nil {
+		t.Fatalf("failed to start KIND cluster: %v", err)
+	}
+
+	defer func() {
+		if err := kind.Stop(); err != nil {
+			t.Fatalf("failed to stop KIND cluster: %v", err)
+		}
+	}()
+
+	docker, err := dockerClient.NewClientWithOpts(dockerClient.FromEnv)
+	if err != nil {
+		t.Fatalf("failed to create Docker client: %v", err)
+	}
+
+	docker.NegotiateAPIVersion(ctx)
+
+	if !kind.IsRunning() {
+		t.Error("KIND isn't running")
+	}
+
+	reader, err := docker.ImagePull(ctx, testImage, types.ImagePullOptions{})
+	if err != nil {
+		t.Errorf("failed to pull test image: %v", err)
+	}
+
+	scanner := bufio.NewScanner(reader)
+	for scanner.Scan() {
+		t.Log(scanner.Text())
+	}
+
+	if err := reader.Close(); err != nil {
+		t.Errorf("failed to close image pull output: %v", err)
+	}
+
+	if err := kind.AddContainers(docker, []string{testImage}); err != nil {
+		t.Errorf("failed to add container to KIND cluster: %v", err)
+	}
+
+	nodes, err := kind.Provider.ListNodes(kindTestContext)
+	if err != nil {
+		t.Fatalf("failed to list nodes of KIND cluster: %v", err)
+	}
+
+	for _, node := range nodes {
+		images, err := nodeImages(node)
+		if err != nil {
+			t.Errorf("failed to list node images: %v", err)
+		}
+
+		if !contains(images, testImage) {
+			t.Errorf("failed to find image %s on node %s", testImage, node.String())
+		}
+	}
+}
+
+func nodeImages(node nodes.Node) ([]string, error) {
+	var stdout bytes.Buffer
+
+	cmd := node.Command("ctr", "--namespace=k8s.io", "images", "list", "-q")
+	cmd.SetStdout(&stdout)
+
+	if err := cmd.Run(); err != nil {
+		return []string{}, err
+	}
+
+	return strings.Split(stdout.String(), "\n"), nil
+}
+
+func contains(values []string, value string) bool {
+	for _, v := range values {
+		if strings.Contains(v, value) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/test/utils/docker.go
+++ b/pkg/test/utils/docker.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"context"
+	"io"
 
 	dockertypes "github.com/docker/docker/api/types"
 	volumetypes "github.com/docker/docker/api/types/volume"
@@ -11,4 +12,5 @@ import (
 type DockerClient interface {
 	NegotiateAPIVersion(context.Context)
 	VolumeCreate(context.Context, volumetypes.VolumeCreateBody) (dockertypes.Volume, error)
+	ImageSave(context.Context, []string) (io.ReadCloser, error)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kudo/blob/master/CONTRIBUTING.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kudobuilder/kudo/blob/master/RELEASE.md
3. Ensure you have added or ran the appropriate tests for your PR
4. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What this PR does / why we need it**:
In preparation for https://github.com/kudobuilder/kudo/issues/1177, this PR refactors the `test` packages to have a `kind` struct that is a thin abstraction layer for running KinD clusters.
It adds the 'kindContainers' option to the test harness. This option allows to add (local) Docker images to a KinD cluster, e.g. when testing local artifacts.

Solves #684