### PR TITLE
Verifier for tasks and plans

### DIFF
--- a/pkg/kudoctl/cmd/verify/verify.go
+++ b/pkg/kudoctl/cmd/verify/verify.go
@@ -6,13 +6,14 @@ import (
 
 	"github.com/kudobuilder/kudo/pkg/kudoctl/packages"
 	"github.com/kudobuilder/kudo/pkg/kudoctl/packages/verifier"
+	"github.com/kudobuilder/kudo/pkg/kudoctl/packages/verifier/task"
 	"github.com/kudobuilder/kudo/pkg/kudoctl/packages/verifier/template"
 )
 
 var verifiers = []verifier.PackageVerifier{
 	DuplicateVerifier{},
 	InvalidCharVerifier{";,"},
-	PlanVerifier{},
+	task.ReferenceVerifier{},
 	template.ParametersVerifier{},
 	template.ReferenceVerifier{},
 }
@@ -56,65 +57,6 @@ func (v InvalidCharVerifier) Verify(pf *packages.Files) verifier.Result {
 			}
 		}
 
-	}
-
-	return res
-}
-
-// PlanVerifier verifies plans, with errors for step tasks that do not exist and warnings for tasks which are not used in a plan
-type PlanVerifier struct{}
-
-func (PlanVerifier) Verify(pf *packages.Files) verifier.Result {
-	res := verifier.NewResult()
-	res.Merge(tasksNotDefined(pf))
-	res.Merge(tasksDefinedNotUsed(pf))
-
-	return res
-}
-
-func tasksDefinedNotUsed(pf *packages.Files) verifier.Result {
-	res := verifier.NewResult()
-	usedTasks := make(map[string]bool)
-
-	// map / set of all tasks that are referenced in a plan
-	for _, plan := range pf.Operator.Plans {
-		for _, phase := range plan.Phases {
-			for _, step := range phase.Steps {
-				for _, task := range step.Tasks {
-					usedTasks[task] = true
-				}
-			}
-		}
-	}
-
-	for _, task := range pf.Operator.Tasks {
-		if _, ok := usedTasks[task.Name]; !ok {
-			res.AddWarnings(fmt.Sprintf("task %q defined but not used", task.Name))
-		}
-	}
-
-	return res
-}
-
-func tasksNotDefined(pf *packages.Files) verifier.Result {
-	res := verifier.NewResult()
-	definedTasks := make(map[string]bool)
-
-	// map of all tasks defined
-	for _, task := range pf.Operator.Tasks {
-		definedTasks[task.Name] = true
-	}
-
-	for planName, plan := range pf.Operator.Plans {
-		for _, phase := range plan.Phases {
-			for _, step := range phase.Steps {
-				for _, task := range step.Tasks {
-					if _, ok := definedTasks[task]; !ok {
-						res.AddErrors(fmt.Sprintf("task %q in plan %q is not defined", task, planName))
-					}
-				}
-			}
-		}
 	}
 
 	return res

--- a/pkg/kudoctl/cmd/verify/verify.go
+++ b/pkg/kudoctl/cmd/verify/verify.go
@@ -12,6 +12,7 @@ import (
 var verifiers = []verifier.PackageVerifier{
 	DuplicateVerifier{},
 	InvalidCharVerifier{";,"},
+	PlanVerifier{},
 	template.ParametersVerifier{},
 	template.ReferenceVerifier{},
 }
@@ -55,6 +56,65 @@ func (v InvalidCharVerifier) Verify(pf *packages.Files) verifier.Result {
 			}
 		}
 
+	}
+
+	return res
+}
+
+// PlanVerifier verifies plans, with errors for step tasks that do not exist and warnings for tasks which are not used in a plan
+type PlanVerifier struct{}
+
+func (PlanVerifier) Verify(pf *packages.Files) verifier.Result {
+	res := verifier.NewResult()
+	res.Merge(tasksNotDefined(pf))
+	res.Merge(tasksDefinedNotUsed(pf))
+
+	return res
+}
+
+func tasksDefinedNotUsed(pf *packages.Files) verifier.Result {
+	res := verifier.NewResult()
+	usedTasks := make(map[string]bool)
+
+	// map / set of all tasks that are referenced in a plan
+	for _, plan := range pf.Operator.Plans {
+		for _, phase := range plan.Phases {
+			for _, step := range phase.Steps {
+				for _, task := range step.Tasks {
+					usedTasks[task] = true
+				}
+			}
+		}
+	}
+
+	for _, task := range pf.Operator.Tasks {
+		if _, ok := usedTasks[task.Name]; !ok {
+			res.AddWarnings(fmt.Sprintf("task %q defined but not used", task.Name))
+		}
+	}
+
+	return res
+}
+
+func tasksNotDefined(pf *packages.Files) verifier.Result {
+	res := verifier.NewResult()
+	definedTasks := make(map[string]bool)
+
+	// map of all tasks defined
+	for _, task := range pf.Operator.Tasks {
+		definedTasks[task.Name] = true
+	}
+
+	for planName, plan := range pf.Operator.Plans {
+		for _, phase := range plan.Phases {
+			for _, step := range phase.Steps {
+				for _, task := range step.Tasks {
+					if _, ok := definedTasks[task]; !ok {
+						res.AddErrors(fmt.Sprintf("task %q in plan %q is not defined", task, planName))
+					}
+				}
+			}
+		}
 	}
 
 	return res

--- a/pkg/kudoctl/packages/verifier/task/verify_references.go
+++ b/pkg/kudoctl/packages/verifier/task/verify_references.go
@@ -1,0 +1,67 @@
+package task
+
+import (
+	"fmt"
+
+	"github.com/kudobuilder/kudo/pkg/kudoctl/packages"
+	"github.com/kudobuilder/kudo/pkg/kudoctl/packages/verifier"
+)
+
+// ReferenceVerifier verifies tasks producing errors for tasks referenced in plans that do not exist and warnings for tasks which are not used in a plan
+type ReferenceVerifier struct{}
+
+func (ReferenceVerifier) Verify(pf *packages.Files) verifier.Result {
+	res := verifier.NewResult()
+	res.Merge(tasksNotDefined(pf))
+	res.Merge(tasksDefinedNotUsed(pf))
+
+	return res
+}
+
+func tasksDefinedNotUsed(pf *packages.Files) verifier.Result {
+	res := verifier.NewResult()
+	usedTasks := make(map[string]bool)
+
+	// map / set of all tasks that are referenced in a plan
+	for _, plan := range pf.Operator.Plans {
+		for _, phase := range plan.Phases {
+			for _, step := range phase.Steps {
+				for _, task := range step.Tasks {
+					usedTasks[task] = true
+				}
+			}
+		}
+	}
+
+	for _, task := range pf.Operator.Tasks {
+		if _, ok := usedTasks[task.Name]; !ok {
+			res.AddWarnings(fmt.Sprintf("task %q defined but not used", task.Name))
+		}
+	}
+
+	return res
+}
+
+func tasksNotDefined(pf *packages.Files) verifier.Result {
+	res := verifier.NewResult()
+	definedTasks := make(map[string]bool)
+
+	// map of all tasks defined
+	for _, task := range pf.Operator.Tasks {
+		definedTasks[task.Name] = true
+	}
+
+	for planName, plan := range pf.Operator.Plans {
+		for _, phase := range plan.Phases {
+			for _, step := range phase.Steps {
+				for _, task := range step.Tasks {
+					if _, ok := definedTasks[task]; !ok {
+						res.AddErrors(fmt.Sprintf("task %q in plan %q is not defined", task, planName))
+					}
+				}
+			}
+		}
+	}
+
+	return res
+}

--- a/pkg/kudoctl/packages/verifier/task/verify_references_test.go
+++ b/pkg/kudoctl/packages/verifier/task/verify_references_test.go
@@ -1,0 +1,65 @@
+package task
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/kudobuilder/kudo/pkg/apis/kudo/v1beta1"
+	"github.com/kudobuilder/kudo/pkg/kudoctl/packages"
+)
+
+func TestTaskReferenceVerifier(t *testing.T) {
+
+	// 2 task , 1 referenced, 1 not referenced (results in warning)
+	resources := []string{"sally.yaml"}
+	tasks := []v1beta1.Task{{
+		Name: "thingOne",
+		Kind: "Apply",
+		Spec: v1beta1.TaskSpec{
+			ResourceTaskSpec: v1beta1.ResourceTaskSpec{Resources: resources},
+		},
+	}, {
+		Name: "thingTwo",
+		Kind: "Apply",
+		Spec: v1beta1.TaskSpec{
+			ResourceTaskSpec: v1beta1.ResourceTaskSpec{Resources: resources},
+		},
+	}}
+
+	steps := []v1beta1.Step{{
+		Name:  "cat-in-hat",
+		Tasks: []string{"thingOne"},
+	}, {
+		Name:  "mayham",
+		Tasks: []string{"thingThree"},
+	}}
+
+	phases := []v1beta1.Phase{{
+		Name:     "parents leave",
+		Strategy: "serial",
+		Steps:    steps,
+	}}
+
+	plans := make(map[string]v1beta1.Plan)
+	plans["boring-rainy"] = v1beta1.Plan{
+		Strategy: "serial",
+		Phases:   phases,
+	}
+
+	operator := packages.OperatorFile{
+		Tasks: tasks,
+		Plans: plans,
+	}
+
+	pf := packages.Files{
+		Operator: &operator,
+	}
+	verifier := ReferenceVerifier{}
+	res := verifier.Verify(&pf)
+
+	assert.Equal(t, 1, len(res.Warnings))
+	assert.Equal(t, `task "thingTwo" defined but not used`, res.Warnings[0])
+	assert.Equal(t, 1, len(res.Errors))
+	assert.Equal(t, `task "thingThree" in plan "boring-rainy" is not defined`, res.Errors[0])
+}


### PR DESCRIPTION
Signed-off-by: Ken Sipe <kensipe@gmail.com>

**What this PR does / why we need it**:

Realized with lots of work on operators and skeleton generators that we could use verification on plan tasks and defined tasks since they are loosely coupled by name.

This PR provides a new "PlanVerifier" which provides warnings for tasks that are defined but are not used in a plan and an error for tasks in a plan that are not defined.

Fixes #
