### PR TITLE
Remove unnecessary accidental debug logging from test harness

### DIFF
--- a/pkg/test/utils/kubernetes.go
+++ b/pkg/test/utils/kubernetes.go
@@ -755,7 +755,6 @@ func GetAPIResource(dClient discovery.DiscoveryInterface, gvk schema.GroupVersio
 		return metav1.APIResource{}, err
 	}
 
-	fmt.Printf("%v", resourceTypes)
 	for _, resource := range resourceTypes.APIResources {
 		if !strings.EqualFold(resource.Kind, gvk.Kind) {
 			continue


### PR DESCRIPTION
**What this PR does / why we need it**:

This removes some excessive printing that I believe was introduced by accident, e.g.,:

```
=== RUN   TestWaitForCRDs
&APIResourceList{GroupVersion:apiextensions.k8s.io/v1beta1,APIResources:[]APIResource{APIResource{Name:customresourcedefinitions,Namespaced:false,Kind:CustomResourceDefinition,Verbs:[create delete deletecollection get list patch update watch],ShortNames:[crd crds],SingularName:,Categories:[],Group:,Version:,StorageVersionHash:jfWCUB31mvA=,},APIResource{Name:customresourcedefinitions/status,Namespaced:false,Kind:CustomResourceDefinition,Verbs:[get patch update],ShortNames:[],SingularName:,Categories:[],Group:,Version:,StorageVersionHash:,},},}2019/12/27 00:08:39 CustomResourceDefinition:/instances.kudo.dev created
&APIResourceList{GroupVersion:apiextensions.k8s.io/v1beta1,APIResources:[]APIResource{APIResource{Name:customresourcedefinitions,Namespaced:false,Kind:CustomResourceDefinition,Verbs:[create delete deletecollection get list patch update watch],ShortNames:[crd crds],SingularName:,Categories:[],Group:,Version:,StorageVersionHash:jfWCUB31mvA=,},APIResource{Name:customresourcedefinitions/status,Namespaced:false,Kind:CustomResourceDefinition,Verbs:[get patch update],ShortNames:[],SingularName:,Categories:[],Group:,Version:,StorageVersionHash:,},},}2019/12/27 00:08:39 CustomResourceDefinition:/operators.kudo.dev created
&APIResourceList{GroupVersion:apiextensions.k8s.io/v1beta1,APIResources:[]APIResource{APIResource{Name:customresourcedefinitions,Namespaced:false,Kind:CustomResourceDefinition,Verbs:[create delete deletecollection get list patch update watch],ShortNames:[crd crds],SingularName:,Categories:[],Group:,Version:,StorageVersionHash:jfWCUB31mvA=,},APIResource{Name:customresourcedefinitions/status,Namespaced:false,Kind:CustomResourceDefinition,Verbs:[get patch update],ShortNames:[],SingularName:,Categories:[],Group:,Version:,StorageVersionHash:,},},}2019/12/27 00:08:39 CustomResourceDefinition:/operatorversions.kudo.dev created
&APIResourceList{GroupVersion:apiextensions.k8s.io/v1beta1,APIResources:[]APIResource{APIResource{Name:customresourcedefinitions,Namespaced:false,Kind:CustomResourceDefinition,Verbs:[create delete deletecollection get list patch update watch],ShortNames:[crd crds],SingularName:,Categories:[],Group:,Version:,StorageVersionHash:jfWCUB31mvA=,},APIResource{Name:customresourcedefinitions/status,Namespaced:false,Kind:CustomResourceDefinition,Verbs:[get patch update],ShortNames:[],SingularName:,Categories:[],Group:,Version:,StorageVersionHash:,},},}2019/12/27 00:08:39 CustomResourceDefinition:/teststeps.kudo.dev created
&APIResourceList{GroupVersion:apiextensions.k8s.io/v1beta1,APIResources:[]APIResource{APIResource{Name:customresourcedefinitions,Namespaced:false,Kind:CustomResourceDefinition,Verbs:[create delete deletecollection get list patch update watch],ShortNames:[crd crds],SingularName:,Categories:[],Group:,Version:,StorageVersionHash:jfWCUB31mvA=,},APIResource{Name:customresourcedefinitions/status,Namespaced:false,Kind:CustomResourceDefinition,Verbs:[get patch update],ShortNames:[],SingularName:,Categories:[],Group:,Version:,StorageVersionHash:,},},}2019/12/27 00:08:39 CustomResourceDefinition:/testsuites.kudo.dev created
--- PASS: TestWaitForCRDs (0.22s)
```