### PR TITLE
Code Gen Classes should not have Imports reorganized

### DIFF
--- a/pkg/client/clientset/versioned/clientset.go
+++ b/pkg/client/clientset/versioned/clientset.go
@@ -19,11 +19,10 @@ package versioned
 import (
 	"fmt"
 
+	kudov1beta1 "github.com/kudobuilder/kudo/pkg/client/clientset/versioned/typed/kudo/v1beta1"
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
 	flowcontrol "k8s.io/client-go/util/flowcontrol"
-
-	kudov1beta1 "github.com/kudobuilder/kudo/pkg/client/clientset/versioned/typed/kudo/v1beta1"
 )
 
 type Interface interface {

--- a/pkg/client/clientset/versioned/fake/clientset_generated.go
+++ b/pkg/client/clientset/versioned/fake/clientset_generated.go
@@ -17,15 +17,14 @@ limitations under the License.
 package fake
 
 import (
+	clientset "github.com/kudobuilder/kudo/pkg/client/clientset/versioned"
+	kudov1beta1 "github.com/kudobuilder/kudo/pkg/client/clientset/versioned/typed/kudo/v1beta1"
+	fakekudov1beta1 "github.com/kudobuilder/kudo/pkg/client/clientset/versioned/typed/kudo/v1beta1/fake"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/discovery"
 	fakediscovery "k8s.io/client-go/discovery/fake"
 	"k8s.io/client-go/testing"
-
-	clientset "github.com/kudobuilder/kudo/pkg/client/clientset/versioned"
-	kudov1beta1 "github.com/kudobuilder/kudo/pkg/client/clientset/versioned/typed/kudo/v1beta1"
-	fakekudov1beta1 "github.com/kudobuilder/kudo/pkg/client/clientset/versioned/typed/kudo/v1beta1/fake"
 )
 
 // NewSimpleClientset returns a clientset that will respond with the provided objects.

--- a/pkg/client/clientset/versioned/fake/register.go
+++ b/pkg/client/clientset/versioned/fake/register.go
@@ -17,13 +17,12 @@ limitations under the License.
 package fake
 
 import (
+	kudov1beta1 "github.com/kudobuilder/kudo/pkg/apis/kudo/v1beta1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-
-	kudov1beta1 "github.com/kudobuilder/kudo/pkg/apis/kudo/v1beta1"
 )
 
 var scheme = runtime.NewScheme()

--- a/pkg/client/clientset/versioned/scheme/register.go
+++ b/pkg/client/clientset/versioned/scheme/register.go
@@ -17,13 +17,12 @@ limitations under the License.
 package scheme
 
 import (
+	kudov1beta1 "github.com/kudobuilder/kudo/pkg/apis/kudo/v1beta1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-
-	kudov1beta1 "github.com/kudobuilder/kudo/pkg/apis/kudo/v1beta1"
 )
 
 var Scheme = runtime.NewScheme()

--- a/pkg/client/clientset/versioned/typed/kudo/v1beta1/fake/fake_instance.go
+++ b/pkg/client/clientset/versioned/typed/kudo/v1beta1/fake/fake_instance.go
@@ -17,14 +17,13 @@ limitations under the License.
 package fake
 
 import (
+	v1beta1 "github.com/kudobuilder/kudo/pkg/apis/kudo/v1beta1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	testing "k8s.io/client-go/testing"
-
-	v1beta1 "github.com/kudobuilder/kudo/pkg/apis/kudo/v1beta1"
 )
 
 // FakeInstances implements InstanceInterface

--- a/pkg/client/clientset/versioned/typed/kudo/v1beta1/fake/fake_kudo_client.go
+++ b/pkg/client/clientset/versioned/typed/kudo/v1beta1/fake/fake_kudo_client.go
@@ -17,10 +17,9 @@ limitations under the License.
 package fake
 
 import (
+	v1beta1 "github.com/kudobuilder/kudo/pkg/client/clientset/versioned/typed/kudo/v1beta1"
 	rest "k8s.io/client-go/rest"
 	testing "k8s.io/client-go/testing"
-
-	v1beta1 "github.com/kudobuilder/kudo/pkg/client/clientset/versioned/typed/kudo/v1beta1"
 )
 
 type FakeKudoV1beta1 struct {

--- a/pkg/client/clientset/versioned/typed/kudo/v1beta1/fake/fake_operator.go
+++ b/pkg/client/clientset/versioned/typed/kudo/v1beta1/fake/fake_operator.go
@@ -17,14 +17,13 @@ limitations under the License.
 package fake
 
 import (
+	v1beta1 "github.com/kudobuilder/kudo/pkg/apis/kudo/v1beta1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	testing "k8s.io/client-go/testing"
-
-	v1beta1 "github.com/kudobuilder/kudo/pkg/apis/kudo/v1beta1"
 )
 
 // FakeOperators implements OperatorInterface

--- a/pkg/client/clientset/versioned/typed/kudo/v1beta1/fake/fake_operatorversion.go
+++ b/pkg/client/clientset/versioned/typed/kudo/v1beta1/fake/fake_operatorversion.go
@@ -17,14 +17,13 @@ limitations under the License.
 package fake
 
 import (
+	v1beta1 "github.com/kudobuilder/kudo/pkg/apis/kudo/v1beta1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	testing "k8s.io/client-go/testing"
-
-	v1beta1 "github.com/kudobuilder/kudo/pkg/apis/kudo/v1beta1"
 )
 
 // FakeOperatorVersions implements OperatorVersionInterface

--- a/pkg/client/clientset/versioned/typed/kudo/v1beta1/instance.go
+++ b/pkg/client/clientset/versioned/typed/kudo/v1beta1/instance.go
@@ -19,13 +19,12 @@ package v1beta1
 import (
 	"time"
 
+	v1beta1 "github.com/kudobuilder/kudo/pkg/apis/kudo/v1beta1"
+	scheme "github.com/kudobuilder/kudo/pkg/client/clientset/versioned/scheme"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
-
-	v1beta1 "github.com/kudobuilder/kudo/pkg/apis/kudo/v1beta1"
-	scheme "github.com/kudobuilder/kudo/pkg/client/clientset/versioned/scheme"
 )
 
 // InstancesGetter has a method to return a InstanceInterface.

--- a/pkg/client/clientset/versioned/typed/kudo/v1beta1/kudo_client.go
+++ b/pkg/client/clientset/versioned/typed/kudo/v1beta1/kudo_client.go
@@ -17,10 +17,9 @@ limitations under the License.
 package v1beta1
 
 import (
-	rest "k8s.io/client-go/rest"
-
 	v1beta1 "github.com/kudobuilder/kudo/pkg/apis/kudo/v1beta1"
 	"github.com/kudobuilder/kudo/pkg/client/clientset/versioned/scheme"
+	rest "k8s.io/client-go/rest"
 )
 
 type KudoV1beta1Interface interface {

--- a/pkg/client/clientset/versioned/typed/kudo/v1beta1/operator.go
+++ b/pkg/client/clientset/versioned/typed/kudo/v1beta1/operator.go
@@ -19,13 +19,12 @@ package v1beta1
 import (
 	"time"
 
+	v1beta1 "github.com/kudobuilder/kudo/pkg/apis/kudo/v1beta1"
+	scheme "github.com/kudobuilder/kudo/pkg/client/clientset/versioned/scheme"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
-
-	v1beta1 "github.com/kudobuilder/kudo/pkg/apis/kudo/v1beta1"
-	scheme "github.com/kudobuilder/kudo/pkg/client/clientset/versioned/scheme"
 )
 
 // OperatorsGetter has a method to return a OperatorInterface.

--- a/pkg/client/clientset/versioned/typed/kudo/v1beta1/operatorversion.go
+++ b/pkg/client/clientset/versioned/typed/kudo/v1beta1/operatorversion.go
@@ -19,13 +19,12 @@ package v1beta1
 import (
 	"time"
 
+	v1beta1 "github.com/kudobuilder/kudo/pkg/apis/kudo/v1beta1"
+	scheme "github.com/kudobuilder/kudo/pkg/client/clientset/versioned/scheme"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
-
-	v1beta1 "github.com/kudobuilder/kudo/pkg/apis/kudo/v1beta1"
-	scheme "github.com/kudobuilder/kudo/pkg/client/clientset/versioned/scheme"
 )
 
 // OperatorVersionsGetter has a method to return a OperatorVersionInterface.

--- a/pkg/client/informers/externalversions/factory.go
+++ b/pkg/client/informers/externalversions/factory.go
@@ -21,14 +21,13 @@ import (
 	sync "sync"
 	time "time"
 
+	versioned "github.com/kudobuilder/kudo/pkg/client/clientset/versioned"
+	internalinterfaces "github.com/kudobuilder/kudo/pkg/client/informers/externalversions/internalinterfaces"
+	kudo "github.com/kudobuilder/kudo/pkg/client/informers/externalversions/kudo"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	cache "k8s.io/client-go/tools/cache"
-
-	versioned "github.com/kudobuilder/kudo/pkg/client/clientset/versioned"
-	internalinterfaces "github.com/kudobuilder/kudo/pkg/client/informers/externalversions/internalinterfaces"
-	kudo "github.com/kudobuilder/kudo/pkg/client/informers/externalversions/kudo"
 )
 
 // SharedInformerOption defines the functional option type for SharedInformerFactory.

--- a/pkg/client/informers/externalversions/generic.go
+++ b/pkg/client/informers/externalversions/generic.go
@@ -19,10 +19,9 @@ package externalversions
 import (
 	"fmt"
 
+	v1beta1 "github.com/kudobuilder/kudo/pkg/apis/kudo/v1beta1"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	cache "k8s.io/client-go/tools/cache"
-
-	v1beta1 "github.com/kudobuilder/kudo/pkg/apis/kudo/v1beta1"
 )
 
 // GenericInformer is type of SharedIndexInformer which will locate and delegate to other

--- a/pkg/client/informers/externalversions/internalinterfaces/factory_interfaces.go
+++ b/pkg/client/informers/externalversions/internalinterfaces/factory_interfaces.go
@@ -19,11 +19,10 @@ package internalinterfaces
 import (
 	time "time"
 
+	versioned "github.com/kudobuilder/kudo/pkg/client/clientset/versioned"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	cache "k8s.io/client-go/tools/cache"
-
-	versioned "github.com/kudobuilder/kudo/pkg/client/clientset/versioned"
 )
 
 // NewInformerFunc takes versioned.Interface and time.Duration to return a SharedIndexInformer.

--- a/pkg/client/informers/externalversions/kudo/v1beta1/instance.go
+++ b/pkg/client/informers/externalversions/kudo/v1beta1/instance.go
@@ -19,15 +19,14 @@ package v1beta1
 import (
 	time "time"
 
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	runtime "k8s.io/apimachinery/pkg/runtime"
-	watch "k8s.io/apimachinery/pkg/watch"
-	cache "k8s.io/client-go/tools/cache"
-
 	kudov1beta1 "github.com/kudobuilder/kudo/pkg/apis/kudo/v1beta1"
 	versioned "github.com/kudobuilder/kudo/pkg/client/clientset/versioned"
 	internalinterfaces "github.com/kudobuilder/kudo/pkg/client/informers/externalversions/internalinterfaces"
 	v1beta1 "github.com/kudobuilder/kudo/pkg/client/listers/kudo/v1beta1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	runtime "k8s.io/apimachinery/pkg/runtime"
+	watch "k8s.io/apimachinery/pkg/watch"
+	cache "k8s.io/client-go/tools/cache"
 )
 
 // InstanceInformer provides access to a shared informer and lister for

--- a/pkg/client/informers/externalversions/kudo/v1beta1/operator.go
+++ b/pkg/client/informers/externalversions/kudo/v1beta1/operator.go
@@ -19,15 +19,14 @@ package v1beta1
 import (
 	time "time"
 
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	runtime "k8s.io/apimachinery/pkg/runtime"
-	watch "k8s.io/apimachinery/pkg/watch"
-	cache "k8s.io/client-go/tools/cache"
-
 	kudov1beta1 "github.com/kudobuilder/kudo/pkg/apis/kudo/v1beta1"
 	versioned "github.com/kudobuilder/kudo/pkg/client/clientset/versioned"
 	internalinterfaces "github.com/kudobuilder/kudo/pkg/client/informers/externalversions/internalinterfaces"
 	v1beta1 "github.com/kudobuilder/kudo/pkg/client/listers/kudo/v1beta1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	runtime "k8s.io/apimachinery/pkg/runtime"
+	watch "k8s.io/apimachinery/pkg/watch"
+	cache "k8s.io/client-go/tools/cache"
 )
 
 // OperatorInformer provides access to a shared informer and lister for

--- a/pkg/client/informers/externalversions/kudo/v1beta1/operatorversion.go
+++ b/pkg/client/informers/externalversions/kudo/v1beta1/operatorversion.go
@@ -19,15 +19,14 @@ package v1beta1
 import (
 	time "time"
 
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	runtime "k8s.io/apimachinery/pkg/runtime"
-	watch "k8s.io/apimachinery/pkg/watch"
-	cache "k8s.io/client-go/tools/cache"
-
 	kudov1beta1 "github.com/kudobuilder/kudo/pkg/apis/kudo/v1beta1"
 	versioned "github.com/kudobuilder/kudo/pkg/client/clientset/versioned"
 	internalinterfaces "github.com/kudobuilder/kudo/pkg/client/informers/externalversions/internalinterfaces"
 	v1beta1 "github.com/kudobuilder/kudo/pkg/client/listers/kudo/v1beta1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	runtime "k8s.io/apimachinery/pkg/runtime"
+	watch "k8s.io/apimachinery/pkg/watch"
+	cache "k8s.io/client-go/tools/cache"
 )
 
 // OperatorVersionInformer provides access to a shared informer and lister for

--- a/pkg/client/listers/kudo/v1beta1/instance.go
+++ b/pkg/client/listers/kudo/v1beta1/instance.go
@@ -17,11 +17,10 @@ limitations under the License.
 package v1beta1
 
 import (
+	v1beta1 "github.com/kudobuilder/kudo/pkg/apis/kudo/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
-
-	v1beta1 "github.com/kudobuilder/kudo/pkg/apis/kudo/v1beta1"
 )
 
 // InstanceLister helps list Instances.

--- a/pkg/client/listers/kudo/v1beta1/operator.go
+++ b/pkg/client/listers/kudo/v1beta1/operator.go
@@ -17,11 +17,10 @@ limitations under the License.
 package v1beta1
 
 import (
+	v1beta1 "github.com/kudobuilder/kudo/pkg/apis/kudo/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
-
-	v1beta1 "github.com/kudobuilder/kudo/pkg/apis/kudo/v1beta1"
 )
 
 // OperatorLister helps list Operators.

--- a/pkg/client/listers/kudo/v1beta1/operatorversion.go
+++ b/pkg/client/listers/kudo/v1beta1/operatorversion.go
@@ -17,11 +17,10 @@ limitations under the License.
 package v1beta1
 
 import (
+	v1beta1 "github.com/kudobuilder/kudo/pkg/apis/kudo/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
-
-	v1beta1 "github.com/kudobuilder/kudo/pkg/apis/kudo/v1beta1"
 )
 
 // OperatorVersionLister helps list OperatorVersions.


### PR DESCRIPTION
These classes must have had their imports organized... which was inappropriate for code gen classes.   These classes were re-generated.

Signed-off-by: Ken Sipe <kensipe@gmail.com>

