### PR TITLE
Adding code gen to CI build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,8 @@ jobs:
       - restore_cache:
           keys:
             - go-mod-v1-{{ checksum "go.sum" }}
-      - run: make lint
+            # prebuild runs lint after code generation
+      - run: make prebuild
       - save_cache:
           key: go-mod-v1-{{ checksum "go.sum" }}
           paths:


### PR DESCRIPTION
It is necessary for code gen to be apart of the build process to ensure that code is clean... 
Personally I would prefer we do NOT check in generated code.

Signed-off-by: Ken Sipe <kensipe@gmail.com>
