### PR TITLE
Check that generated files are up to date

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,8 +30,7 @@ jobs:
       - restore_cache:
           keys:
             - go-mod-v1-{{ checksum "go.sum" }}
-            # prebuild runs lint after code generation
-      - run: make prebuild
+      - run: make lint
       - save_cache:
           key: go-mod-v1-{{ checksum "go.sum" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,7 @@ jobs:
           keys:
             - go-mod-v1-{{ checksum "go.sum" }}
       - run: make lint
+      - run: ./hack/verify-generate.sh
       - save_cache:
           key: go-mod-v1-{{ checksum "go.sum" }}
           paths:

--- a/hack/verify-generate.sh
+++ b/hack/verify-generate.sh
@@ -12,6 +12,7 @@ fi
 
 if ! git diff-index --quiet HEAD --; then
     echo "Running 'make generate' produces changes to the current git status. Maybe you forgot to check-in your updated generated files?"
+    echo "The current diff: `git diff`"
     exit 1
 fi
 

--- a/hack/verify-generate.sh
+++ b/hack/verify-generate.sh
@@ -12,12 +12,12 @@ if [[ ${RETVAL} != 0 ]]; then
     exit 1
 fi
 
-git diff-index --quiet HEAD --
+git diff --exit-code --quiet
 RETVAL=$?
 
 if [[ ${RETVAL} != 0 ]]; then
     echo "Running 'make generate' produces changes to the current git status. Maybe you forgot to check-in your updated generated files?"
-    echo "The current diff: `git diff-index HEAD --`"
+    echo "The current diff: `git diff`"
     exit 1
 fi
 

--- a/hack/verify-generate.sh
+++ b/hack/verify-generate.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# make sure make generate can be invoked
+if ! make generate; then
+    echo "Invoking 'make generate' ends with non-zero exit code."
+    exit 1
+fi
+
+if ! git diff-index --quiet HEAD --; then
+    echo "Running 'make generate' produces changes to the current git status. Maybe you forgot to check-in your updated generated files?"
+    exit 1
+fi
+
+echo "Verifying 'make generate' was successful! ヽ(•‿•)ノ"
+exit 0

--- a/hack/verify-generate.sh
+++ b/hack/verify-generate.sh
@@ -14,11 +14,10 @@ fi
 
 git diff-index --quiet HEAD --
 RETVAL=$?
-echo $RETVAL
 
 if [[ ${RETVAL} != 0 ]]; then
     echo "Running 'make generate' produces changes to the current git status. Maybe you forgot to check-in your updated generated files?"
-    echo "The current diff: `git diff`"
+    echo "The current diff: `git diff-index HEAD --`"
     exit 1
 fi
 

--- a/hack/verify-generate.sh
+++ b/hack/verify-generate.sh
@@ -1,16 +1,22 @@
 #!/usr/bin/env bash
 
-set -o errexit
 set -o nounset
 set -o pipefail
+# intentionally not setting 'set -o errexit' because we want to print custom error messages
 
 # make sure make generate can be invoked
-if ! make generate; then
+make generate
+RETVAL=$?
+if [[ ${RETVAL} != 0 ]]; then
     echo "Invoking 'make generate' ends with non-zero exit code."
     exit 1
 fi
 
-if ! git diff-index --quiet HEAD --; then
+git diff-index --quiet HEAD --
+RETVAL=$?
+echo $RETVAL
+
+if [[ ${RETVAL} != 0 ]]; then
     echo "Running 'make generate' produces changes to the current git status. Maybe you forgot to check-in your updated generated files?"
     echo "The current diff: `git diff`"
     exit 1

--- a/pkg/kudoctl/kudoinit/crd/bindata.go
+++ b/pkg/kudoctl/kudoinit/crd/bindata.go
@@ -116,7 +116,7 @@ func configCrdsKudoDev_operatorsYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "config/crds/kudo.dev_operators.yaml", size: 1103, mode: os.FileMode(420), modTime: time.Unix(1577106046, 0)}
+	info := bindataFileInfo{name: "config/crds/kudo.dev_operators.yaml", size: 1103, mode: os.FileMode(420), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -136,7 +136,7 @@ func configCrdsKudoDev_operatorversionsYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "config/crds/kudo.dev_operatorversions.yaml", size: 3449, mode: os.FileMode(420), modTime: time.Unix(1577106046, 0)}
+	info := bindataFileInfo{name: "config/crds/kudo.dev_operatorversions.yaml", size: 3449, mode: os.FileMode(420), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -156,7 +156,7 @@ func configCrdsKudoDev_teststepsYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "config/crds/kudo.dev_teststeps.yaml", size: 3992, mode: os.FileMode(420), modTime: time.Unix(1577106046, 0)}
+	info := bindataFileInfo{name: "config/crds/kudo.dev_teststeps.yaml", size: 3992, mode: os.FileMode(420), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -176,7 +176,7 @@ func configCrdsKudoDev_testsuitesYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "config/crds/kudo.dev_testsuites.yaml", size: 3529, mode: os.FileMode(420), modTime: time.Unix(1577106046, 0)}
+	info := bindataFileInfo{name: "config/crds/kudo.dev_testsuites.yaml", size: 3529, mode: os.FileMode(420), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/pkg/kudoctl/kudoinit/crd/bindata.go
+++ b/pkg/kudoctl/kudoinit/crd/bindata.go
@@ -96,7 +96,7 @@ func configCrdsKudoDev_instancesYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "config/crds/kudo.dev_instances.yaml", size: 1040, mode: os.FileMode(420), modTime: time.Unix(1577106046, 0)}
+	info := bindataFileInfo{name: "config/crds/kudo.dev_instances.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/pkg/kudoctl/kudoinit/crd/bindata.go
+++ b/pkg/kudoctl/kudoinit/crd/bindata.go
@@ -96,7 +96,7 @@ func configCrdsKudoDev_instancesYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "config/crds/kudo.dev_instances.yaml", size: 1040, mode: os.FileMode(420), modTime: time.Unix(1576836957, 0)}
+	info := bindataFileInfo{name: "config/crds/kudo.dev_instances.yaml", size: 1040, mode: os.FileMode(420), modTime: time.Unix(1577106046, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -116,7 +116,7 @@ func configCrdsKudoDev_operatorsYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "config/crds/kudo.dev_operators.yaml", size: 1103, mode: os.FileMode(420), modTime: time.Unix(1576836957, 0)}
+	info := bindataFileInfo{name: "config/crds/kudo.dev_operators.yaml", size: 1103, mode: os.FileMode(420), modTime: time.Unix(1577106046, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -136,7 +136,7 @@ func configCrdsKudoDev_operatorversionsYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "config/crds/kudo.dev_operatorversions.yaml", size: 3449, mode: os.FileMode(420), modTime: time.Unix(1576836957, 0)}
+	info := bindataFileInfo{name: "config/crds/kudo.dev_operatorversions.yaml", size: 3449, mode: os.FileMode(420), modTime: time.Unix(1577106046, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -156,7 +156,7 @@ func configCrdsKudoDev_teststepsYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "config/crds/kudo.dev_teststeps.yaml", size: 3992, mode: os.FileMode(420), modTime: time.Unix(1576836957, 0)}
+	info := bindataFileInfo{name: "config/crds/kudo.dev_teststeps.yaml", size: 3992, mode: os.FileMode(420), modTime: time.Unix(1577106046, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -176,7 +176,7 @@ func configCrdsKudoDev_testsuitesYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "config/crds/kudo.dev_testsuites.yaml", size: 3529, mode: os.FileMode(420), modTime: time.Unix(1576836957, 0)}
+	info := bindataFileInfo{name: "config/crds/kudo.dev_testsuites.yaml", size: 3529, mode: os.FileMode(420), modTime: time.Unix(1577106046, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kudo/blob/master/CONTRIBUTING.md
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://github.com/kudobuilder/kudo/blob/master/RELEASE.md
3. Ensure you have added or ran the appropriate tests for your PR
4. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What this PR does / why we need it**:
The problem I with #1231 is that we're not just checking generate exit code but we're also **generating files in CI** and we're then running build and tests on those generated files instead on those checked in. Because of that, if someone forgets to check in their generated file as part of commit, this won't be catched in CI because CI will build on code that was produced by running the introduced `make generate`.

One solution would be to remove generated files from git and always force people to generate. I see two problems with that:
- generate is pretty slow, just when I was debugging this PR, I spent so much time just waiting for it to finish, I cannot see that doing before every build
-  it's recommended and even required if your code is used as a library by Go authors to have generated files checked in `Also, if the containing package is intended for import by go get, once the file is generated (and tested!) it must be checked into the source code repository to be available to clients.` see https://blog.golang.org/generate for reference