### PR TITLE
need to lock in version of generators

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ deploy-clean:
 # Generate code
 generate:
 ifeq (, $(shell which go-bindata))
-	go get github.com/go-bindata/go-bindata/go-bindata
+	go get github.com/go-bindata/go-bindata/go-bindata@v3.1.2
 endif
 	go-bindata -pkg crd -o pkg/kudoctl/kudoinit/crd/bindata.go -ignore README.md config/crds
 	./hack/update_codegen.sh

--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ generate:
 ifeq (, $(shell which go-bindata))
 	go get github.com/go-bindata/go-bindata/go-bindata@v3.1.2
 endif
-	go-bindata -pkg crd -o pkg/kudoctl/kudoinit/crd/bindata.go -ignore README.md config/crds
+	go-bindata -pkg crd -o pkg/kudoctl/kudoinit/crd/bindata.go -ignore README.md -modtime 0 config/crds
 	./hack/update_codegen.sh
 
 .PHONY: generate-clean

--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ generate:
 ifeq (, $(shell which go-bindata))
 	go get github.com/go-bindata/go-bindata/go-bindata@v3.1.2
 endif
-	go-bindata -pkg crd -o pkg/kudoctl/kudoinit/crd/bindata.go -ignore README.md -modtime 0 config/crds
+	go-bindata -pkg crd -o pkg/kudoctl/kudoinit/crd/bindata.go -ignore README.md -nometadata config/crds
 	./hack/update_codegen.sh
 
 .PHONY: generate-clean

--- a/pkg/kudoctl/kudoinit/crd/bindata.go
+++ b/pkg/kudoctl/kudoinit/crd/bindata.go
@@ -96,7 +96,7 @@ func configCrdsKudoDev_instancesYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "config/crds/kudo.dev_instances.yaml", size: 1040, mode: os.FileMode(420), modTime: time.Unix(1577746674, 0)}
+	info := bindataFileInfo{name: "config/crds/kudo.dev_instances.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -116,7 +116,7 @@ func configCrdsKudoDev_operatorsYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "config/crds/kudo.dev_operators.yaml", size: 1103, mode: os.FileMode(420), modTime: time.Unix(1577746674, 0)}
+	info := bindataFileInfo{name: "config/crds/kudo.dev_operators.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -136,7 +136,7 @@ func configCrdsKudoDev_operatorversionsYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "config/crds/kudo.dev_operatorversions.yaml", size: 3449, mode: os.FileMode(420), modTime: time.Unix(1577746674, 0)}
+	info := bindataFileInfo{name: "config/crds/kudo.dev_operatorversions.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -156,7 +156,7 @@ func configCrdsKudoDev_teststepsYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "config/crds/kudo.dev_teststeps.yaml", size: 3992, mode: os.FileMode(420), modTime: time.Unix(1577746674, 0)}
+	info := bindataFileInfo{name: "config/crds/kudo.dev_teststeps.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -176,7 +176,7 @@ func configCrdsKudoDev_testsuitesYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "config/crds/kudo.dev_testsuites.yaml", size: 3529, mode: os.FileMode(420), modTime: time.Unix(1577746674, 0)}
+	info := bindataFileInfo{name: "config/crds/kudo.dev_testsuites.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/pkg/kudoctl/kudoinit/crd/bindata.go
+++ b/pkg/kudoctl/kudoinit/crd/bindata.go
@@ -96,7 +96,7 @@ func configCrdsKudoDev_instancesYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "config/crds/kudo.dev_instances.yaml", size: 1040, mode: os.FileMode(420), modTime: time.Unix(1577472062, 0)}
+	info := bindataFileInfo{name: "config/crds/kudo.dev_instances.yaml", size: 1040, mode: os.FileMode(420), modTime: time.Unix(1577746674, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -116,7 +116,7 @@ func configCrdsKudoDev_operatorsYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "config/crds/kudo.dev_operators.yaml", size: 1103, mode: os.FileMode(420), modTime: time.Unix(1577472062, 0)}
+	info := bindataFileInfo{name: "config/crds/kudo.dev_operators.yaml", size: 1103, mode: os.FileMode(420), modTime: time.Unix(1577746674, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -136,7 +136,7 @@ func configCrdsKudoDev_operatorversionsYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "config/crds/kudo.dev_operatorversions.yaml", size: 3449, mode: os.FileMode(420), modTime: time.Unix(1577472062, 0)}
+	info := bindataFileInfo{name: "config/crds/kudo.dev_operatorversions.yaml", size: 3449, mode: os.FileMode(420), modTime: time.Unix(1577746674, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -156,7 +156,7 @@ func configCrdsKudoDev_teststepsYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "config/crds/kudo.dev_teststeps.yaml", size: 3992, mode: os.FileMode(420), modTime: time.Unix(1577472062, 0)}
+	info := bindataFileInfo{name: "config/crds/kudo.dev_teststeps.yaml", size: 3992, mode: os.FileMode(420), modTime: time.Unix(1577746674, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -176,7 +176,7 @@ func configCrdsKudoDev_testsuitesYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "config/crds/kudo.dev_testsuites.yaml", size: 3529, mode: os.FileMode(420), modTime: time.Unix(1577472062, 0)}
+	info := bindataFileInfo{name: "config/crds/kudo.dev_testsuites.yaml", size: 3529, mode: os.FileMode(420), modTime: time.Unix(1577746674, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/pkg/kudoctl/kudoinit/crd/bindata.go
+++ b/pkg/kudoctl/kudoinit/crd/bindata.go
@@ -96,7 +96,7 @@ func configCrdsKudoDev_instancesYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "config/crds/kudo.dev_instances.yaml", size: 1040, mode: os.FileMode(420), modTime: time.Unix(1576836957, 0)}
+	info := bindataFileInfo{name: "config/crds/kudo.dev_instances.yaml", size: 1040, mode: os.FileMode(420), modTime: time.Unix(1577472062, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -116,7 +116,7 @@ func configCrdsKudoDev_operatorsYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "config/crds/kudo.dev_operators.yaml", size: 1103, mode: os.FileMode(420), modTime: time.Unix(1576836957, 0)}
+	info := bindataFileInfo{name: "config/crds/kudo.dev_operators.yaml", size: 1103, mode: os.FileMode(420), modTime: time.Unix(1577472062, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -136,7 +136,7 @@ func configCrdsKudoDev_operatorversionsYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "config/crds/kudo.dev_operatorversions.yaml", size: 3449, mode: os.FileMode(420), modTime: time.Unix(1576836957, 0)}
+	info := bindataFileInfo{name: "config/crds/kudo.dev_operatorversions.yaml", size: 3449, mode: os.FileMode(420), modTime: time.Unix(1577472062, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -156,7 +156,7 @@ func configCrdsKudoDev_teststepsYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "config/crds/kudo.dev_teststeps.yaml", size: 3992, mode: os.FileMode(420), modTime: time.Unix(1576836957, 0)}
+	info := bindataFileInfo{name: "config/crds/kudo.dev_teststeps.yaml", size: 3992, mode: os.FileMode(420), modTime: time.Unix(1577472062, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -176,7 +176,7 @@ func configCrdsKudoDev_testsuitesYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "config/crds/kudo.dev_testsuites.yaml", size: 3529, mode: os.FileMode(420), modTime: time.Unix(1576836957, 0)}
+	info := bindataFileInfo{name: "config/crds/kudo.dev_testsuites.yaml", size: 3529, mode: os.FileMode(420), modTime: time.Unix(1577472062, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }


### PR DESCRIPTION
Signed-off-by: Ken Sipe <kensipe@gmail.com>

Follow up to https://github.com/kudobuilder/kudo/pull/1211 
It is not OK to not lock in the version of the build tool chain.

Also the file gen is out of date :( 