### PR TITLE
Run a KUDO deployment for E2E testing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,7 @@
 FROM golang:1.13 as builder
 
 # Setting arguments
-ARG git_version_arg
-ARG git_commit_arg
-ARG build_date_arg
+ARG ldflags_arg
 
 
 # Copy in the go src
@@ -17,9 +15,7 @@ ENV GO111MODULE on
 
 # Build with ldflags set
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager \
-    -ldflags "-X ${git_version_arg} \
-              -X ${git_commit_arg} \
-              -X ${build_date_arg}" github.com/kudobuilder/kudo/cmd/manager
+    -ldflags "${ldflags_arg}" github.com/kudobuilder/kudo/cmd/manager
 
 # Copy the controller-manager into a thin image
 FROM ubuntu:18.04

--- a/Makefile
+++ b/Makefile
@@ -119,9 +119,7 @@ clean:  cli-clean test-clean manager-clean deploy-clean
 .PHONY: docker-build
 # Build the docker image
 docker-build: generate lint
-	docker build --build-arg git_version_arg=${GIT_VERSION_PATH}=v${GIT_VERSION} \
-	--build-arg git_commit_arg=${GIT_COMMIT_PATH}=${GIT_COMMIT} \
-	--build-arg build_date_arg=${BUILD_DATE_PATH}=${BUILD_DATE} . -t ${DOCKER_IMG}:${DOCKER_TAG}
+	docker build --build-arg ldflags_arg="${LDFLAGS}" . -t ${DOCKER_IMG}:${DOCKER_TAG}
 	docker tag ${DOCKER_IMG}:${DOCKER_TAG} ${DOCKER_IMG}:v${GIT_VERSION}
 	docker tag ${DOCKER_IMG}:${DOCKER_TAG} ${DOCKER_IMG}:latest
 

--- a/hack/run-e2e-tests.sh
+++ b/hack/run-e2e-tests.sh
@@ -6,6 +6,17 @@ set -o pipefail
 set -o xtrace
 
 INTEGRATION_OUTPUT_JUNIT=${INTEGRATION_OUTPUT_JUNIT:-false}
+VERSION=${VERSION:-test}
+
+docker build . \
+    --build-arg ldflags_arg="" \
+    -t "kudobuilder/controller:$VERSION"
+
+./bin/kubectl-kudo init --dry-run --output yaml \
+    | sed -E -e "/image:/ s/:[[:alnum:]]+/:$VERSION/" -e '/imagePullPolicy/ s/Always/Never/' \
+    > test/manifests/kudo.yaml
+
+sed "s/%version%/$VERSION/" kudo-e2e-test.yaml.tmpl > kudo-e2e-test.yaml
 
 if [ "$INTEGRATION_OUTPUT_JUNIT" == true ]
 then
@@ -13,21 +24,27 @@ then
     mkdir -p reports/
     go get github.com/jstemmer/go-junit-report
 
-    go run ./cmd/kubectl-kudo test --config kudo-e2e-test.yaml 2>&1 |tee /dev/fd/2 |go-junit-report -set-exit-code > reports/kudo_e2e_test_report.xml
+    ./bin/kubectl-kudo test --config kudo-e2e-test.yaml 2>&1 \
+        | tee /dev/fd/2 \
+        | go-junit-report -set-exit-code \
+        > reports/kudo_e2e_test_report.xml
 
-	rm -rf operators
-	git clone https://github.com/kudobuilder/operators
-	mkdir operators/bin/
-	cp ./bin/kubectl-kudo operators/bin/
-	cd operators && go run ../cmd/kubectl-kudo test 2>&1 |tee /dev/fd/2 |go-junit-report -set-exit-code > ../reports/kudo_operators_test_report.xml
+    rm -rf operators
+    git clone https://github.com/kudobuilder/operators
+    mkdir operators/bin/
+    cp ./bin/kubectl-kudo operators/bin/
+    cd operators && ./bin/kubectl-kudo test 2>&1 \
+        | tee /dev/fd/2 \
+        | go-junit-report -set-exit-code \
+        > ../reports/kudo_operators_test_report.xml
 else
     echo "Running E2E tests without junit output"
 
-    go run ./cmd/kubectl-kudo test --config kudo-e2e-test.yaml
+    ./bin/kubectl-kudo test --config kudo-e2e-test.yaml
 
-	rm -rf operators
-	git clone https://github.com/kudobuilder/operators
-	mkdir operators/bin/
-	cp ./bin/kubectl-kudo operators/bin/
-	cd operators && go run ../cmd/kubectl-kudo test
+    rm -rf operators
+    git clone https://github.com/kudobuilder/operators
+    mkdir operators/bin/
+    cp ./bin/kubectl-kudo operators/bin/
+    cd operators && ./bin/kubectl-kudo test
 fi

--- a/hack/run-e2e-tests.sh
+++ b/hack/run-e2e-tests.sh
@@ -12,6 +12,7 @@ docker build . \
     --build-arg ldflags_arg="" \
     -t "kudobuilder/controller:$VERSION"
 
+# Generate the kudo.yaml that is used to install KUDO while running e2e-test
 ./bin/kubectl-kudo init --dry-run --output yaml \
     | sed -E -e "/image:/ s/:[[:alnum:]]+/:$VERSION/" -e '/imagePullPolicy/ s/Always/Never/' \
     > test/manifests/kudo.yaml

--- a/kudo-e2e-test.yaml.tmpl
+++ b/kudo-e2e-test.yaml.tmpl
@@ -6,5 +6,7 @@ manifestDirs:
 testDirs:
 - ./test/e2e
 startKIND: true
-startKUDO: true
+kindContainers:
+- kudobuilder/controller:%version%
+startKUDO: false
 timeout: 300

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && apt-get install -y \
     add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable" && \
     apt-get update && apt-get install -y docker-ce-cli
 
-COPY Makefile go.mod go.sum ./
+COPY Dockerfile Makefile go.mod go.sum ./
 RUN make download
 COPY config/ config/
 COPY pkg/ pkg/
@@ -21,4 +21,4 @@ COPY hack/run-integration-tests.sh hack/run-integration-tests.sh
 COPY hack/run-e2e-tests.sh hack/run-e2e-tests.sh
 COPY test/ test/
 COPY kudo-test.yaml kudo-test.yaml
-COPY kudo-e2e-test.yaml kudo-e2e-test.yaml
+COPY kudo-e2e-test.yaml.tmpl kudo-e2e-test.yaml.tmpl


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kudo/blob/master/CONTRIBUTING.md
2. Make sure you have added and ran the tests before submitting your PR
3. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What this PR does / why we need it**:
A Docker image of the KUDO manager is built and deployed in the E2E test cluster.
This is done by adding the build KUDO image to the KinD cluster and changing the 'kubctl kudo init' output to ensure that this image will be used when deploying KUDO.

<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1177
