### PR TITLE
Replace 'properties/assert' with 'testify/assert'

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,6 @@ require (
 	github.com/huandu/xstrings v1.2.0 // indirect
 	github.com/imdario/mergo v0.3.7 // indirect
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
-	github.com/magiconair/properties v1.8.1
 	github.com/manifoldco/promptui v0.6.0
 	github.com/mattn/go-colorable v0.1.4 // indirect
 	github.com/mattn/go-runewidth v0.0.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -317,14 +317,10 @@ github.com/lunixbochs/vtclean v0.0.0-20180621232353-2d01aacdc34a h1:weJVJJRzAJBF
 github.com/lunixbochs/vtclean v0.0.0-20180621232353-2d01aacdc34a/go.mod h1:pHhQNgMf3btfWnGBVipUOjRYhoOsdGqdm/+2c2E2WMI=
 github.com/magiconair/properties v1.8.0 h1:LLgXmsheXeRoUOBOjtwPQCWIYqM/LU1ayDtDePerRcY=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
-github.com/magiconair/properties v1.8.1 h1:ZC2Vc7/ZFkGmsVC9KvOjumD+G5lXy2RtTKyzRKO2BQ4=
-github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mailru/easyjson v0.0.0-20160728113105-d5b7844b561a/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20180823135443-60711f1a8329/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190312143242-1de009706dbe/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
-github.com/mailru/easyjson v0.0.0-20190620125010-da37f6c1e481 h1:IaSjLMT6WvkoZZjspGxy3rdaTEmWLoRm49WbtVUi9sA=
-github.com/mailru/easyjson v0.0.0-20190620125010-da37f6c1e481/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.7.0 h1:aizVhC/NAAcKWb+5QsU1iNOZb4Yws5UO2I+aIprQITM=
 github.com/mailru/easyjson v0.7.0/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7ldAVICs=

--- a/pkg/kudoctl/kudohome/home_test.go
+++ b/pkg/kudoctl/kudohome/home_test.go
@@ -3,12 +3,12 @@ package kudohome
 import (
 	"testing"
 
-	"github.com/magiconair/properties/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestKudoHome(t *testing.T) {
 	h := Home("/a")
 
-	assert.Equal(t, h.String(), "/a")
-	assert.Equal(t, h.RepositoryFile(), "/a/repository/repositories.yaml")
+	assert.Equal(t, "/a", h.String())
+	assert.Equal(t, "/a/repository/repositories.yaml", h.RepositoryFile())
 }

--- a/pkg/kudoctl/util/repo/index_test.go
+++ b/pkg/kudoctl/util/repo/index_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/magiconair/properties/assert"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/kudobuilder/kudo/pkg/apis/kudo/v1beta1"
 	"github.com/kudobuilder/kudo/pkg/kudoctl/packages"
@@ -46,9 +46,9 @@ entries:
 	b := []byte(indexString)
 	index, _ := ParseIndexFile(b)
 
-	assert.Equal(t, len(index.Entries), 2, "number of operator entries is 2")
-	assert.Equal(t, len(index.Entries["kafka"]), 2, "number of kafka operators is 2")
-	assert.Equal(t, index.Entries["flink"][0].AppVersion, "1.7.2", "flink app version")
+	assert.Equal(t, 2, len(index.Entries), "number of operator entries is 2")
+	assert.Equal(t, 2, len(index.Entries["kafka"]), "number of kafka operators is 2")
+	assert.Equal(t, "1.7.2", index.Entries["flink"][0].AppVersion, "flink app version")
 }
 
 // TestParsingGoldenIndex and parses the index file catching marshalling issues.
@@ -183,8 +183,8 @@ func TestMapPackageFileToPackageVersion(t *testing.T) {
 
 	pv := ToPackageVersion(&pf, "1234", "http://localhost")
 
-	assert.Equal(t, pv.Name, o.Name)
-	assert.Equal(t, pv.Version, o.Version)
-	assert.Equal(t, pv.URLs[0], "http://localhost/kafka-1.0.0.tgz")
-	assert.Equal(t, pv.Digest, "1234")
+	assert.Equal(t, o.Name, pv.Name)
+	assert.Equal(t, o.Version, pv.Version)
+	assert.Equal(t, "http://localhost/kafka-1.0.0.tgz", pv.URLs[0])
+	assert.Equal(t, "1234", pv.Digest)
 }

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -3,7 +3,7 @@ package version
 import (
 	"testing"
 
-	"github.com/magiconair/properties/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_validVersion(t *testing.T) {
@@ -22,7 +22,7 @@ func Test_validVersion(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			val := tt.expected.CompareMajorMinor(tt.actual)
-			assert.Equal(t, tt.val, val)
+			assert.Equal(t, val, tt.val)
 		})
 	}
 }
@@ -40,7 +40,7 @@ func TestClean(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := Clean(tt.actual)
-			assert.Equal(t, result, tt.expected)
+			assert.Equal(t, tt.expected, result)
 		})
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kudo/blob/master/CONTRIBUTING.md
2. Make sure you have added and ran the tests before submitting your PR
3. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What this PR does / why we need it**:
This removes the "properties" dependency and uses "testify" instead. The main reason was that the assertions provided by "properties" didn't correctly show the line in which an assertion failed. "testify" does. E.g. "properties" showed `assert.go:24: got 1.7.2 want  flink app version` while "testify" shows
```
    index_test.go:63: 
        	Error Trace:	index_test.go:63
        	Error:      	Not equal: 
        	            	expected: ""
        	            	actual  : "1.7.2"
        	            	
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -1 +1 @@
        	            	-
        	            	+1.7.2
        	Test:       	TestParseIndexFile
        	Messages:   	flink app version
```

Also this improves code consistency by removing a package when we have other packages already providing that functionality.