### PR TITLE
Remove confusing no-op `validate:` tags.

### DIFF
--- a/pkg/apis/kudo/v1beta1/operatorversion_types.go
+++ b/pkg/apis/kudo/v1beta1/operatorversion_types.go
@@ -64,11 +64,11 @@ const (
 // Plan specifies a series of Phases that need to be completed.
 type Plan struct {
 	// +optional
-	Strategy Ordering `json:"strategy" validate:"required"` // makes field mandatory and checks if set and non empty
+	Strategy Ordering `json:"strategy"`
 	// Phases maps a phase name to a Phase object.
 	// +optional
 	// +nullable
-	Phases []Phase `json:"phases" validate:"required,gt=0,dive"` // makes field mandatory and checks if its gt 0
+	Phases []Phase `json:"phases"`
 }
 
 // Parameter captures the variability of an OperatorVersion being instantiated in an instance.
@@ -100,31 +100,31 @@ type Parameter struct {
 // Phase specifies a list of steps that contain Kubernetes objects.
 type Phase struct {
 	// +optional
-	Name string `json:"name" validate:"required"` // makes field mandatory and checks if set and non empty
+	Name string `json:"name"`
 	// +optional
-	Strategy Ordering `json:"strategy" validate:"required"` // makes field mandatory and checks if set and non empty
+	Strategy Ordering `json:"strategy"`
 
 	// Steps maps a step name to a list of templated Kubernetes objects stored as a string.
 	// +optional
-	Steps []Step `json:"steps" validate:"required,gt=0,dive"` // makes field mandatory and checks if its gt 0
+	Steps []Step `json:"steps"`
 }
 
 // Step defines a specific set of operations that occur.
 type Step struct {
 	// +optional
-	Name string `json:"name" validate:"required"` // makes field mandatory and checks if set and non empty
+	Name string `json:"name"`
 	// +optional
-	Tasks []string `json:"tasks" validate:"required,gt=0,dive"` // makes field mandatory and checks if non empty
+	Tasks []string `json:"tasks"`
 }
 
 // Task is a global, polymorphic implementation of all publicly available tasks
 type Task struct {
 	// +optional
-	Name string `json:"name" validate:"required"`
+	Name string `json:"name"`
 	// +optional
-	Kind string `json:"kind" validate:"required"`
+	Kind string `json:"kind"`
 	// +optional
-	Spec TaskSpec `json:"spec" validate:"required"`
+	Spec TaskSpec `json:"spec"`
 }
 
 // TaskSpec embeds all possible task specs. This allows us to avoid writing custom un/marshallers that would only parse


### PR DESCRIPTION
**What this PR does / why we need it**:

My guess is that they were meant for https://github.com/go-validator/validator
but this library does not seem to be used (any more?).

We do not seem to be using these tags for anything, they are not enforced, and
the current codebase violates them.

I did try to make the CRD validation markers match the tags in the process of
fixing #862, but there is plenty of test code which violates those rules, so it
would be a bigger task at this point.

Since these tags contradict the +optional markers on directly preceding lines,
it is best we reduce confusion by removing them.