### PR TITLE
Fake being in GOPATH when generating code.

### DIFF
--- a/hack/update_codegen.sh
+++ b/hack/update_codegen.sh
@@ -9,7 +9,8 @@ set -o pipefail
 # it has been modified to enable caching.
 export GO111MODULE=on
 VERSION=$(go list -m all | grep k8s.io/code-generator | rev | cut -d"-" -f1 | cut -d" " -f1 | rev)
-CODE_GEN_DIR="hack/code-gen/$VERSION"
+REPO_ROOT="${REPO_ROOT:-$(git rev-parse --show-toplevel)}"
+CODE_GEN_DIR="${REPO_ROOT}/hack/code-gen/$VERSION"
 
 if [[ -d ${CODE_GEN_DIR} ]]; then
     echo "Using cached code generator version: $VERSION"
@@ -17,6 +18,15 @@ else
     git clone https://github.com/kubernetes/code-generator.git "${CODE_GEN_DIR}"
     git -C "${CODE_GEN_DIR}" reset --hard "${VERSION}"
 fi
+
+# Fake being in a $GOPATH until kubernetes fully supports modules
+# https://github.com/kudobuilder/kudo/issues/1252
+FAKE_GOPATH="$(mktemp -d)"
+trap 'chmod -R u+rwX ${FAKE_GOPATH} && rm -rf ${FAKE_GOPATH}' EXIT
+FAKE_REPOPATH="${FAKE_GOPATH}/src/github.com/kudobuilder/kudo"
+mkdir -p "$(dirname "${FAKE_REPOPATH}")" && ln -s "${REPO_ROOT}" "${FAKE_REPOPATH}"
+export GOPATH="${FAKE_GOPATH}"
+cd "${FAKE_REPOPATH}"
 
 "${CODE_GEN_DIR}"/generate-groups.sh \
   all \


### PR DESCRIPTION
**What this PR does / why we need it**:

This is a workaround for the code generators requiring $GOPATH to put output in the correct location.
Details in the issue.

<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1252