### PR TITLE
Check the type assertion on funk.Keys return value.

### DIFF
--- a/pkg/kudoctl/cmd/package_list_plans.go
+++ b/pkg/kudoctl/cmd/package_list_plans.go
@@ -97,7 +97,10 @@ func displayPlanTable(pf *packages.Files, withTasks bool, out io.Writer) {
 }
 
 func sortedPlanNames(pf *packages.Files) []string {
-	planNames := funk.Keys(pf.Operator.Plans).([]string)
+	planNames, ok := funk.Keys(pf.Operator.Plans).([]string)
+	if !ok {
+		panic("funk.Keys returned unexpected type")
+	}
 	sort.Strings(planNames)
 	return planNames
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Make lint happy again.
This was result of a race between merging https://github.com/kudobuilder/kudo/pull/1223 and https://github.com/kudobuilder/kudo/pull/1245