### PR TITLE
Forces pulling down base image before building new image via goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,6 +9,8 @@ before:
     - go mod download
     # you may remove this if you don't need go generate
     - go generate ./...
+    # Pulls down the latest version of the controller's parent image
+    - docker pull ubuntu:18.04
 builds:
   - id: "manager"
     binary: manager
@@ -41,7 +43,6 @@ dockers:
       - "kudobuilder/controller:latest"
       - "kudobuilder/controller:{{ .Tag }}"
     skip_push: auto
-
 archives:
   - id: kubectl-kudo-tarball
     builds:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kudo/blob/master/CONTRIBUTING.md
2. Make sure you have added and ran the tests before submitting your PR
3. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What this PR does / why we need it**:
This PR forces the base image for the controller to be updated before releasing



The current release process does not force the Release Manager to update the base image (`ubuntu:18.04`) before releasing our controller.  This has caused releases to go out with vulnerabilities that were fixed in new versions of `ubuntu:18.04`, but not be part of the image that was used for release:


(All vulnerabilities found via https://github.com/anchore/anchore-engine )

Current vuln list for `ubuntu:18.04`
```bash
$ anchore-cli image vuln ubuntu:18.04 all
Vulnerability ID        Package                                  Severity          Fix         CVE Refs        Vulnerability URL
CVE-2009-5155           libc-bin-2.27-3ubuntu1                   Low               None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2009-5155
CVE-2009-5155           libc6-2.27-3ubuntu1                      Low               None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2009-5155
CVE-2013-4235           login-1:4.5-1ubuntu2                     Low               None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2013-4235
CVE-2013-4235           passwd-1:4.5-1ubuntu2                    Low               None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2013-4235
CVE-2015-8985           libc-bin-2.27-3ubuntu1                   Low               None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2015-8985
CVE-2015-8985           libc6-2.27-3ubuntu1                      Low               None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2015-8985
CVE-2016-10739          libc-bin-2.27-3ubuntu1                   Low               None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2016-10739
CVE-2016-10739          libc6-2.27-3ubuntu1                      Low               None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2016-10739
CVE-2016-2781           coreutils-8.28-1ubuntu1                  Low               None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2016-2781
CVE-2017-11164          libpcre3-2:8.39-9                        Low               None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2017-11164
CVE-2018-16868          libgnutls30-3.5.18-1ubuntu1.1            Low               None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-16868
CVE-2018-16869          libhogweed4-3.4-1                        Low               None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-16869
CVE-2018-16869          libnettle6-3.4-1                         Low               None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-16869
CVE-2018-20482          tar-1.29b-2ubuntu0.1                     Low               None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-20482
CVE-2018-7169           login-1:4.5-1ubuntu2                     Low               None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-7169
CVE-2018-7169           passwd-1:4.5-1ubuntu2                    Low               None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-7169
CVE-2019-12904          libgcrypt20-1.8.1-4ubuntu1.1             Low               None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-12904
CVE-2019-17543          liblz4-1-0.0~r131-2ubuntu3               Low               None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-17543
CVE-2019-3843           libsystemd0-237-3ubuntu10.33             Low               None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-3843
CVE-2019-3843           libudev1-237-3ubuntu10.33                Low               None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-3843
CVE-2019-3844           libsystemd0-237-3ubuntu10.33             Low               None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-3844
CVE-2019-3844           libudev1-237-3ubuntu10.33                Low               None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-3844
CVE-2019-9169           libc-bin-2.27-3ubuntu1                   Low               None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-9169
CVE-2019-9169           libc6-2.27-3ubuntu1                      Low               None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-9169
CVE-2018-11236          libc-bin-2.27-3ubuntu1                   Medium            None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-11236
CVE-2018-11236          libc6-2.27-3ubuntu1                      Medium            None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-11236
CVE-2018-11237          libc-bin-2.27-3ubuntu1                   Medium            None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-11237
CVE-2018-11237          libc6-2.27-3ubuntu1                      Medium            None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-11237
CVE-2018-19591          libc-bin-2.27-3ubuntu1                   Medium            None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-19591
CVE-2018-19591          libc6-2.27-3ubuntu1                      Medium            None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-19591
CVE-2018-20839          libsystemd0-237-3ubuntu10.33             Medium            None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-20839
CVE-2018-20839          libudev1-237-3ubuntu10.33                Medium            None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-20839
CVE-2019-13050          gpgv-2.2.4-1ubuntu1.2                    Medium            None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-13050
CVE-2019-13627          libgcrypt20-1.8.1-4ubuntu1.1             Medium            None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-13627
CVE-2019-5188           e2fsprogs-1.44.1-1ubuntu1.2              Medium            None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-5188
CVE-2019-5188           libcom-err2-1.44.1-1ubuntu1.2            Medium            None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-5188
CVE-2019-5188           libext2fs2-1.44.1-1ubuntu1.2             Medium            None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-5188
CVE-2019-5188           libss2-1.44.1-1ubuntu1.2                 Medium            None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-5188
CVE-2016-10228          libc-bin-2.27-3ubuntu1                   Negligible        None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2016-10228
CVE-2016-10228          libc6-2.27-3ubuntu1                      Negligible        None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2016-10228
CVE-2017-7245           libpcre3-2:8.39-9                        Negligible        None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2017-7245
CVE-2017-7246           libpcre3-2:8.39-9                        Negligible        None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2017-7246
CVE-2017-8283           dpkg-1.19.0.5ubuntu2.3                   Negligible        None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2017-8283
CVE-2018-1000654        libtasn1-6-4.13-2                        Negligible        None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-1000654
CVE-2018-20796          libc-bin-2.27-3ubuntu1                   Negligible        None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-20796
CVE-2018-20796          libc6-2.27-3ubuntu1                      Negligible        None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-20796
CVE-2018-7738           fdisk-2.31.1-0.4ubuntu3.4                Negligible        None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-7738
CVE-2018-7738           libblkid1-2.31.1-0.4ubuntu3.4            Negligible        None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-7738
CVE-2018-7738           libfdisk1-2.31.1-0.4ubuntu3.4            Negligible        None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-7738
CVE-2018-7738           libmount1-2.31.1-0.4ubuntu3.4            Negligible        None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-7738
CVE-2018-7738           libsmartcols1-2.31.1-0.4ubuntu3.4        Negligible        None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-7738
CVE-2018-7738           libuuid1-2.31.1-0.4ubuntu3.4             Negligible        None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-7738
CVE-2018-7738           mount-2.31.1-0.4ubuntu3.4                Negligible        None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-7738
CVE-2018-7738           util-linux-2.31.1-0.4ubuntu3.4           Negligible        None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-7738
CVE-2019-17594          libncurses5-6.1-1ubuntu1.18.04           Negligible        None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-17594
CVE-2019-17594          libncursesw5-6.1-1ubuntu1.18.04          Negligible        None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-17594
CVE-2019-17594          libtinfo5-6.1-1ubuntu1.18.04             Negligible        None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-17594
CVE-2019-17594          ncurses-base-6.1-1ubuntu1.18.04          Negligible        None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-17594
CVE-2019-17594          ncurses-bin-6.1-1ubuntu1.18.04           Negligible        None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-17594
CVE-2019-17595          libncurses5-6.1-1ubuntu1.18.04           Negligible        None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-17595
CVE-2019-17595          libncursesw5-6.1-1ubuntu1.18.04          Negligible        None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-17595
CVE-2019-17595          libtinfo5-6.1-1ubuntu1.18.04             Negligible        None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-17595
CVE-2019-17595          ncurses-base-6.1-1ubuntu1.18.04          Negligible        None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-17595
CVE-2019-17595          ncurses-bin-6.1-1ubuntu1.18.04           Negligible        None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-17595
CVE-2019-7309           libc-bin-2.27-3ubuntu1                   Negligible        None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-7309
CVE-2019-7309           libc6-2.27-3ubuntu1                      Negligible        None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-7309
CVE-2019-9192           libc-bin-2.27-3ubuntu1                   Negligible        None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-9192
CVE-2019-9192           libc6-2.27-3ubuntu1                      Negligible        None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-9192
```

Current vuln list for `kudobuilder/controller:v0.10.0`
```bash
$ anchore-cli image vuln kudobuilder/controller:v0.10.0 all
Vulnerability ID        Package                                Severity          Fix                           CVE Refs        Vulnerability URL
CVE-2018-0501           apt-1.6.1                              High              1.6.3ubuntu0.1                                http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-0501
CVE-2018-0501           libapt-pkg5.0-1.6.1                    High              1.6.3ubuntu0.1                                http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-0501
CVE-2018-16864          libsystemd0-237-3ubuntu10              High              237-3ubuntu10.11                              http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-16864
CVE-2018-16864          libudev1-237-3ubuntu10                 High              237-3ubuntu10.11                              http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-16864
CVE-2018-16865          libsystemd0-237-3ubuntu10              High              237-3ubuntu10.11                              http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-16865
CVE-2018-16865          libudev1-237-3ubuntu10                 High              237-3ubuntu10.11                              http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-16865
CVE-2019-3462           apt-1.6.1                              High              1.6.6ubuntu0.1                                http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-3462
CVE-2019-3462           libapt-pkg5.0-1.6.1                    High              1.6.6ubuntu0.1                                http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-3462
CVE-2009-5155           libc-bin-2.27-3ubuntu1                 Low               None                                          http://people.ubuntu.com/~ubuntu-security/cve/CVE-2009-5155
CVE-2009-5155           libc6-2.27-3ubuntu1                    Low               None                                          http://people.ubuntu.com/~ubuntu-security/cve/CVE-2009-5155
CVE-2013-4235           login-1:4.5-1ubuntu1                   Low               None                                          http://people.ubuntu.com/~ubuntu-security/cve/CVE-2013-4235
CVE-2013-4235           passwd-1:4.5-1ubuntu1                  Low               None                                          http://people.ubuntu.com/~ubuntu-security/cve/CVE-2013-4235
CVE-2015-8985           libc-bin-2.27-3ubuntu1                 Low               None                                          http://people.ubuntu.com/~ubuntu-security/cve/CVE-2015-8985
CVE-2015-8985           libc6-2.27-3ubuntu1                    Low               None                                          http://people.ubuntu.com/~ubuntu-security/cve/CVE-2015-8985
CVE-2016-10739          libc-bin-2.27-3ubuntu1                 Low               None                                          http://people.ubuntu.com/~ubuntu-security/cve/CVE-2016-10739
CVE-2016-10739          libc6-2.27-3ubuntu1                    Low               None                                          http://people.ubuntu.com/~ubuntu-security/cve/CVE-2016-10739
CVE-2016-2781           coreutils-8.28-1ubuntu1                Low               None                                          http://people.ubuntu.com/~ubuntu-security/cve/CVE-2016-2781
CVE-2017-11164          libpcre3-2:8.39-9                      Low               None                                          http://people.ubuntu.com/~ubuntu-security/cve/CVE-2017-11164
CVE-2018-0495           libgcrypt20-1.8.1-4ubuntu1             Low               1.8.1-4ubuntu1.1                              http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-0495
CVE-2018-16868          libgnutls30-3.5.18-1ubuntu1            Low               None                                          http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-16868
CVE-2018-16869          libhogweed4-3.4-1                      Low               None                                          http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-16869
CVE-2018-16869          libnettle6-3.4-1                       Low               None                                          http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-16869
CVE-2018-20482          tar-1.29b-2                            Low               None                                          http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-20482
CVE-2018-6557           base-files-10.1ubuntu2                 Low               10.1ubuntu2.2                                 http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-6557
CVE-2018-7169           login-1:4.5-1ubuntu1                   Low               None                                          http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-7169
CVE-2018-7169           passwd-1:4.5-1ubuntu1                  Low               None                                          http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-7169
CVE-2018-9234           gpgv-2.2.4-1ubuntu1                    Low               2.2.4-1ubuntu1.1                              http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-9234
CVE-2019-12904          libgcrypt20-1.8.1-4ubuntu1             Low               None                                          http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-12904
CVE-2019-17543          liblz4-1-0.0~r131-2ubuntu3             Low               None                                          http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-17543
CVE-2019-3843           libsystemd0-237-3ubuntu10              Low               None                                          http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-3843
CVE-2019-3843           libudev1-237-3ubuntu10                 Low               None                                          http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-3843
CVE-2019-3844           libsystemd0-237-3ubuntu10              Low               None                                          http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-3844
CVE-2019-3844           libudev1-237-3ubuntu10                 Low               None                                          http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-3844
CVE-2019-9169           libc-bin-2.27-3ubuntu1                 Low               None                                          http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-9169
CVE-2019-9169           libc6-2.27-3ubuntu1                    Low               None                                          http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-9169
CVE-2018-1000858        gpgv-2.2.4-1ubuntu1                    Medium            2.2.4-1ubuntu1.2                              http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-1000858
CVE-2018-10844          libgnutls30-3.5.18-1ubuntu1            Medium            3.5.18-1ubuntu1.1                             http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-10844
CVE-2018-10845          libgnutls30-3.5.18-1ubuntu1            Medium            3.5.18-1ubuntu1.1                             http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-10845
CVE-2018-10846          libgnutls30-3.5.18-1ubuntu1            Medium            3.5.18-1ubuntu1.1                             http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-10846
CVE-2018-1122           libprocps6-2:3.3.12-3ubuntu1           Medium            2:3.3.12-3ubuntu1.1                           http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-1122
CVE-2018-1122           procps-2:3.3.12-3ubuntu1               Medium            2:3.3.12-3ubuntu1.1                           http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-1122
CVE-2018-1123           libprocps6-2:3.3.12-3ubuntu1           Medium            2:3.3.12-3ubuntu1.1                           http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-1123
CVE-2018-1123           procps-2:3.3.12-3ubuntu1               Medium            2:3.3.12-3ubuntu1.1                           http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-1123
CVE-2018-11236          libc-bin-2.27-3ubuntu1                 Medium            None                                          http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-11236
CVE-2018-11236          libc6-2.27-3ubuntu1                    Medium            None                                          http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-11236
CVE-2018-11237          libc-bin-2.27-3ubuntu1                 Medium            None                                          http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-11237
CVE-2018-11237          libc6-2.27-3ubuntu1                    Medium            None                                          http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-11237
CVE-2018-1124           libprocps6-2:3.3.12-3ubuntu1           Medium            2:3.3.12-3ubuntu1.1                           http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-1124
CVE-2018-1124           procps-2:3.3.12-3ubuntu1               Medium            2:3.3.12-3ubuntu1.1                           http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-1124
CVE-2018-1125           libprocps6-2:3.3.12-3ubuntu1           Medium            2:3.3.12-3ubuntu1.1                           http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-1125
CVE-2018-1125           procps-2:3.3.12-3ubuntu1               Medium            2:3.3.12-3ubuntu1.1                           http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-1125
CVE-2018-1126           libprocps6-2:3.3.12-3ubuntu1           Medium            2:3.3.12-3ubuntu1.1                           http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-1126
CVE-2018-1126           procps-2:3.3.12-3ubuntu1               Medium            2:3.3.12-3ubuntu1.1                           http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-1126
CVE-2018-12015          perl-base-5.26.1-6                     Medium            5.26.1-6ubuntu0.1                             http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-12015
CVE-2018-12020          gpgv-2.2.4-1ubuntu1                    Medium            2.2.4-1ubuntu1.1                              http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-12020
CVE-2018-15686          libsystemd0-237-3ubuntu10              Medium            237-3ubuntu10.6                               http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-15686
CVE-2018-15686          libudev1-237-3ubuntu10                 Medium            237-3ubuntu10.6                               http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-15686
CVE-2018-15687          libsystemd0-237-3ubuntu10              Medium            237-3ubuntu10.6                               http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-15687
CVE-2018-15687          libudev1-237-3ubuntu10                 Medium            237-3ubuntu10.6                               http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-15687
CVE-2018-15688          libsystemd0-237-3ubuntu10              Medium            237-3ubuntu10.4                               http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-15688
CVE-2018-15688          libudev1-237-3ubuntu10                 Medium            237-3ubuntu10.4                               http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-15688
CVE-2018-16866          libsystemd0-237-3ubuntu10              Medium            237-3ubuntu10.11                              http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-16866
CVE-2018-16866          libudev1-237-3ubuntu10                 Medium            237-3ubuntu10.11                              http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-16866
CVE-2018-18311          perl-base-5.26.1-6                     Medium            5.26.1-6ubuntu0.3                             http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-18311
CVE-2018-18312          perl-base-5.26.1-6                     Medium            5.26.1-6ubuntu0.3                             http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-18312
CVE-2018-18313          perl-base-5.26.1-6                     Medium            5.26.1-6ubuntu0.3                             http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-18313
CVE-2018-18314          perl-base-5.26.1-6                     Medium            5.26.1-6ubuntu0.3                             http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-18314
CVE-2018-19591          libc-bin-2.27-3ubuntu1                 Medium            None                                          http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-19591
CVE-2018-19591          libc6-2.27-3ubuntu1                    Medium            None                                          http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-19591
CVE-2018-20839          libsystemd0-237-3ubuntu10              Medium            None                                          http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-20839
CVE-2018-20839          libudev1-237-3ubuntu10                 Medium            None                                          http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-20839
CVE-2018-6954           libsystemd0-237-3ubuntu10              Medium            237-3ubuntu10.9                               http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-6954
CVE-2018-6954           libudev1-237-3ubuntu10                 Medium            237-3ubuntu10.9                               http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-6954
CVE-2019-11922          libzstd1-1.3.3+dfsg-2ubuntu1           Medium            1.3.3+dfsg-2ubuntu1.1                         http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-11922
CVE-2019-12290          libidn2-0-2.0.4-1.1build2              Medium            2.0.4-1.1ubuntu0.2                            http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-12290
CVE-2019-12900          bzip2-1.0.6-8.1                        Medium            1.0.6-8.1ubuntu0.2                            http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-12900
CVE-2019-12900          libbz2-1.0-1.0.6-8.1                   Medium            1.0.6-8.1ubuntu0.2                            http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-12900
CVE-2019-13050          gpgv-2.2.4-1ubuntu1                    Medium            None                                          http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-13050
CVE-2019-13627          libgcrypt20-1.8.1-4ubuntu1             Medium            None                                          http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-13627
CVE-2019-15718          libsystemd0-237-3ubuntu10              Medium            237-3ubuntu10.28                              http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-15718
CVE-2019-15718          libudev1-237-3ubuntu10                 Medium            237-3ubuntu10.28                              http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-15718
CVE-2019-18224          libidn2-0-2.0.4-1.1build2              Medium            2.0.4-1.1ubuntu0.2                            http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-18224
CVE-2019-3829           libgnutls30-3.5.18-1ubuntu1            Medium            3.5.18-1ubuntu1.1                             http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-3829
CVE-2019-3842           libsystemd0-237-3ubuntu10              Medium            237-3ubuntu10.19                              http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-3842
CVE-2019-3842           libudev1-237-3ubuntu10                 Medium            237-3ubuntu10.19                              http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-3842
CVE-2019-5094           e2fsprogs-1.44.1-1                     Medium            1.44.1-1ubuntu1.2                             http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-5094
CVE-2019-5094           libcom-err2-1.44.1-1                   Medium            1.44.1-1ubuntu1.2                             http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-5094
CVE-2019-5094           libext2fs2-1.44.1-1                    Medium            1.44.1-1ubuntu1.2                             http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-5094
CVE-2019-5094           libss2-1.44.1-1                        Medium            1.44.1-1ubuntu1.2                             http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-5094
CVE-2019-5188           e2fsprogs-1.44.1-1                     Medium            None                                          http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-5188
CVE-2019-5188           libcom-err2-1.44.1-1                   Medium            None                                          http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-5188
CVE-2019-5188           libext2fs2-1.44.1-1                    Medium            None                                          http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-5188
CVE-2019-5188           libss2-1.44.1-1                        Medium            None                                          http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-5188
CVE-2019-6454           libsystemd0-237-3ubuntu10              Medium            237-3ubuntu10.13                              http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-6454
CVE-2019-6454           libudev1-237-3ubuntu10                 Medium            237-3ubuntu10.13                              http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-6454
CVE-2019-8457           libdb5.3-5.3.28-13.1ubuntu1            Medium            5.3.28-13.1ubuntu1.1                          http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-8457
CVE-2019-9893           libseccomp2-2.3.1-2.1ubuntu4           Medium            2.4.1-0ubuntu0.18.04.2                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-9893
CVE-2016-10228          libc-bin-2.27-3ubuntu1                 Negligible        None                                          http://people.ubuntu.com/~ubuntu-security/cve/CVE-2016-10228
CVE-2016-10228          libc6-2.27-3ubuntu1                    Negligible        None                                          http://people.ubuntu.com/~ubuntu-security/cve/CVE-2016-10228
CVE-2017-7245           libpcre3-2:8.39-9                      Negligible        None                                          http://people.ubuntu.com/~ubuntu-security/cve/CVE-2017-7245
CVE-2017-7246           libpcre3-2:8.39-9                      Negligible        None                                          http://people.ubuntu.com/~ubuntu-security/cve/CVE-2017-7246
CVE-2017-8283           dpkg-1.19.0.5ubuntu2                   Negligible        None                                          http://people.ubuntu.com/~ubuntu-security/cve/CVE-2017-8283
CVE-2018-1000654        libtasn1-6-4.13-2                      Negligible        None                                          http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-1000654
CVE-2018-20796          libc-bin-2.27-3ubuntu1                 Negligible        None                                          http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-20796
CVE-2018-20796          libc6-2.27-3ubuntu1                    Negligible        None                                          http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-20796
CVE-2018-7738           fdisk-2.31.1-0.4ubuntu3                Negligible        None                                          http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-7738
CVE-2018-7738           libblkid1-2.31.1-0.4ubuntu3            Negligible        None                                          http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-7738
CVE-2018-7738           libfdisk1-2.31.1-0.4ubuntu3            Negligible        None                                          http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-7738
CVE-2018-7738           libmount1-2.31.1-0.4ubuntu3            Negligible        None                                          http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-7738
CVE-2018-7738           libsmartcols1-2.31.1-0.4ubuntu3        Negligible        None                                          http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-7738
CVE-2018-7738           libuuid1-2.31.1-0.4ubuntu3             Negligible        None                                          http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-7738
CVE-2018-7738           mount-2.31.1-0.4ubuntu3                Negligible        None                                          http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-7738
CVE-2018-7738           util-linux-2.31.1-0.4ubuntu3           Negligible        None                                          http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-7738
CVE-2019-17594          libncurses5-6.1-1ubuntu1               Negligible        None                                          http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-17594
CVE-2019-17594          libncursesw5-6.1-1ubuntu1              Negligible        None                                          http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-17594
CVE-2019-17594          libtinfo5-6.1-1ubuntu1                 Negligible        None                                          http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-17594
CVE-2019-17594          ncurses-base-6.1-1ubuntu1              Negligible        None                                          http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-17594
CVE-2019-17594          ncurses-bin-6.1-1ubuntu1               Negligible        None                                          http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-17594
CVE-2019-17595          libncurses5-6.1-1ubuntu1               Negligible        None                                          http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-17595
CVE-2019-17595          libncursesw5-6.1-1ubuntu1              Negligible        None                                          http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-17595
CVE-2019-17595          libtinfo5-6.1-1ubuntu1                 Negligible        None                                          http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-17595
CVE-2019-17595          ncurses-base-6.1-1ubuntu1              Negligible        None                                          http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-17595
CVE-2019-17595          ncurses-bin-6.1-1ubuntu1               Negligible        None                                          http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-17595
CVE-2019-7309           libc-bin-2.27-3ubuntu1                 Negligible        None                                          http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-7309
CVE-2019-7309           libc6-2.27-3ubuntu1                    Negligible        None                                          http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-7309
CVE-2019-9192           libc-bin-2.27-3ubuntu1                 Negligible        None                                          http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-9192
CVE-2019-9192           libc6-2.27-3ubuntu1                    Negligible        None                                          http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-9192
```

Vuln list when building with current `ubuntu:18.04`:

```bash
$ anchore-cli image vuln runyonsolutions/kudo-controller:v0.10.0 all
Vulnerability ID        Package                                  Severity          Fix         CVE Refs        Vulnerability URL
CVE-2009-5155           libc-bin-2.27-3ubuntu1                   Low               None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2009-5155
CVE-2009-5155           libc6-2.27-3ubuntu1                      Low               None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2009-5155
CVE-2013-4235           login-1:4.5-1ubuntu2                     Low               None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2013-4235
CVE-2013-4235           passwd-1:4.5-1ubuntu2                    Low               None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2013-4235
CVE-2015-8985           libc-bin-2.27-3ubuntu1                   Low               None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2015-8985
CVE-2015-8985           libc6-2.27-3ubuntu1                      Low               None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2015-8985
CVE-2016-10739          libc-bin-2.27-3ubuntu1                   Low               None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2016-10739
CVE-2016-10739          libc6-2.27-3ubuntu1                      Low               None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2016-10739
CVE-2016-2781           coreutils-8.28-1ubuntu1                  Low               None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2016-2781
CVE-2017-11164          libpcre3-2:8.39-9                        Low               None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2017-11164
CVE-2018-16868          libgnutls30-3.5.18-1ubuntu1.1            Low               None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-16868
CVE-2018-16869          libhogweed4-3.4-1                        Low               None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-16869
CVE-2018-16869          libnettle6-3.4-1                         Low               None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-16869
CVE-2018-20482          tar-1.29b-2ubuntu0.1                     Low               None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-20482
CVE-2018-7169           login-1:4.5-1ubuntu2                     Low               None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-7169
CVE-2018-7169           passwd-1:4.5-1ubuntu2                    Low               None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-7169
CVE-2019-12904          libgcrypt20-1.8.1-4ubuntu1.1             Low               None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-12904
CVE-2019-17543          liblz4-1-0.0~r131-2ubuntu3               Low               None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-17543
CVE-2019-3843           libsystemd0-237-3ubuntu10.33             Low               None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-3843
CVE-2019-3843           libudev1-237-3ubuntu10.33                Low               None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-3843
CVE-2019-3844           libsystemd0-237-3ubuntu10.33             Low               None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-3844
CVE-2019-3844           libudev1-237-3ubuntu10.33                Low               None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-3844
CVE-2019-9169           libc-bin-2.27-3ubuntu1                   Low               None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-9169
CVE-2019-9169           libc6-2.27-3ubuntu1                      Low               None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-9169
CVE-2018-11236          libc-bin-2.27-3ubuntu1                   Medium            None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-11236
CVE-2018-11236          libc6-2.27-3ubuntu1                      Medium            None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-11236
CVE-2018-11237          libc-bin-2.27-3ubuntu1                   Medium            None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-11237
CVE-2018-11237          libc6-2.27-3ubuntu1                      Medium            None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-11237
CVE-2018-19591          libc-bin-2.27-3ubuntu1                   Medium            None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-19591
CVE-2018-19591          libc6-2.27-3ubuntu1                      Medium            None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-19591
CVE-2018-20839          libsystemd0-237-3ubuntu10.33             Medium            None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-20839
CVE-2018-20839          libudev1-237-3ubuntu10.33                Medium            None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-20839
CVE-2019-13050          gpgv-2.2.4-1ubuntu1.2                    Medium            None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-13050
CVE-2019-13627          libgcrypt20-1.8.1-4ubuntu1.1             Medium            None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-13627
CVE-2019-5188           e2fsprogs-1.44.1-1ubuntu1.2              Medium            None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-5188
CVE-2019-5188           libcom-err2-1.44.1-1ubuntu1.2            Medium            None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-5188
CVE-2019-5188           libext2fs2-1.44.1-1ubuntu1.2             Medium            None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-5188
CVE-2019-5188           libss2-1.44.1-1ubuntu1.2                 Medium            None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-5188
CVE-2016-10228          libc-bin-2.27-3ubuntu1                   Negligible        None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2016-10228
CVE-2016-10228          libc6-2.27-3ubuntu1                      Negligible        None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2016-10228
CVE-2017-7245           libpcre3-2:8.39-9                        Negligible        None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2017-7245
CVE-2017-7246           libpcre3-2:8.39-9                        Negligible        None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2017-7246
CVE-2017-8283           dpkg-1.19.0.5ubuntu2.3                   Negligible        None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2017-8283
CVE-2018-1000654        libtasn1-6-4.13-2                        Negligible        None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-1000654
CVE-2018-20796          libc-bin-2.27-3ubuntu1                   Negligible        None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-20796
CVE-2018-20796          libc6-2.27-3ubuntu1                      Negligible        None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-20796
CVE-2018-7738           fdisk-2.31.1-0.4ubuntu3.4                Negligible        None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-7738
CVE-2018-7738           libblkid1-2.31.1-0.4ubuntu3.4            Negligible        None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-7738
CVE-2018-7738           libfdisk1-2.31.1-0.4ubuntu3.4            Negligible        None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-7738
CVE-2018-7738           libmount1-2.31.1-0.4ubuntu3.4            Negligible        None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-7738
CVE-2018-7738           libsmartcols1-2.31.1-0.4ubuntu3.4        Negligible        None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-7738
CVE-2018-7738           libuuid1-2.31.1-0.4ubuntu3.4             Negligible        None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-7738
CVE-2018-7738           mount-2.31.1-0.4ubuntu3.4                Negligible        None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-7738
CVE-2018-7738           util-linux-2.31.1-0.4ubuntu3.4           Negligible        None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-7738
CVE-2019-17594          libncurses5-6.1-1ubuntu1.18.04           Negligible        None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-17594
CVE-2019-17594          libncursesw5-6.1-1ubuntu1.18.04          Negligible        None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-17594
CVE-2019-17594          libtinfo5-6.1-1ubuntu1.18.04             Negligible        None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-17594
CVE-2019-17594          ncurses-base-6.1-1ubuntu1.18.04          Negligible        None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-17594
CVE-2019-17594          ncurses-bin-6.1-1ubuntu1.18.04           Negligible        None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-17594
CVE-2019-17595          libncurses5-6.1-1ubuntu1.18.04           Negligible        None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-17595
CVE-2019-17595          libncursesw5-6.1-1ubuntu1.18.04          Negligible        None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-17595
CVE-2019-17595          libtinfo5-6.1-1ubuntu1.18.04             Negligible        None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-17595
CVE-2019-17595          ncurses-base-6.1-1ubuntu1.18.04          Negligible        None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-17595
CVE-2019-17595          ncurses-bin-6.1-1ubuntu1.18.04           Negligible        None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-17595
CVE-2019-7309           libc-bin-2.27-3ubuntu1                   Negligible        None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-7309
CVE-2019-7309           libc6-2.27-3ubuntu1                      Negligible        None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-7309
CVE-2019-9192           libc-bin-2.27-3ubuntu1                   Negligible        None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-9192
CVE-2019-9192           libc6-2.27-3ubuntu1                      Negligible        None                        http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-9192
```