### PR TITLE
Remove "CRDs" from Error Messages when resolving Operator Packages

### DIFF
--- a/pkg/kudoctl/cmd/install/install.go
+++ b/pkg/kudoctl/cmd/install/install.go
@@ -67,12 +67,12 @@ func installOperator(operatorArgument string, options *Options, fs afero.Fs, set
 		return fmt.Errorf("creating kudo client: %w", err)
 	}
 
-	clog.V(3).Printf("getting package crds")
+	clog.V(3).Printf("getting operator package")
 
 	resolver := pkgresolver.New(repository)
 	pkg, err := resolver.Resolve(operatorArgument, options.AppVersion, options.OperatorVersion)
 	if err != nil {
-		return fmt.Errorf("failed to resolve package CRDs for operator: %s %w", operatorArgument, err)
+		return fmt.Errorf("failed to resolve operator package for: %s %w", operatorArgument, err)
 	}
 
 	return kudo.InstallPackage(kc, pkg.Resources, options.SkipInstance, options.InstanceName, settings.Namespace, options.Parameters)

--- a/pkg/kudoctl/cmd/upgrade.go
+++ b/pkg/kudoctl/cmd/upgrade.go
@@ -99,7 +99,7 @@ func runUpgrade(args []string, options *options, fs afero.Fs, settings *env.Sett
 	resolver := pkgresolver.New(repository)
 	pkg, err := resolver.Resolve(packageToUpgrade, options.AppVersion, options.OperatorVersion)
 	if err != nil {
-		return fmt.Errorf("failed to resolve package CRDs for operator: %s: %w", packageToUpgrade, err)
+		return fmt.Errorf("failed to resolve operator package for: %s: %w", packageToUpgrade, err)
 	}
 
 	resources := pkg.Resources


### PR DESCRIPTION
better message.  the previous message was confusing around CRDs which isn't true.  we are trying to resolve an operator package

Fixes: #1272
Signed-off-by: Ken Sipe <kensipe@gmail.com>
