### PR TITLE
Verify kubernetesVersion when run 'package verify'.

### DIFF
--- a/pkg/kudoctl/cmd/verify/verify.go
+++ b/pkg/kudoctl/cmd/verify/verify.go
@@ -8,11 +8,13 @@ import (
 	"github.com/kudobuilder/kudo/pkg/kudoctl/packages/verifier"
 	"github.com/kudobuilder/kudo/pkg/kudoctl/packages/verifier/task"
 	"github.com/kudobuilder/kudo/pkg/kudoctl/packages/verifier/template"
+	"github.com/kudobuilder/kudo/pkg/version"
 )
 
 var verifiers = []verifier.PackageVerifier{
 	DuplicateVerifier{},
 	InvalidCharVerifier{";,"},
+	K8sVersionVerifier{},
 	task.ReferenceVerifier{},
 	template.ParametersVerifier{},
 	template.ReferenceVerifier{},
@@ -57,6 +59,24 @@ func (v InvalidCharVerifier) Verify(pf *packages.Files) verifier.Result {
 			}
 		}
 
+	}
+
+	return res
+}
+
+// K8sVersionVerifier verifies the kubernetesVersion of operator.yaml
+type K8sVersionVerifier struct{}
+
+func (K8sVersionVerifier) Verify(pf *packages.Files) verifier.Result {
+	res := verifier.NewResult()
+	if pf.Operator == nil {
+		res.AddErrors("Operator not defined.")
+		return res
+	}
+	_, err := version.New(pf.Operator.KubernetesVersion)
+	if err != nil {
+		res.AddErrors(fmt.Sprintf("Unable to parse operators kubernetes version: %v", err))
+		return res
 	}
 
 	return res

--- a/pkg/kudoctl/cmd/verify/verify_test.go
+++ b/pkg/kudoctl/cmd/verify/verify_test.go
@@ -75,3 +75,36 @@ func packageFileForParams(params []v1beta1.Parameter) *packages.Files {
 		Params: &p,
 	}
 }
+
+func TestK8sVersionVerifier(t *testing.T) {
+	tests := []struct {
+		name             string
+		operatorFile     *packages.OperatorFile
+		expectedWarnings []string
+		expectedErrors   []string
+	}{
+		{"no warning or error", &packages.OperatorFile{
+			APIVersion:        packages.APIVersion,
+			Name:              "kafka",
+			KubernetesVersion: "1.15",
+		}, []string{}, []string{}},
+		{"no warning or error", &packages.OperatorFile{
+			APIVersion:        packages.APIVersion,
+			Name:              "kafka",
+			KubernetesVersion: "",
+		}, []string{}, []string{"Unable to parse operators kubernetes version: Invalid Semantic Version"}},
+	}
+
+	verifier := K8sVersionVerifier{}
+	for _, tt := range tests {
+		res := verifier.Verify(packageFileForOperator(tt.operatorFile))
+		assert.Equal(t, tt.expectedWarnings, res.Warnings, tt.name)
+		assert.Equal(t, tt.expectedErrors, res.Errors, tt.name)
+	}
+}
+
+func packageFileForOperator(op *packages.OperatorFile) *packages.Files {
+	return &packages.Files{
+		Operator: op,
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kudo/blob/master/CONTRIBUTING.md
2. Make sure you have added and ran the tests before submitting your PR
3. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What this PR does / why we need it**:

Fix https://github.com/kudobuilder/kudo/issues/1266.
But currently, we do not compare `kubernetesVersion` with `apiserver`. Only the `kubernetesVersion` in the `operator.yaml` is verified.

<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
