### PR TITLE
Bugfix: No Panic for Missing Map of Plans

### DIFF
--- a/pkg/kudoctl/cmd/generate/plans.go
+++ b/pkg/kudoctl/cmd/generate/plans.go
@@ -18,6 +18,9 @@ func AddPlan(fs afero.Fs, path string, planName string, plan *v1beta1.Plan) erro
 	}
 
 	o := pf.Files.Operator
+	if o.Plans == nil {
+		o.Plans = make(map[string]v1beta1.Plan)
+	}
 	plans := o.Plans
 	plans[planName] = *plan
 	pf.Files.Operator.Plans = plans


### PR DESCRIPTION
if plans are missing from operator yaml it results in a nil map.  no joy.  this fixes that.

Signed-off-by: Ken Sipe <kensipe@gmail.com>
