### PR TITLE
Print detailed error when installing package.

### DIFF
--- a/pkg/kudoctl/packages/resolver/resolver.go
+++ b/pkg/kudoctl/packages/resolver/resolver.go
@@ -1,8 +1,6 @@
 package resolver
 
 import (
-	"fmt"
-
 	"github.com/kudobuilder/kudo/pkg/kudoctl/clog"
 	"github.com/kudobuilder/kudo/pkg/kudoctl/http"
 	"github.com/kudobuilder/kudo/pkg/kudoctl/packages"
@@ -41,32 +39,24 @@ func New(repo *repo.Client) *PackageResolver {
 // - an operator name in the remote repository
 // in that order. Should there exist a local folder e.g. `cassandra` it will take precedence
 // over the remote repository package with the same name.
-func (m *PackageResolver) Resolve(name string, appVersion string, operatorVersion string) (*packages.Package, error) {
+func (m *PackageResolver) Resolve(name string, appVersion string, operatorVersion string) (p *packages.Package, err error) {
 
 	// Local files/folder have priority
-	if _, err := m.local.fs.Stat(name); err == nil {
+	if _, err = m.local.fs.Stat(name); err == nil {
 		clog.V(2).Printf("local operator discovered: %v", name)
-		b, err := m.local.Resolve(name, appVersion, operatorVersion)
-		if err != nil {
-			return nil, err
-		}
-		return b, nil
+		p, err = m.local.Resolve(name, appVersion, operatorVersion)
+		return
 	}
 
 	clog.V(3).Printf("no local operator discovered, looking for http")
 	if http.IsValidURL(name) {
 		clog.V(3).Printf("operator using http protocol for %v", name)
-		b, err := m.uri.Resolve(name, appVersion, operatorVersion)
-		if err != nil {
-			return nil, err
-		}
-		return b, nil
+		p, err = m.uri.Resolve(name, appVersion, operatorVersion)
+		return
 	}
 
 	clog.V(3).Printf("no http discovered, looking for repository")
-	if b, err := m.repo.Resolve(name, appVersion, operatorVersion); err == nil {
-		return b, nil
-	}
+	p, err = m.repo.Resolve(name, appVersion, operatorVersion)
 
-	return nil, fmt.Errorf("resolver: unable to find packages for %v", name)
+	return
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kudo/blob/master/CONTRIBUTING.md
2. Make sure you have added and ran the tests before submitting your PR
3. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What this PR does / why we need it**:


<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1269 
Print detailed error when `resolver` cannot find the specific package or version.

1. When install a non-existent operator version:
```
# ./bin/kubectl-kudo-original install kafka --operator-version=8.0.0        
Error: failed to resolve operator package for: kafka resolver: unable to find packages for kafka
# ./bin/kubectl-kudo-new-fix install kafka --operator-version=8.0.0    
Error: failed to resolve operator package for: kafka getting kafka in index file: no operator version found for kafka-8.0.0
```

2. When install a non-existent package
```
# ./bin/kubectl-kudo-original install non-exist     
Error: failed to resolve operator package for: non-exist resolver: unable to find packages for non-exist
# ./bin/kubectl-kudo-new-fix install non-exist  
Error: failed to resolve operator package for: non-exist getting non-exist in index file: no operator found for: non-exist
```

