### PR TITLE
Fix error logging in kudo-cli test

### DIFF
--- a/pkg/kudoctl/cmd/update_test.go
+++ b/pkg/kudoctl/cmd/update_test.go
@@ -83,7 +83,7 @@ func TestUpdate(t *testing.T) {
 				t.Errorf("%s: expected error '%s' but got '%v'", tt.name, tt.errMessageContains, err)
 			}
 		} else if tt.errMessageContains != "" {
-			t.Errorf("%s: expected no error but got %v", tt.name, err)
+			t.Errorf("%s: expected error '%s' but got nil", tt.name, tt.errMessageContains)
 		} else {
 			// the upgrade should have passed without error
 			instance, err := c.GetInstance(testInstance.Name, installNamespace)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kudo/blob/master/CONTRIBUTING.md
2. Make sure you have added and ran the tests before submitting your PR
3. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What this PR does / why we need it**:


<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Original code:
```
		if err != nil {
			if !strings.Contains(err.Error(), tt.errMessageContains) {
				t.Errorf("%s: expected error '%s' but got '%v'", tt.name, tt.errMessageContains, err)
			}
		} else if tt.errMessageContains != "" {  
			t.Errorf("%s: expected no error but got %v", tt.name, err)
```
Here err is nil but tt.errMessageContains is not nil. So the error logging should be fixed