### PR TITLE
Fix `ApplyTask` patch behavior

### DIFF
--- a/pkg/engine/task/task_apply.go
+++ b/pkg/engine/task/task_apply.go
@@ -8,9 +8,13 @@ import (
 	v1 "k8s.io/api/core/v1"
 	apiextv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	apijson "k8s.io/apimachinery/pkg/util/json"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/kudobuilder/kudo/pkg/apis/kudo/v1beta1"
 	"github.com/kudobuilder/kudo/pkg/engine/health"
 )
 
@@ -118,38 +122,44 @@ func isClusterResource(r runtime.Object) bool {
 // because of that for now we just try to apply the patch every time
 // it mutates the object passed in to be consistent with the kubernetes client behavior
 func patch(newObj runtime.Object, c client.Client) error {
-	//newObjJSON, _ := apijson.Marshal(newObj)
 	key, _ := client.ObjectKeyFromObject(newObj)
-	//_, isUnstructured := newObj.(runtime.Unstructured)
-	//_, isCRD := newObj.(*apiextv1beta1.CustomResourceDefinition)
+	_, isUnstructured := newObj.(runtime.Unstructured)
+	_, isCRD := newObj.(*apiextv1beta1.CustomResourceDefinition)
 
-	err := c.Update(context.TODO(), newObj)
-	if err != nil {
-		return fmt.Errorf("failed to update to object %s/%s: %w", key.Namespace, key.Name, err)
+	if isUnstructured || isCRD || isKudoType(newObj) {
+		newObjJSON, _ := apijson.Marshal(newObj)
+
+		// strategic merge patch is not supported for these types, falling back to merge patch
+		err := c.Patch(context.TODO(), newObj, client.ConstantPatch(types.MergePatchType, newObjJSON))
+		if err != nil {
+			return fmt.Errorf("failed to apply merge patch to object %s/%s: %w", key.Namespace, key.Name, err)
+		}
+	} else {
+		// For the strategic merge patch we want to add the "$path: replace" directive so that
+		// Lists get replaced and not merged.
+		us, err := runtime.DefaultUnstructuredConverter.ToUnstructured(newObj)
+		if err != nil {
+			return fmt.Errorf("failed to convert object to unstructured %s/%s: %w", key.Namespace, key.Name, err)
+		}
+		us["$patch"] = "replace"
+		usObj := unstructured.Unstructured{Object: us}
+
+		newObjJSON, _ := apijson.Marshal(usObj)
+		err = c.Patch(context.TODO(), &usObj, client.ConstantPatch(types.StrategicMergePatchType, newObjJSON))
+		if err != nil {
+			return fmt.Errorf("failed to apply StrategicMergePatch to object %s/%s: %w", key.Namespace, key.Name, err)
+		}
 	}
-
-	//if isUnstructured || isCRD || isKudoType(newObj) {
-	//	// strategic merge patch is not supported for these types, falling back to merge patch
-	//	err := c.Patch(context.TODO(), newObj, client.Apply)
-	//	if err != nil {
-	//		return fmt.Errorf("failed to apply merge patch to object %s/%s: %w", key.Namespace, key.Name, err)
-	//	}
-	//} else {
-	//	err := c.Patch(context.TODO(), newObj, client.ConstantPatch(types.StrategicMergePatchType, newObjJSON))
-	//	if err != nil {
-	//		return fmt.Errorf("failed to apply StrategicMergePatch to object %s/%s: %w", key.Namespace, key.Name, err)
-	//	}
-	//}
 
 	return nil
 }
 
-//func isKudoType(object runtime.Object) bool {
-//	_, isOperator := object.(*v1beta1.OperatorVersion)
-//	_, isOperatorVersion := object.(*v1beta1.Operator)
-//	_, isInstance := object.(*v1beta1.Instance)
-//	return isOperator || isOperatorVersion || isInstance
-//}
+func isKudoType(object runtime.Object) bool {
+	_, isOperator := object.(*v1beta1.OperatorVersion)
+	_, isOperatorVersion := object.(*v1beta1.Operator)
+	_, isInstance := object.(*v1beta1.Instance)
+	return isOperator || isOperatorVersion || isInstance
+}
 
 func isHealthy(ro []runtime.Object) error {
 	for _, r := range ro {

--- a/pkg/engine/task/task_apply.go
+++ b/pkg/engine/task/task_apply.go
@@ -8,7 +8,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	apiextv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	apijson "k8s.io/apimachinery/pkg/util/json"
@@ -135,24 +134,111 @@ func patch(newObj runtime.Object, c client.Client) error {
 			return fmt.Errorf("failed to apply merge patch to object %s/%s: %w", key.Namespace, key.Name, err)
 		}
 	} else {
-		// For the strategic merge patch we want to add the "$path: replace" directive so that
-		// Lists get replaced and not merged.
-		us, err := runtime.DefaultUnstructuredConverter.ToUnstructured(newObj)
-		if err != nil {
-			return fmt.Errorf("failed to convert object to unstructured %s/%s: %w", key.Namespace, key.Name, err)
-		}
-		us["$patch"] = "replace"
-		usObj := unstructured.Unstructured{Object: us}
-
-		newObjJSON, _ := apijson.Marshal(usObj)
-		err = c.Patch(context.TODO(), &usObj, client.ConstantPatch(types.StrategicMergePatchType, newObjJSON))
-		if err != nil {
-			return fmt.Errorf("failed to apply StrategicMergePatch to object %s/%s: %w", key.Namespace, key.Name, err)
-		}
+		return patchNormalMerge(newObj, c)
+		//return patchStrategicMerge(newObj, c)
 	}
 
 	return nil
 }
+
+func patchNormalMerge(newObj runtime.Object, c client.Client) error {
+	newObjJSON, _ := apijson.Marshal(newObj)
+
+	// strategic merge patch is not supported for these types, falling back to merge patch
+	return c.Patch(context.TODO(), newObj, client.ConstantPatch(types.MergePatchType, newObjJSON))
+}
+
+//func patchStrategicMerge(newObj runtime.Object, c client.Client) error {
+//	key, _ := client.ObjectKeyFromObject(newObj)
+//
+//	// For the strategic merge patch we want to add the "$path: replace" directive so that
+//	// Lists get replaced and not merged.
+//	us, err := runtime.DefaultUnstructuredConverter.ToUnstructured(newObj)
+//	if err != nil {
+//		return fmt.Errorf("failed to convert object to unstructured %s/%s: %w", key.Namespace, key.Name, err)
+//	}
+//
+//	//us = markAllListsAsReplace(us).(map[string]interface{})
+//	//us = addPatchReplaceInRoot(us)
+//	us = addPatchReplaceToSelectedPaths(us)
+//
+//	newObjJSON, _ := apijson.Marshal(newObj)
+//	usObjJSON, _ := apijson.Marshal(us)
+//
+//	patchNew := make(map[string]interface{})
+//	patchUs := make(map[string]interface{})
+//
+//	err = apijson.Unmarshal(newObjJSON, &patchNew)
+//	if err != nil {
+//		fmt.Printf("Failed to unmarshal patch %v\n", err)
+//	}
+//	err = apijson.Unmarshal(usObjJSON, &patchUs)
+//	if err != nil {
+//		fmt.Printf("Failed to unmarshal patch %v\n", err)
+//	}
+//
+//	fmt.Printf("Sending patchNew %+v\n", patchNew)
+//	fmt.Printf("Sending patchUs  %+v\n", patchUs)
+//
+//	err = c.Patch(context.TODO(), newObj, client.ConstantPatch(types.StrategicMergePatchType, usObjJSON))
+//	if err != nil {
+//		return fmt.Errorf("failed to apply StrategicMergePatch to object %s/%s: %w", key.Namespace, key.Name, err)
+//	}
+//
+//	existing := &unstructured.Unstructured{}
+//	existing.GetObjectKind().SetGroupVersionKind(newObj.GetObjectKind().GroupVersionKind())
+//
+//	err = c.Get(context.TODO(), key, existing)
+//	if err != nil {
+//		fmt.Printf("Failed to get after patch %v\n", err)
+//	}
+//
+//	fmt.Printf("After Patching, the object is now: %+v\n", existing)
+//
+//	return nil
+//}
+
+//func addPatchReplaceToSelectedPaths(data map[string]interface{}) map[string]interface{} {
+//	paths := [][]string{
+//		{"spec", "template", "spec", "containers"},
+//		{"spec", "template", "spec", "initContainers"},
+//		{"spec", "template", "spec", "ephemeralContainers"},
+//	}
+//
+//	for _, path := range paths {
+//		list, found, _ := unstructured.NestedSlice(data, path...)
+//		if found {
+//			// TODO: This does not yet work if we remove the full list in newObj...
+//			list = append(list, map[string]interface{}{"$patch": "replace"})
+//			_ = unstructured.SetNestedSlice(data, list, path...)
+//		}
+//	}
+//
+//	return data
+//}
+
+//func addPatchReplaceInRoot(data map[string]interface{}) map[string]interface{} {
+//	data["$patch"] = "replace"
+//	return data
+//}
+
+//func markAllListsAsReplace(data interface{}) interface{} {
+//	if m, ok := data.(map[string]interface{}); ok {
+//		for k, v := range m {
+//			m[k] = markAllListsAsReplace(v)
+//		}
+//		return m
+//	}
+//	if l, ok := data.([]interface{}); ok {
+//		for i, v := range l {
+//			l[i] = markAllListsAsReplace(v)
+//		}
+//		l = append(l, map[string]string{"$patch": "replace"})
+//		return l
+//	}
+//
+//	return data
+//}
 
 func isKudoType(object runtime.Object) bool {
 	_, isOperator := object.(*v1beta1.OperatorVersion)

--- a/pkg/engine/task/task_delete.go
+++ b/pkg/engine/task/task_delete.go
@@ -30,7 +30,7 @@ func (dt DeleteTask) Run(ctx Context) (bool, error) {
 	}
 
 	// 3. - Delete them using the client -
-	err = deleteObj(enhanced, ctx.Client)
+	err = deleteResource(enhanced, ctx.Client)
 	if err != nil {
 		return false, err
 	}
@@ -39,7 +39,7 @@ func (dt DeleteTask) Run(ctx Context) (bool, error) {
 	return true, nil
 }
 
-func deleteObj(ro []runtime.Object, c client.Client) error {
+func deleteResource(ro []runtime.Object, c client.Client) error {
 	for _, r := range ro {
 		err := c.Delete(context.TODO(), r, client.PropagationPolicy(metav1.DeletePropagationForeground))
 		if !apierrors.IsNotFound(err) && err != nil {

--- a/pkg/engine/task/task_delete.go
+++ b/pkg/engine/task/task_delete.go
@@ -30,7 +30,7 @@ func (dt DeleteTask) Run(ctx Context) (bool, error) {
 	}
 
 	// 3. - Delete them using the client -
-	err = delete(enhanced, ctx.Client)
+	err = deleteObj(enhanced, ctx.Client)
 	if err != nil {
 		return false, err
 	}
@@ -39,7 +39,7 @@ func (dt DeleteTask) Run(ctx Context) (bool, error) {
 	return true, nil
 }
 
-func delete(ro []runtime.Object, c client.Client) error {
+func deleteObj(ro []runtime.Object, c client.Client) error {
 	for _, r := range ro {
 		err := c.Delete(context.TODO(), r, client.PropagationPolicy(metav1.DeletePropagationForeground))
 		if !apierrors.IsNotFound(err) && err != nil {

--- a/pkg/engine/task/task_pipe.go
+++ b/pkg/engine/task/task_pipe.go
@@ -134,7 +134,7 @@ func (pt PipeTask) Run(ctx Context) (bool, error) {
 
 	// 12. - Delete pipe pod -
 	log.Printf("PipeTask: %s/%s deleting pipe pod", ctx.Meta.InstanceNamespace, ctx.Meta.InstanceName)
-	err = delete(podObj, ctx.Client)
+	err = deleteObj(podObj, ctx.Client)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/engine/task/task_pipe.go
+++ b/pkg/engine/task/task_pipe.go
@@ -87,7 +87,7 @@ func (pt PipeTask) Run(ctx Context) (bool, error) {
 	}
 
 	// 6. - Apply pod using the client -
-	podObj, err = apply(podObj, ctx.Client, ctx.Discovery)
+	podObj, err = applyResource(podObj, ctx.Client, ctx.Discovery)
 	if err != nil {
 		return false, err
 	}
@@ -127,14 +127,14 @@ func (pt PipeTask) Run(ctx Context) (bool, error) {
 	}
 
 	// 11. - Apply artifacts using the client -
-	_, err = apply(artObj, ctx.Client, ctx.Discovery)
+	_, err = applyResource(artObj, ctx.Client, ctx.Discovery)
 	if err != nil {
 		return false, err
 	}
 
 	// 12. - Delete pipe pod -
 	log.Printf("PipeTask: %s/%s deleting pipe pod", ctx.Meta.InstanceNamespace, ctx.Meta.InstanceName)
-	err = deleteObj(podObj, ctx.Client)
+	err = deleteResource(podObj, ctx.Client)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/engine/task/task_pipe.go
+++ b/pkg/engine/task/task_pipe.go
@@ -87,7 +87,7 @@ func (pt PipeTask) Run(ctx Context) (bool, error) {
 	}
 
 	// 6. - Apply pod using the client -
-	podObj, err = applyResource(podObj, ctx.Client, ctx.Discovery)
+	podObj, err = applyResources(podObj, ctx)
 	if err != nil {
 		return false, err
 	}
@@ -127,7 +127,7 @@ func (pt PipeTask) Run(ctx Context) (bool, error) {
 	}
 
 	// 11. - Apply artifacts using the client -
-	_, err = applyResource(artObj, ctx.Client, ctx.Discovery)
+	_, err = applyResources(artObj, ctx)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/test/utils/subset.go
+++ b/pkg/test/utils/subset.go
@@ -3,7 +3,6 @@ package utils
 import (
 	"fmt"
 	"reflect"
-	"strings"
 )
 
 // SubsetError is an error type used by IsSubset for tracking the path in the struct.
@@ -64,19 +63,6 @@ func IsSubset(expected, actual interface{}) error {
 		iter := reflect.ValueOf(expected).MapRange()
 
 		for iter.Next() {
-			key := iter.Key().String()
-			if strings.HasPrefix(key, "$REQUIRE_MISSING_") {
-				key = strings.TrimPrefix(key, "$REQUIRE_MISSING_")
-				actualValue := reflect.ValueOf(actual).MapIndex(reflect.ValueOf(key))
-				if actualValue.IsValid() {
-					return &SubsetError{
-						path:    []string{key},
-						message: fmt.Sprintf("key was expected to be missing but is present (%v)", actualValue),
-					}
-				}
-				continue
-			}
-
 			actualValue := reflect.ValueOf(actual).MapIndex(iter.Key())
 
 			if !actualValue.IsValid() {

--- a/pkg/test/utils/subset.go
+++ b/pkg/test/utils/subset.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"fmt"
 	"reflect"
+	"strings"
 )
 
 // SubsetError is an error type used by IsSubset for tracking the path in the struct.
@@ -63,6 +64,19 @@ func IsSubset(expected, actual interface{}) error {
 		iter := reflect.ValueOf(expected).MapRange()
 
 		for iter.Next() {
+			key := iter.Key().String()
+			if strings.HasPrefix(key, "$REQUIRE_MISSING_") {
+				key = strings.TrimPrefix(key, "$REQUIRE_MISSING_")
+				actualValue := reflect.ValueOf(actual).MapIndex(reflect.ValueOf(key))
+				if actualValue.IsValid() {
+					return &SubsetError{
+						path:    []string{key},
+						message: fmt.Sprintf("key was expected to be missing but is present (%v)", actualValue),
+					}
+				}
+				continue
+			}
+
 			actualValue := reflect.ValueOf(actual).MapIndex(iter.Key())
 
 			if !actualValue.IsValid() {

--- a/pkg/util/kudo/labels.go
+++ b/pkg/util/kudo/labels.go
@@ -19,4 +19,7 @@ const (
 
 	// PlanUIDAnnotation is a k8s annotation key for the last time a given plan was run on the referenced object
 	PlanUIDAnnotation = "kudo.dev/last-plan-execution-uid"
+
+	// Last applied state for three way merges
+	LastAppliedConfigAnnotation = "kudo.dev/last-applied-configuration"
 )

--- a/test/integration/remove-pod-container/00-assert.yaml
+++ b/test/integration/remove-pod-container/00-assert.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  replicas: 1
+  template:
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.7.9
+        ports:
+        - containerPort: 80
+      - name: nginx2
+        image: nginx:1.7.9
+        ports:
+          - containerPort: 8080

--- a/test/integration/remove-pod-container/00-assert.yaml
+++ b/test/integration/remove-pod-container/00-assert.yaml
@@ -6,7 +6,6 @@ spec:
   replicas: 1
   template:
     spec:
-      $REQUIRE_MISSING_priority: nil
       containers:
       - name: nginx
         image: nginx:1.7.9

--- a/test/integration/remove-pod-container/00-assert.yaml
+++ b/test/integration/remove-pod-container/00-assert.yaml
@@ -6,6 +6,7 @@ spec:
   replicas: 1
   template:
     spec:
+      $REQUIRE_MISSING_priority: nil
       containers:
       - name: nginx
         image: nginx:1.7.9

--- a/test/integration/remove-pod-container/00-errors.yaml
+++ b/test/integration/remove-pod-container/00-errors.yaml
@@ -6,8 +6,4 @@ spec:
   replicas: 1
   template:
     spec:
-      containers:
-      - name: nginx
-        image: nginx:1.7.9
-        ports:
-        - containerPort: 80
+      priority: 100

--- a/test/integration/remove-pod-container/00-install.yaml
+++ b/test/integration/remove-pod-container/00-install.yaml
@@ -1,4 +1,4 @@
 apiVersion: kudo.dev/v1beta1
 kind: TestStep
 kubectl:
-- kudo install --instance dual-pod ./dual-pod-operator
+- kudo install --instance dual-pod ./dual-pod-operator -p  WITH_PRIORITY="false"

--- a/test/integration/remove-pod-container/00-install.yaml
+++ b/test/integration/remove-pod-container/00-install.yaml
@@ -1,0 +1,4 @@
+apiVersion: kudo.dev/v1beta1
+kind: TestStep
+kubectl:
+- kudo install --instance dual-pod ./dual-pod-operator

--- a/test/integration/remove-pod-container/01-assert.yaml
+++ b/test/integration/remove-pod-container/01-assert.yaml
@@ -1,0 +1,13 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  replicas: 1
+  template:
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.7.9
+        ports:
+        - containerPort: 80

--- a/test/integration/remove-pod-container/01-update.yaml
+++ b/test/integration/remove-pod-container/01-update.yaml
@@ -1,4 +1,4 @@
 apiVersion: kudo.dev/v1beta1
 kind: TestStep
 kubectl:
-- kudo update --instance dual-pod -p SECOND_CONTAINER="false"
+- kudo update --instance dual-pod -p SECOND_CONTAINER="false" -p WITH_PRIORITY="true"

--- a/test/integration/remove-pod-container/01-update.yaml
+++ b/test/integration/remove-pod-container/01-update.yaml
@@ -1,0 +1,4 @@
+apiVersion: kudo.dev/v1beta1
+kind: TestStep
+kubectl:
+- kudo update --instance dual-pod -p SECOND_CONTAINER="false"

--- a/test/integration/remove-pod-container/02-assert.yaml
+++ b/test/integration/remove-pod-container/02-assert.yaml
@@ -6,7 +6,6 @@ spec:
   replicas: 1
   template:
     spec:
-      priority: 100
       containers:
       - name: nginx
         image: nginx:1.7.9

--- a/test/integration/remove-pod-container/02-assert.yaml
+++ b/test/integration/remove-pod-container/02-assert.yaml
@@ -6,6 +6,7 @@ spec:
   replicas: 1
   template:
     spec:
+      $REQUIRE_MISSING_priority: nil
       containers:
       - name: nginx
         image: nginx:1.7.9

--- a/test/integration/remove-pod-container/02-errors.yaml
+++ b/test/integration/remove-pod-container/02-errors.yaml
@@ -6,8 +6,4 @@ spec:
   replicas: 1
   template:
     spec:
-      containers:
-      - name: nginx
-        image: nginx:1.7.9
-        ports:
-        - containerPort: 80
+      priority: 100

--- a/test/integration/remove-pod-container/02-update_param.yaml
+++ b/test/integration/remove-pod-container/02-update_param.yaml
@@ -1,0 +1,4 @@
+apiVersion: kudo.dev/v1beta1
+kind: TestStep
+kubectl:
+- kudo update --instance dual-pod -p WITH_PRIORITY="false"

--- a/test/integration/remove-pod-container/dual-pod-operator/operator.yaml
+++ b/test/integration/remove-pod-container/dual-pod-operator/operator.yaml
@@ -1,0 +1,25 @@
+apiVersion: kudo.dev/v1beta1
+name: "dual-pod-operator"
+operatorVersion: "0.1.0"
+appVersion: "1.7.9"
+kubernetesVersion: 1.13.0
+maintainers:
+  - name: Your name
+    email: <your@email.com>
+url: https://kudo.dev
+tasks:
+  - name: app
+    kind: Apply
+    spec:
+      resources:
+        - deployment.yaml
+plans:
+  deploy:
+    strategy: serial
+    phases:
+      - name: main
+        strategy: parallel
+        steps:
+          - name: everything
+            tasks:
+              - app

--- a/test/integration/remove-pod-container/dual-pod-operator/params.yaml
+++ b/test/integration/remove-pod-container/dual-pod-operator/params.yaml
@@ -3,3 +3,6 @@ parameters:
   - name: SECOND_CONTAINER
     description: If the second container should be started
     default: true
+  - name: WITH_PRIORITY
+    description: If true, a priority is set
+    default: true

--- a/test/integration/remove-pod-container/dual-pod-operator/params.yaml
+++ b/test/integration/remove-pod-container/dual-pod-operator/params.yaml
@@ -1,0 +1,5 @@
+apiVersion: kudo.dev/v1beta1
+parameters:
+  - name: SECOND_CONTAINER
+    description: If the second container should be started
+    default: true

--- a/test/integration/remove-pod-container/dual-pod-operator/templates/deployment.yaml
+++ b/test/integration/remove-pod-container/dual-pod-operator/templates/deployment.yaml
@@ -12,6 +12,9 @@ spec:
       labels:
         app: nginx
     spec:
+      {{ if eq .Params.WITH_PRIORITY "true" }}
+      priority: 100
+      {{ end }}
       containers:
         - name: nginx
           image: nginx:{{ .AppVersion }}

--- a/test/integration/remove-pod-container/dual-pod-operator/templates/deployment.yaml
+++ b/test/integration/remove-pod-container/dual-pod-operator/templates/deployment.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  selector:
+    matchLabels:
+      app: nginx
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:{{ .AppVersion }}
+          ports:
+            - containerPort: 80
+      {{ if eq .Params.SECOND_CONTAINER "true"}}
+        - name: nginx2
+          image: nginx:{{ .AppVersion }}
+          ports:
+            - containerPort: 8080
+      {{ end }}


### PR DESCRIPTION
**What this PR does / why we need it**:
The ApplyTask patch method currently uses a StrategicMerge patch, which by default merges some lists, for example, containers in a Deployment-PodTemplate. This makes it impossible to have a conditional container in an operator.

Added a test harness test.

Fixes #1286 

**Issue**
The Big Problem is that applying new versions of rendered resources from KUDO to the cluster is not as easy as it seems: We generally render full resources from the `OperatorVersion` templates, but there is no easy way to update existing resources in the cluster:

**Patch with StrategicMerge**
This is the solution we use at the moment. The issue is, that a strategic merge does not replace certain lists - for example, the list of containers in a PodTemplate is merged, not replaced by default. If a list (or map) is merged instead of replaced depends on the annotations in the resource types:
```
	// +patchMergeKey=name
	// +patchStrategy=merge
	Containers []Container `json:"containers" patchStrategy:"merge" patchMergeKey:"name" protobuf:"bytes,2,rep,name=containers"`
```

It is possible to overwrite this behavior for strategic merges: https://www.disasterproject.com/kubernetes-kubectl-patching/
We can add an entry `$patch: replace` to a list or a map to replace instead of merge. But we can't add these entries to *all* maps and lists, as this would trigger the replacement of immutable fields which leads to an error by the k8s API. We would have to maintain a list of all places to add these patch-entries.

**Replace**
We could replace resources instead of patching them. This approach does not work as a lot of resources have immutable fields that can't be updated - for example the ServiceSpec.ClusterIP. As this field is usually filled in by k8s, it's not filled when we generate the resource from the KUDO template. A replace would then complain that ClusterIP will be updated with "" which is not allowed.

It might be possible to Force-Replace. This allows us to update immutable fields by doing a delete/create instead of a replace; the downside is that it would, for example, assign a new ClusterIP and be a disruptive update (https://kubernetes.io/docs/concepts/cluster-administration/manage-deployment/#disruptive-updates)

**ServerSideApply**
This should theoretically work best. All creations and updates should be done via:
```
c.Patch(context.TODO(), newObj, client.Apply, client.FieldOwner("KUDO"))
```
and k8s should figure out what actually changed and apply it. There are some problems on the integration tests (no darwin binaries for kube-apiserver > 15.5), and bugs in the server side apply feature itself. Might be an option for the future.

**Client Side Threeway-Diff**
This is the only real way to do this at the moment.
First approach was to reuse code from `kudectl apply`, but that fails for various reasons. kubectl isn't really expected to be used as a library.

I rewrote the code similar to `kudectl apply` though, it still needs some polishing but it should work for now.

