### PR TITLE
Compare real operator name, not prefix when checking for installed versions

### DIFF
--- a/pkg/kudoctl/util/kudo/install.go
+++ b/pkg/kudoctl/util/kudo/install.go
@@ -45,6 +45,8 @@ func InstallPackage(kc *Client, resources *packages.Resources, skipInstance bool
 			return fmt.Errorf("failed to install %s-operatorversion.yaml: %v", operatorName, err)
 		}
 		clog.Printf("operatorversion.%s/%s created", resources.OperatorVersion.APIVersion, resources.OperatorVersion.Name)
+	} else {
+		clog.Printf("operatorversion.%s/%s already installed", resources.OperatorVersion.APIVersion, resources.OperatorVersion.Name)
 	}
 
 	if skipInstance {

--- a/pkg/kudoctl/util/kudo/kudo.go
+++ b/pkg/kudoctl/util/kudo/kudo.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"strings"
 	"time"
 
 	v1core "k8s.io/api/core/v1"
@@ -216,10 +215,10 @@ func (c *Client) OperatorVersionsInstalled(operatorName, namespace string) ([]st
 	if err != nil {
 		return nil, err
 	}
-	existingVersions := []string{}
+	existingVersions := make([]string, 0)
 
 	for _, v := range ov.Items {
-		if strings.HasPrefix(v.Name, operatorName) {
+		if v.Spec.Operator.Name == operatorName {
 			existingVersions = append(existingVersions, v.Spec.Version)
 		}
 	}

--- a/pkg/kudoctl/util/kudo/kudo.go
+++ b/pkg/kudoctl/util/kudo/kudo.go
@@ -215,7 +215,7 @@ func (c *Client) OperatorVersionsInstalled(operatorName, namespace string) ([]st
 	if err != nil {
 		return nil, err
 	}
-	existingVersions := make([]string, 0)
+	existingVersions := []string{}
 
 	for _, v := range ov.Items {
 		if v.Spec.Operator.Name == operatorName {

--- a/pkg/kudoctl/util/kudo/kudo_test.go
+++ b/pkg/kudoctl/util/kudo/kudo_test.go
@@ -211,8 +211,14 @@ func TestKudoClient_OperatorVersionsInstalled(t *testing.T) {
 		},
 		Spec: v1beta1.OperatorVersionSpec{
 			Version: "1.0",
+			Operator: v1.ObjectReference{
+				Name: operatorName,
+			},
 		},
 	}
+	objWithSamePrefix := obj.DeepCopy()
+	objWithSamePrefix.Name = operatorName + "-demo"
+	objWithSamePrefix.Spec.Operator.Name = operatorName + "-demo"
 
 	installNamespace := "default"
 	tests := []struct {
@@ -224,6 +230,7 @@ func TestKudoClient_OperatorVersionsInstalled(t *testing.T) {
 		{"no operator version defined", []string{}, installNamespace, nil},
 		{"operator version exists in the same namespace", []string{obj.Spec.Version}, installNamespace, &obj},
 		{"operator version exists in different namespace", []string{}, "otherns", &obj},
+		{"operator with same prefix exists", []string{}, installNamespace, objWithSamePrefix},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Add unit tests to verify that.
Add message if operator version install does not install new version

Signed-off-by: Andreas Neumann <aneumann@mesosphere.com>

Fixes #615 
