### PR TITLE
Plan verifier checks for mandatory `deploy` plan

### DIFF
--- a/pkg/apis/kudo/v1beta1/instance_types.go
+++ b/pkg/apis/kudo/v1beta1/instance_types.go
@@ -175,7 +175,7 @@ const (
 )
 
 var (
-	ReservedPlanNames = []string{
+	SpecialPlanNames = []string{
 		DeployPlanName,
 		UpgradePlanName,
 		UpdatePlanName,

--- a/pkg/kudoctl/cmd/package_verify_test.go
+++ b/pkg/kudoctl/cmd/package_verify_test.go
@@ -31,5 +31,5 @@ func TestOperatorVerify(t *testing.T) {
 		t.Fatalf("failed reading .golden: %s", err)
 	}
 
-	assert.Equal(t, out.String(), string(g), "yaml does not match .golden file %s", gp)
+	assert.Equal(t, string(g), out.String(), "yaml does not match .golden file %s", gp)
 }

--- a/pkg/kudoctl/cmd/testdata/invalid-params.golden
+++ b/pkg/kudoctl/cmd/testdata/invalid-params.golden
@@ -1,5 +1,4 @@
 Warnings                                
-plan "validation" defined but not used  
 parameter "Cpus" defined but not used.  
 parameter "comma," defined but not used.
 Errors                                                            

--- a/pkg/kudoctl/packages/verifier/plan/verify_references.go
+++ b/pkg/kudoctl/packages/verifier/plan/verify_references.go
@@ -8,37 +8,25 @@ import (
 	"github.com/kudobuilder/kudo/pkg/kudoctl/packages/verifier"
 )
 
-// ReferenceVerifier verifies plans producing errors for plans referenced in param triggers that do not exist and warnings for plans which are not used in a param
+// ReferenceVerifier verifies plans producing errors for plans referenced in param triggers that do not exist
+// and warnings for missing mandatory plans.
 type ReferenceVerifier struct{}
 
 func (ReferenceVerifier) Verify(pf *packages.Files) verifier.Result {
 	res := verifier.NewResult()
 	res.Merge(plansNotDefined(pf))
-	res.Merge(plansDefinedNotUsed(pf))
+	res.Merge(hasMandatoryPlans(pf))
 
 	return res
 }
 
-func plansDefinedNotUsed(pf *packages.Files) verifier.Result {
+func hasMandatoryPlans(pf *packages.Files) verifier.Result {
 	res := verifier.NewResult()
-	usedPlans := make(map[string]bool)
+	plans := pf.Operator.Plans
 
-	// Mark reserved plan names as used
-	for _, plan := range v1beta1.ReservedPlanNames {
-		usedPlans[plan] = true
-	}
-
-	// Mark plans in param triggers as used
-	for _, param := range pf.Params.Parameters {
-		if param.Trigger != "" {
-			usedPlans[param.Trigger] = true
-		}
-	}
-
-	for name := range pf.Operator.Plans {
-		if _, ok := usedPlans[name]; !ok {
-			res.AddWarnings(fmt.Sprintf("plan %q defined but not used", name))
-		}
+	// Currently only 'deploy' plan is mandatory
+	if _, ok := plans[v1beta1.DeployPlanName]; !ok {
+		res.AddErrors(fmt.Sprintf("an operator is required to have '%s' plan", v1beta1.DeployPlanName))
 	}
 
 	return res

--- a/pkg/kudoctl/packages/verifier/plan/verify_references_test.go
+++ b/pkg/kudoctl/packages/verifier/plan/verify_references_test.go
@@ -1,7 +1,6 @@
 package plan
 
 import (
-	"log"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -70,7 +69,6 @@ func TestPlanReferenceVerifier(t *testing.T) {
 	verifier := ReferenceVerifier{}
 	res := verifier.Verify(&pf)
 
-	res.PrintErrors(log.Writer())
 	assert.Equal(t, 1, len(res.Errors))
 	assert.Equal(t, `plan "not-existing-plan" used in parameter "PARAM2" is not defined`, res.Errors[0])
 }

--- a/pkg/kudoctl/packages/verifier/plan/verify_references_test.go
+++ b/pkg/kudoctl/packages/verifier/plan/verify_references_test.go
@@ -1,6 +1,7 @@
 package plan
 
 import (
+	"log"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -69,8 +70,7 @@ func TestPlanReferenceVerifier(t *testing.T) {
 	verifier := ReferenceVerifier{}
 	res := verifier.Verify(&pf)
 
-	assert.Equal(t, 1, len(res.Warnings))
-	assert.Equal(t, `plan "unused-plan" defined but not used`, res.Warnings[0])
+	res.PrintErrors(log.Writer())
 	assert.Equal(t, 1, len(res.Errors))
 	assert.Equal(t, `plan "not-existing-plan" used in parameter "PARAM2" is not defined`, res.Errors[0])
 }


### PR DESCRIPTION
Summary:
 - removed verifying that a plan is not referenced by any parameter. In the light of upcoming KEP-18 allowing triggering plans manually, some plans e.g. `backup` won be referenced by any parameter
 - added verifying that at least `deploy` plan exists in the operator
