### PR TITLE
Error out in instance webhook when a parameter has an undefined plan trigger

### DIFF
--- a/pkg/webhook/instance_admission.go
+++ b/pkg/webhook/instance_admission.go
@@ -199,11 +199,14 @@ func triggeredPlan(params []kudov1beta1.Parameter, ov *kudov1beta1.OperatorVersi
 
 	plans := make([]string, 0)
 	for _, p := range params {
-		if p.Trigger != "" && kudov1beta1.SelectPlan([]string{p.Trigger}, ov) != nil {
-			plans = append(plans, p.Trigger)
+		if p.Trigger != "" {
+			if kudov1beta1.SelectPlan([]string{p.Trigger}, ov) != nil {
+				plans = append(plans, p.Trigger)
+			} else {
+				return nil, fmt.Errorf("param %s defined trigger plan %s, but plan not defined in operatorversion", p.Name, p.Trigger)
+			}
 		}
 	}
-
 	plans = funk.UniqString(plans)
 
 	switch len(plans) {

--- a/pkg/webhook/instance_admission_test.go
+++ b/pkg/webhook/instance_admission_test.go
@@ -350,6 +350,13 @@ func Test_triggeredPlan(t *testing.T) {
 			want:    nil,
 			wantErr: true,
 		},
+		{
+			name:    "params triggering a non-existing plan",
+			params:  []v1beta1.Parameter{{Name: "foo", Trigger: "fake"}},
+			ov:      ov,
+			want:    nil,
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Summary:
This is a followup to #1336 which verified that triggered plans are actually defined in the OV. This PR adds this logic to the instance webhook.

Fixes #1268

Signed-off-by: Aleksey Dukhovniy <alex.dukhovniy@googlemail.com>