### PR TITLE
Mark the status in the kep-template provisional

### DIFF
--- a/keps/0000-kep-template.md
+++ b/keps/0000-kep-template.md
@@ -10,7 +10,7 @@ owners:
 editor: TBD
 creation-date: yyyy-mm-dd
 last-updated: yyyy-mm-dd
-status: implemented
+status: provisional
 see-also:
   - KEP-1
   - KEP-2


### PR DESCRIPTION
I can see why we might mark it "implemented" if we consider this document itself a KEP, however the other fields are mostly fillers as well, so I think it makes sense to mark it provisional by default since a new KEP will always be provisional.