### PR TITLE
Support arbitrary YAML as parameter values

### DIFF
--- a/pkg/engine/renderer/engine_test.go
+++ b/pkg/engine/renderer/engine_test.go
@@ -22,6 +22,10 @@ func TestRender(t *testing.T) {
 			},
 			expected: "Name: Bob User"},
 		{name: "function", template: "Name: {{ .Params.Name | upper }}", params: map[string]interface{}{"Name": "hello"}, expected: "Name: HELLO"},
+		{name: "YAML parameter values",
+			template: "Name: {{ index .Params.Name 1 }}",
+			params:   map[string]interface{}{"Name": []string{"foo", "Some Name"}},
+			expected: "Name: Some Name"},
 	}
 
 	engine := New()

--- a/pkg/engine/task/render_test.go
+++ b/pkg/engine/task/render_test.go
@@ -1,0 +1,60 @@
+package task
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConvertYAMLParameters(t *testing.T) {
+	tests := []struct {
+		name     string
+		params   map[string]string
+		expected map[string]interface{}
+	}{
+		{
+			name:     "empty",
+			params:   nil,
+			expected: map[string]interface{}{},
+		},
+		{
+			name: "string value",
+			params: map[string]string{
+				"foo": "bar",
+			},
+			expected: map[string]interface{}{
+				"foo": "bar",
+			},
+		},
+		{
+			name: "YAML array",
+			params: map[string]string{
+				"foo": "- bar\n- baz",
+			},
+			expected: map[string]interface{}{
+				"foo": []interface{}{"bar", "baz"},
+			},
+		},
+		{
+			name: "complex YAML",
+			params: map[string]string{
+				"foo": "hello: World\nports:\n  - name: HTTP\n    port: 80\n  - name: FTP\n    port: 21\n",
+			},
+			expected: map[string]interface{}{
+				"foo": map[interface{}]interface{}{
+					"hello": "World",
+					"ports": []interface{}{
+						map[interface{}]interface{}{"name": "HTTP", "port": 80},
+						map[interface{}]interface{}{"name": "FTP", "port": 21},
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		actual, err := convertYAMLParameters(test.params)
+		assert.NoError(t, err, test.name)
+		assert.Equal(t, test.expected, actual, test.name)
+	}
+}

--- a/test/integration/operator-with-yaml-param/00-assert.yaml
+++ b/test/integration/operator-with-yaml-param/00-assert.yaml
@@ -1,0 +1,13 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  template:
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.7.9
+        ports:
+        - containerPort: 80
+        - containerPort: 443

--- a/test/integration/operator-with-yaml-param/00-install.yaml
+++ b/test/integration/operator-with-yaml-param/00-install.yaml
@@ -1,0 +1,62 @@
+apiVersion: kudo.dev/v1beta1
+kind: OperatorVersion
+metadata:
+  name: nginx-operator
+spec:
+  version: "1.0"
+  parameters:
+  - name: PORTS
+  templates:
+    deployment.yaml: |
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: nginx-deployment
+      spec:
+        selector:
+          matchLabels:
+            app: nginx
+        replicas: 1
+        template:
+          metadata:
+            labels:
+              app: nginx
+          spec:
+            containers:
+              - name: nginx
+                image: nginx:1.7.9
+                ports:
+                  {{ range .Params.PORTS }}
+                  - containerPort: {{ . }}
+                  {{ end }}
+  tasks:
+    - name: app
+      kind: Apply
+      spec:
+        resources:
+          - deployment.yaml
+  plans:
+    deploy:
+      strategy: serial
+      phases:
+        - name: main
+          strategy: parallel
+          steps:
+            - name: everything
+              tasks:
+                - app
+---
+apiVersion: kudo.dev/v1beta1
+kind: Instance
+metadata:
+  name: nginx-instance
+  labels:
+    kudo.dev/operator: nginx-operator
+spec:
+  operatorVersion:
+    name: nginx-operator
+    kind: OperatorVersion
+  parameters:
+    PORTS: |
+      - 80
+      - 443


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kudo/blob/master/CONTRIBUTING.md
2. Make sure you have added and ran the tests before submitting your PR
3. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What this PR does / why we need it**:
This allow templates to access list or dictionary items if parameter values are provided as valid YAML. Because a simple string is also valid YAML, it is still compatible with regular string values.

Currently WIP, I plan to create a KEP around this as well which will provide more background and motivation.

<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1349
