### PR TITLE
chore: add target to update golden-files for individual tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,6 +145,13 @@ ifeq (, $(shell which golangci-lint))
 endif
 	golangci-lint run --disable-all -E goimports --fix
 
+.PHONY: update-golden-%
+# used to update the golden files present in ./pkg/kudoctl/cmd/testdata
+# Requires the individual test name to avoid massive update of all golden files
+# example: make update-golden-TestInitCmd_dry
+update-golden-%:
+	go test ./pkg/kudoctl/cmd -run $* --update=true
+
 .PHONY: todo
 # Show to-do items per file.
 todo:

--- a/Makefile
+++ b/Makefile
@@ -150,7 +150,7 @@ endif
 # Requires the individual test name to avoid massive update of all golden files
 # example: make update-golden-TestInitCmd_dry
 update-golden-%:
-	go test ./pkg/kudoctl/cmd -run $* --update=true
+	go test ./pkg/kudoctl/cmd ./pkg/kudoctl/packages ./pkg/kudoctl/util/repo -v -mod=readonly -run $* --update=true
 
 .PHONY: todo
 # Show to-do items per file.

--- a/pkg/kudoctl/cmd/package_list_params_test.go
+++ b/pkg/kudoctl/cmd/package_list_params_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestParamsLis(t *testing.T) {
+func TestParamsList(t *testing.T) {
 	file := "params-list"
 	out := &bytes.Buffer{}
 	cmd := newPackageListParamsCmd(fs, out)

--- a/test/README.md
+++ b/test/README.md
@@ -88,4 +88,4 @@ Running a non-existing test would return a
 ok      github.com/kudobuilder/kudo/pkg/kudoctl/cmd     0.048s [no tests to run]
 ```
 
-Currently we don't allow to update all golden files through `Makefile` target
+Currently we don't allow to update all golden files through a single `Makefile` target in one go.

--- a/test/README.md
+++ b/test/README.md
@@ -73,3 +73,19 @@ Run tests against a live cluster and do not delete resources after running:
 ```
 go run ./cmd/kubectl-kudo test --start-control-plane=false --skip-delete
 ```
+### Update golden files of the directory testdata
+
+You can update golden files per each test by running `make update-golden-${test-name}`
+
+Examples:
+```
+make update-golden-TestInitCmd_dry
+make update-golden-TestParamsList
+```
+
+Running a non-existing test would return a 
+```
+ok      github.com/kudobuilder/kudo/pkg/kudoctl/cmd     0.048s [no tests to run]
+```
+
+Currently we don't allow to update all golden files through `Makefile` target


### PR DESCRIPTION
Signed-off-by: Zain Malik <zmalikshxil@gmail.com>

**What this PR does / why we need it**:
Updating the golden files for tests wasn't documented and for first time contributors to those it can be hard to discover how to do it.

This PR adds a Make target to update golden files, and requires the name of individual test to update only one by one. This is to address concerns to avoid doing a massive update in golden files by error
examples: 
```
make update-golden-TestInitCmd_dry
make update-golden-TestParamsList
```
