### PR TITLE
Fatal error on terminal job

### DIFF
--- a/pkg/engine/health/health.go
+++ b/pkg/engine/health/health.go
@@ -17,23 +17,27 @@ import (
 )
 
 // IsTerminallyFailed returns whether an object is in a terminal failed state and has no chance to reach healthy
-func IsTerminallyFailed(obj runtime.Object) bool {
+func IsTerminallyFailed(obj runtime.Object) (bool, string) {
 	if obj == nil {
-		return false
+		return false, ""
 	}
 
 	switch obj := obj.(type) {
 	case *batchv1.Job:
-		if obj.Spec.BackoffLimit != nil {
-			if obj.Status.Failed > *obj.Spec.BackoffLimit {
-				log.Printf("HealthUtil: Job \"%v\" has reached terminal state and is unsuccessful, abort", obj.Name)
-				return true
-			}
-		}
+		return isJobTerminallyFailed(obj)
 	default:
-		return false
+		return false, ""
 	}
-	return false
+}
+
+func isJobTerminallyFailed(job *batchv1.Job) (bool, string) {
+	for _, c := range job.Status.Conditions {
+		if c.Type == batchv1.JobFailed && c.Status == corev1.ConditionTrue {
+			log.Printf("HealthUtil: Job \"%v\" has failed: %s", job.Name, c.Message)
+			return true, c.Message
+		}
+	}
+	return false, ""
 }
 
 // IsHealthy returns whether an object is healthy. Must be implemented for each type.

--- a/pkg/engine/health/health.go
+++ b/pkg/engine/health/health.go
@@ -25,7 +25,7 @@ func IsTerminallyFailed(obj runtime.Object) bool {
 	switch obj := obj.(type) {
 	case *batchv1.Job:
 		if obj.Spec.BackoffLimit != nil {
-			if obj.Status.Failed >= *obj.Spec.BackoffLimit {
+			if obj.Status.Failed > *obj.Spec.BackoffLimit {
 				log.Printf("HealthUtil: Job \"%v\" has reached terminal state and is unsuccessful, abort", obj.Name)
 				return true
 			}

--- a/pkg/engine/health/health.go
+++ b/pkg/engine/health/health.go
@@ -16,6 +16,26 @@ import (
 	kudov1beta1 "github.com/kudobuilder/kudo/pkg/apis/kudo/v1beta1"
 )
 
+// IsTerminallyFailed returns whether an object is in a terminal failed state and has no chance to reach healthy
+func IsTerminallyFailed(obj runtime.Object) bool {
+	if obj == nil {
+		return false
+	}
+
+	switch obj := obj.(type) {
+	case *batchv1.Job:
+		if obj.Spec.BackoffLimit != nil {
+			if obj.Status.Failed >= *obj.Spec.BackoffLimit {
+				log.Printf("HealthUtil: Job \"%v\" has reached terminal state and is unsuccessful, abort", obj.Name)
+				return true
+			}
+		}
+	default:
+		return false
+	}
+	return false
+}
+
 // IsHealthy returns whether an object is healthy. Must be implemented for each type.
 func IsHealthy(obj runtime.Object) error {
 	if obj == nil {

--- a/pkg/engine/task/task.go
+++ b/pkg/engine/task/task.go
@@ -53,6 +53,7 @@ var (
 	dummyTaskError          = "DummyTaskError"
 	resourceUnmarshalError  = "ResourceUnmarshalError"
 	resourceValidationError = "ResourceValidationError"
+	failedTerminalState     = "FailedTerminalStateError"
 )
 
 // Build factory method takes an v1beta1.Task and returns a corresponding Tasker object

--- a/pkg/engine/task/task_apply.go
+++ b/pkg/engine/task/task_apply.go
@@ -241,9 +241,9 @@ func isHealthy(ro []runtime.Object) error {
 
 func isTerminallyFailed(ro []runtime.Object) error {
 	for _, r := range ro {
-		if health.IsTerminallyFailed(r) {
+		if failed, msg := health.IsTerminallyFailed(r); failed {
 			key, _ := client.ObjectKeyFromObject(r)
-			return fmt.Errorf("object %s/%s has reached a terminal failed state", key.Namespace, key.Name)
+			return fmt.Errorf("object %s/%s has failed: %s", key.Namespace, key.Name, msg)
 		}
 	}
 	return nil

--- a/pkg/engine/task/task_pipe.go
+++ b/pkg/engine/task/task_pipe.go
@@ -97,6 +97,9 @@ func (pt PipeTask) Run(ctx Context) (bool, error) {
 	// once the pod is Ready, it means that its initContainer finished successfully and we can copy
 	// out the generated files. An error during a health check is not treated as task execution error
 	if err != nil {
+		if fatal := isTerminallyFailed(podObj); fatal != nil {
+			return false, fatalExecutionError(fatal, failedTerminalState, ctx.Meta)
+		}
 		return false, nil
 	}
 

--- a/test/e2e/terminal-failed-job/00-assert.yaml
+++ b/test/e2e/terminal-failed-job/00-assert.yaml
@@ -1,0 +1,11 @@
+apiVersion: kudo.dev/v1beta1
+kind: Instance
+metadata:
+  labels:
+    kudo.dev/operator: failjob-operator
+spec:
+  operatorVersion:
+    name: failjob-operator-0.1.0
+status:
+  aggregatedStatus:
+    status: FATAL_ERROR

--- a/test/e2e/terminal-failed-job/00-install.yaml
+++ b/test/e2e/terminal-failed-job/00-install.yaml
@@ -1,0 +1,4 @@
+apiVersion: kudo.dev/v1beta1
+kind: TestStep
+kubectl:
+- kudo install --instance failjob-operator-instance ./failjob-operator

--- a/test/e2e/terminal-failed-job/01-assert.yaml
+++ b/test/e2e/terminal-failed-job/01-assert.yaml
@@ -1,0 +1,11 @@
+apiVersion: kudo.dev/v1beta1
+kind: Instance
+metadata:
+  labels:
+    kudo.dev/operator: job-timeout-operator
+spec:
+  operatorVersion:
+    name: job-timeout-operator-0.1.0
+status:
+  aggregatedStatus:
+    status: FATAL_ERROR

--- a/test/e2e/terminal-failed-job/01-install-timeout.yaml
+++ b/test/e2e/terminal-failed-job/01-install-timeout.yaml
@@ -1,0 +1,5 @@
+apiVersion: kudo.dev/v1beta1
+kind: TestStep
+kubectl:
+- kudo uninstall --instance failjob-operator-instance
+- kudo install --instance job-timout-operator-instance ./job-timeout-operator

--- a/test/e2e/terminal-failed-job/failjob-operator/operator.yaml
+++ b/test/e2e/terminal-failed-job/failjob-operator/operator.yaml
@@ -1,0 +1,25 @@
+apiVersion: kudo.dev/v1beta1
+name: "failjob-operator"
+operatorVersion: "0.1.0"
+appVersion: "1.7.9"
+kubernetesVersion: 1.13.0
+maintainers:
+  - name: Your name
+    email: <your@email.com>
+url: https://kudo.dev
+tasks:
+  - name: app
+    kind: Apply
+    spec:
+      resources:
+        - failjob.yaml
+plans:
+  deploy:
+    strategy: serial
+    phases:
+      - name: main
+        strategy: parallel
+        steps:
+          - name: everything
+            tasks:
+              - app

--- a/test/e2e/terminal-failed-job/failjob-operator/params.yaml
+++ b/test/e2e/terminal-failed-job/failjob-operator/params.yaml
@@ -1,0 +1,2 @@
+apiVersion: kudo.dev/v1beta1
+parameters:

--- a/test/e2e/terminal-failed-job/failjob-operator/templates/failjob.yaml
+++ b/test/e2e/terminal-failed-job/failjob-operator/templates/failjob.yaml
@@ -1,0 +1,14 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: failing-job
+  namespace: {{ .Namespace }}
+spec:
+  template:
+    spec:
+      containers:
+        - name: main
+          image: alpine
+          command: ["false"]
+      restartPolicy: Never
+  backoffLimit: 0

--- a/test/e2e/terminal-failed-job/job-timeout-operator/operator.yaml
+++ b/test/e2e/terminal-failed-job/job-timeout-operator/operator.yaml
@@ -1,0 +1,25 @@
+apiVersion: kudo.dev/v1beta1
+name: "job-timeout-operator"
+operatorVersion: "0.1.0"
+appVersion: "1.7.9"
+kubernetesVersion: 1.13.0
+maintainers:
+  - name: Your name
+    email: <your@email.com>
+url: https://kudo.dev
+tasks:
+  - name: app
+    kind: Apply
+    spec:
+      resources:
+        - timeoutjob.yaml
+plans:
+  deploy:
+    strategy: serial
+    phases:
+      - name: main
+        strategy: parallel
+        steps:
+          - name: everything
+            tasks:
+              - app

--- a/test/e2e/terminal-failed-job/job-timeout-operator/params.yaml
+++ b/test/e2e/terminal-failed-job/job-timeout-operator/params.yaml
@@ -1,0 +1,2 @@
+apiVersion: kudo.dev/v1beta1
+parameters:

--- a/test/e2e/terminal-failed-job/job-timeout-operator/templates/timeoutjob.yaml
+++ b/test/e2e/terminal-failed-job/job-timeout-operator/templates/timeoutjob.yaml
@@ -1,0 +1,15 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: timeout-job
+  namespace: {{ .Namespace }}
+spec:
+  template:
+    spec:
+      containers:
+        - name: main
+          image: alpine
+          command: ["sleep", "1000"]
+      restartPolicy: Never
+  backoffLimit: 3
+  activeDeadlineSeconds: 60


### PR DESCRIPTION
**What this PR does / why we need it**:

At the moment, the TaskApply waits for all resources to become healthy. Healthy for a job is defined as `Successful`. But there are jobs which may never reach that state, as they fail and reach their `backOfLimit`.

KUDO should acknowledge this and set the task to a FATAL_ERROR so the user gets a feedback and a different job can be executed.


Fixes #1367 
