### PR TITLE
Bump golangci-lint to 1.23.7

### DIFF
--- a/hack/install-golangcilint.sh
+++ b/hack/install-golangcilint.sh
@@ -4,6 +4,6 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-GOLANGCILINT_VERSION=${GOLANGCILINT_VERSION:-v1.23.1}
+GOLANGCILINT_VERSION=${GOLANGCILINT_VERSION:-v1.23.7}
 
 curl -sSfL "https://raw.githubusercontent.com/golangci/golangci-lint/${GOLANGCILINT_VERSION}/install.sh" | sh -s -- -b "$(go env GOPATH)/bin" "${GOLANGCILINT_VERSION}"


### PR DESCRIPTION
**What this PR does / why we need it**:

Upgrade to the latest release of `golangci-lint`.
