### PR TITLE
Simplify instance update code

### DIFF
--- a/pkg/controller/instance/instance_controller.go
+++ b/pkg/controller/instance/instance_controller.go
@@ -264,9 +264,10 @@ func (r *Reconciler) Reconcile(request ctrl.Request) (ctrl.Result, error) {
 }
 
 func updateInstance(instance *kudov1beta1.Instance, oldInstance *kudov1beta1.Instance, client client.Client) error {
+
 	// The order of both updates below is important: *first* the instance Spec and Metadata and *then* the Status.
-	// If Status is update first, a new reconcile request will be scheduled with *WRONG* instance snapshot (which is
-	// saved in the annotations). This request will then have wrong "previous state".
+	// If Status is updated first, a new reconcile request will be scheduled and might fetch the *WRONG* instance
+	// snapshot (which is saved in the annotations). This request will then have wrong "previous state".
 
 	// 1. check if the finalizer can be removed (if the instance is being deleted and cleanup is completed) and then
 	// update instance spec and metadata. this will not update Instance.Status field
@@ -288,16 +289,10 @@ func updateInstance(instance *kudov1beta1.Instance, oldInstance *kudov1beta1.Ins
 	// 2. update instance status
 	err := client.Status().Update(context.TODO(), instance)
 	if err != nil {
-		// this can happen if k8s GC was fast and managed to removed the instance after the above Update removed the finalizer
+		// if k8s GC was fast and managed to removed the instance (after the above Update removed the finalizer), we get  an untyped
+		// "StorageError" telling us that the sub-resource couldn't be modified. We ignore the error (but log it just in case).
 		if isDelete {
-			// This is what *should* happen when the GC is too fast.
-			if apierrors.IsNotFound(err) {
-				log.Printf("Instance %s/%s was deleted, nothing to update.", instance.Namespace, instance.Name)
-				return nil
-			}
-
-			// At the moment, k8s returns an untyped "StorageError", so we ignore all errors for now.
-			log.Printf("Instance %s/%s was deleted, nothing to update. (Ignored error: %v)", instance.Namespace, instance.Name, err)
+			log.Printf("InstanceController: failed status update for a deleted Instance %s/%s. (Ignored error: %v)", instance.Namespace, instance.Name, err)
 			return nil
 		}
 		log.Printf("InstanceController: Error when updating instance status. %v", err)
@@ -698,14 +693,14 @@ func tryRemoveFinalizer(i *v1beta1.Instance) bool {
 			// we check IsFinished and *not* IsTerminal here so that the finalizer is not removed in the FatalError
 			// case. This way a human operator has to intervene and we don't leave garbage in the cluster.
 			if planStatus.Status.IsFinished() {
-				log.Printf("InstanceController: Removing finalizer on instance %s/%s, cleanup plan is finished", i.Namespace, i.Name)
+				log.Printf("Removing finalizer on instance %s/%s, cleanup plan is finished", i.Namespace, i.Name)
 				i.ObjectMeta.Finalizers = remove(i.ObjectMeta.Finalizers, instanceCleanupFinalizerName)
 				return true
 			}
 		} else {
 			// We have a finalizer but no cleanup plan. This could be due to an updated instance.
 			// Let's remove the finalizer.
-			log.Printf("InstanceController: Removing finalizer on instance %s/%s because there is no cleanup plan", i.Namespace, i.Name)
+			log.Printf("Removing finalizer on instance %s/%s because there is no cleanup plan", i.Namespace, i.Name)
 			i.ObjectMeta.Finalizers = remove(i.ObjectMeta.Finalizers, instanceCleanupFinalizerName)
 			return true
 		}

--- a/test/e2e/cli-install-uninstall/02-errors.yaml
+++ b/test/e2e/cli-install-uninstall/02-errors.yaml
@@ -2,9 +2,6 @@ apiVersion: kudo.dev/v1beta1
 kind: Instance
 metadata:
   name: first-operator
-status:
-  aggregatedStatus:
-    status: COMPLETE
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
Summary:
we save one `Update` call in the `instance_controller.go::updateInstance` method by removing the finalizer **before** updating the instance. To avoid misleading log messages, the subsequent updating of the status is handling the fact that the instance might be removed.

Signed-off-by: Aleksey Dukhovniy <alex.dukhovniy@googlemail.com>