### PR TITLE
updating to be consistent with our release process

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,5 +1,5 @@
-name-template: 'kudo-v$NEXT_PATCH_VERSION'
-tag-template: 'v$NEXT_PATCH_VERSION'
+name-template: 'kudo-v$NEXT_MINOR_VERSION'
+tag-template: 'v$NEXT_MINOR_VERSION'
 categories:
   - title: '🚀 Highlights'
     labels:
@@ -12,8 +12,3 @@ template: |
   ## Changes
 
   $CHANGES
-
-  ## Docker images
-
-  - `docker pull kudobuilder/controller:latest`
-  - `docker pull kudobuilder/controller:$NEXT_PATCH_VERSION`


### PR DESCRIPTION
The release on master is targeted to be a minor release not a patch release.
Releases on release branches (releases/0.10) are targeted for a patch release (and we will need to remember to update this when a release branch is created)

The details of docker is removed because:
1. in the process of release notes being added this information is false
2. when we release (currently) it is with goreleaser which will provides this information.   The goreleaser info and this info will need to be manually merged at the end of the release process.


Signed-off-by: Ken Sipe <kensipe@gmail.com>
