### PR TITLE
Update golden files the easy way

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,12 +145,12 @@ ifeq (, $(shell which golangci-lint))
 endif
 	golangci-lint run --disable-all -E goimports --fix
 
-.PHONY: update-golden-%
-# used to update the golden files present in ./pkg/kudoctl/cmd/testdata
-# Requires the individual test name to avoid massive update of all golden files
-# example: make update-golden-TestInitCmd_dry
-update-golden-%:
-	go test ./pkg/kudoctl/cmd ./pkg/kudoctl/packages ./pkg/kudoctl/util/repo -v -mod=readonly -run $* --update=true
+.PHONY: update-golden
+# used to update the golden files present in ./pkg/.../testdata
+# example: make update-golden
+# tests in update==true mode show as failures
+update-golden:
+	go test ./pkg/... -v -mod=readonly --update=true
 
 .PHONY: todo
 # Show to-do items per file.

--- a/test/README.md
+++ b/test/README.md
@@ -75,17 +75,16 @@ go run ./cmd/kubectl-kudo test --start-control-plane=false --skip-delete
 ```
 ### Update golden files of the directory testdata
 
-You can update golden files per each test by running `make update-golden-${test-name}`
+You can update golden files across the project by running `make update-golden`
 
 Examples:
 ```
-make update-golden-TestInitCmd_dry
-make update-golden-TestParamsList
+make update-golden
 ```
 
-Running a non-existing test would return a 
+Running a non-existing test would return a
 ```
 ok      github.com/kudobuilder/kudo/pkg/kudoctl/cmd     0.048s [no tests to run]
 ```
 
-Currently we don't allow to update all golden files through a single `Makefile` target in one go.
+This will update all golden files.   There is no fear in updating the entire project as any change resulting in a golden file test failure would need to be updated regardless.


### PR DESCRIPTION
Update to https://github.com/kudobuilder/kudo/pull/1369

There seemed to be a concern of "massive updates" which doesn't make sense to me.
The requirement to know all tests and manually type each in or copy and paste them is an unnecessary burden on the developer IMO.   Updating the entire project will update all affected files.   If there is a file that was updated that is a surprise to the developer they should investigate before pushing a PR.  Additionally any file that changed that was NOT updated would have failed any tests anyway.  Lets make it easier on us please.

Signed-off-by: Ken Sipe <kensipe@gmail.com>
