### PR TITLE
Instance controller event filter ignores Status updates

### DIFF
--- a/pkg/controller/instance/instance_controller.go
+++ b/pkg/controller/instance/instance_controller.go
@@ -125,8 +125,9 @@ func eventFilter() predicate.Funcs {
 			return !isForPipePod(e)
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
-			// by comparing the Meta.Generation counter we effectively ignore Status sub-resource changes
-			return e.MetaNew.GetGeneration() != e.MetaOld.GetGeneration()
+			// by comparing the Meta.Generation counter for Instances we effectively ignore Instance.Status sub-resource changes
+			_, isInstance := e.ObjectNew.(*kudov1beta1.Instance)
+			return isInstance && (e.MetaNew.GetGeneration() != e.MetaOld.GetGeneration())
 		},
 		GenericFunc: func(event.GenericEvent) bool { return true },
 	}

--- a/pkg/controller/instance/instance_controller.go
+++ b/pkg/controller/instance/instance_controller.go
@@ -127,7 +127,7 @@ func eventFilter() predicate.Funcs {
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			// by comparing the Meta.Generation counter for Instances we effectively ignore Instance.Status sub-resource changes
 			_, isInstance := e.ObjectNew.(*kudov1beta1.Instance)
-			return isInstance && (e.MetaNew.GetGeneration() != e.MetaOld.GetGeneration())
+			return !isInstance || (e.MetaNew.GetGeneration() != e.MetaOld.GetGeneration())
 		},
 		GenericFunc: func(event.GenericEvent) bool { return true },
 	}


### PR DESCRIPTION
by comparing the generation field of the new and old objects. This way we save the controller ~50% of reconciliation calls.

Signed-off-by: Aleksey Dukhovniy <alex.dukhovniy@googlemail.com>