### PR TITLE
Fix decoding errors with large YAML templates

### DIFF
--- a/pkg/engine/renderer/enhancer.go
+++ b/pkg/engine/renderer/enhancer.go
@@ -36,12 +36,12 @@ func (de *DefaultEnhancer) Apply(templates map[string]string, metadata Metadata)
 	for _, v := range templates {
 		parsed, err := YamlToObject(v)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("parsing YAML failed: %v", err)
 		}
 		for _, obj := range parsed {
 			unstructMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("converting to unstructured failed: %v", err)
 			}
 
 			if err = addLabels(unstructMap, metadata); err != nil {
@@ -69,13 +69,13 @@ func (de *DefaultEnhancer) Apply(templates map[string]string, metadata Metadata)
 				}
 			}
 
-			// this is pretty important, if we don't convert it back to the original type everything will be Unstructured
-			// we depend on types later on in the processing e.g. when evaluating health
-			// additionally, as we add annotations and labels to all possible paths, this step gets rid of anything
-			// that doesn't belong to the specific object type
+			// This is pretty important, if we don't convert it back to the original type everything will be Unstructured.
+			// We depend on types later on in the processing e.g. when evaluating health.
+			// Additionally, as we add annotations and labels to all possible paths, this step gets rid of anything
+			// that doesn't belong to the specific object type.
 			err = runtime.DefaultUnstructuredConverter.FromUnstructured(objUnstructured.UnstructuredContent(), obj)
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("converting from unstructured failed: %v", err)
 			}
 			objs = append(objs, obj)
 		}

--- a/pkg/engine/renderer/enhancer.go
+++ b/pkg/engine/renderer/enhancer.go
@@ -36,12 +36,12 @@ func (de *DefaultEnhancer) Apply(templates map[string]string, metadata Metadata)
 	for _, v := range templates {
 		parsed, err := YamlToObject(v)
 		if err != nil {
-			return nil, fmt.Errorf("parsing YAML failed: %v", err)
+			return nil, err
 		}
 		for _, obj := range parsed {
 			unstructMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
 			if err != nil {
-				return nil, fmt.Errorf("converting to unstructured failed: %v", err)
+				return nil, err
 			}
 
 			if err = addLabels(unstructMap, metadata); err != nil {
@@ -69,13 +69,13 @@ func (de *DefaultEnhancer) Apply(templates map[string]string, metadata Metadata)
 				}
 			}
 
-			// This is pretty important, if we don't convert it back to the original type everything will be Unstructured.
-			// We depend on types later on in the processing e.g. when evaluating health.
-			// Additionally, as we add annotations and labels to all possible paths, this step gets rid of anything
-			// that doesn't belong to the specific object type.
+			// this is pretty important, if we don't convert it back to the original type everything will be Unstructured
+			// we depend on types later on in the processing e.g. when evaluating health
+			// additionally, as we add annotations and labels to all possible paths, this step gets rid of anything
+			// that doesn't belong to the specific object type
 			err = runtime.DefaultUnstructuredConverter.FromUnstructured(objUnstructured.UnstructuredContent(), obj)
 			if err != nil {
-				return nil, fmt.Errorf("converting from unstructured failed: %v", err)
+				return nil, err
 			}
 			objs = append(objs, obj)
 		}

--- a/pkg/engine/renderer/parser.go
+++ b/pkg/engine/renderer/parser.go
@@ -11,6 +11,8 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 )
 
+const yamlSeparator = "\n---"
+
 // YamlToObject parses a list of runtime.Objects from the provided yaml
 // If the type is not known in the scheme, it tries to parse it as Unstructured
 // We used to use 'apimachiner/pkg/util/yaml' for splitting the input into multiple yamls,
@@ -20,20 +22,20 @@ import (
 // For more detail read: https://github.com/kudobuilder/kudo/pull/1400
 // TODO(av) could we use something else than a global scheme here? Should we somehow inject it?
 func YamlToObject(yaml string) (objs []runtime.Object, err error) {
-	sepYamlfiles := strings.Split(yaml, "\n---\n")
-	for _, f := range sepYamlfiles {
-		if f == "\n" || f == "" {
+	yamls := strings.Split(yaml, yamlSeparator)
+	for _, y := range yamls {
+		if len(strings.TrimSpace(y)) == 0 {
 			// ignore empty cases
 			continue
 		}
 
 		decode := scheme.Codecs.UniversalDeserializer().Decode
-		obj, _, e := decode([]byte(f), nil, nil)
+		obj, _, e := decode([]byte(y), nil, nil)
 
 		if e != nil {
 			// if parsing to scheme known types fails, just try to parse into unstructured
 			unstructuredObj := &unstructured.Unstructured{}
-			fileBytes := []byte(f)
+			fileBytes := []byte(y)
 			decoder := yamlutil.NewYAMLOrJSONDecoder(bytes.NewBuffer(fileBytes), len(fileBytes))
 			if err = decoder.Decode(unstructuredObj); err != nil {
 				return nil, fmt.Errorf("decoding chunk %q failed: %v", fileBytes, err)

--- a/pkg/engine/renderer/parser.go
+++ b/pkg/engine/renderer/parser.go
@@ -13,8 +13,11 @@ import (
 
 // YamlToObject parses a list of runtime.Objects from the provided yaml
 // If the type is not known in the scheme, it tries to parse it as Unstructured
-// We avoid using `bufio.Scanner` or the helper methods in 'apimachiner/pkg/util/yaml' for splitting the input.
+// We used to use 'apimachiner/pkg/util/yaml' for splitting the input into multiple yamls,
+// however under the covers it uses bufio.NewScanner with token defaults with no option to modify.
+// see: https://github.com/kubernetes/apimachinery/blob/release-1.6/pkg/util/yaml/decoder.go#L94
 // The YAML input can be too large for the default scan token size used by these packages.
+// For more detail read: https://github.com/kudobuilder/kudo/pull/1400
 // TODO(av) could we use something else than a global scheme here? Should we somehow inject it?
 func YamlToObject(yaml string) (objs []runtime.Object, err error) {
 	sepYamlfiles := strings.Split(yaml, "\n---\n")

--- a/pkg/engine/renderer/parser.go
+++ b/pkg/engine/renderer/parser.go
@@ -12,6 +12,8 @@ import (
 
 // YamlToObject parses a list of runtime.Objects from the provided yaml
 // If the type is not known in the scheme, it tries to parse it as Unstructured
+// We avoid using `bufio.Scanner` or the helper methods in 'apimachiner/pkg/util/yaml' for splitting the input.
+// The YAML input can be too large for the default scan token size used by these packages.
 // TODO(av) could we use something else than a global scheme here? Should we somehow inject it?
 func YamlToObject(yaml string) (objs []runtime.Object, err error) {
 	sepYamlfiles := strings.Split(yaml, "\n---\n")

--- a/pkg/engine/renderer/parser_test.go
+++ b/pkg/engine/renderer/parser_test.go
@@ -52,7 +52,7 @@ spec:
         - containerPort: 80
         env:
         - name: PARAM_ENV
-          value: 1`)
+          value: "1"`)
 
 	assert.NoError(t, err)
 	assert.Equal(t, "Deployment", obj[0].GetObjectKind().GroupVersionKind().Kind)

--- a/pkg/engine/renderer/parser_test.go
+++ b/pkg/engine/renderer/parser_test.go
@@ -26,7 +26,9 @@ spec:
     matchLabels:
       spark/servicemonitor: true`)
 
-	assert.NoError(t, err)
+	if err != nil {
+		t.Errorf("Expecting no error but got %s", err)
+	}
 	assert.Equal(t, 1, len(objects))
 }
 
@@ -52,51 +54,11 @@ spec:
         - containerPort: 80
         env:
         - name: PARAM_ENV
-          value: "1"`)
+          value: 1`)
 
-	assert.NoError(t, err)
+	if err != nil {
+		t.Errorf("Expecting no error but got %s", err)
+	}
+
 	assert.Equal(t, "Deployment", obj[0].GetObjectKind().GroupVersionKind().Kind)
-}
-
-func TestParseKubernetesObjects_InvalidYAML(t *testing.T) {
-	_, err := YamlToObject(`"`)
-	assert.Error(t, err)
-}
-
-func TestParseKubernetesObjects_MoreThanOne(t *testing.T) {
-	objects, err := YamlToObject(`apiVersion: foo
-kind: Foo
-metadata:
-  name: foo1
----
-apiVersion: foo
-kind: Foo
-metadata:
-name: foo2`)
-
-	assert.NoError(t, err)
-	assert.Equal(t, 2, len(objects))
-}
-
-func TestParseKubernetesObjects_EmptyListOfObjects(t *testing.T) {
-	tests := []struct {
-		name string
-		yaml string
-	}{
-		{"empty", ""},
-		{"comment", "#comment"},
-		{"empty line", `
-`},
-		{"empty lines", `
-
-`},
-	}
-	for _, test := range tests {
-		test := test
-		t.Run(test.name, func(t *testing.T) {
-			objects, err := YamlToObject(test.yaml)
-			assert.NoError(t, err)
-			assert.Empty(t, objects)
-		})
-	}
 }

--- a/pkg/engine/renderer/parser_test.go
+++ b/pkg/engine/renderer/parser_test.go
@@ -26,9 +26,7 @@ spec:
     matchLabels:
       spark/servicemonitor: true`)
 
-	if err != nil {
-		t.Errorf("Expecting no error but got %s", err)
-	}
+	assert.NoError(t, err)
 	assert.Equal(t, 1, len(objects))
 }
 
@@ -56,9 +54,48 @@ spec:
         - name: PARAM_ENV
           value: 1`)
 
-	if err != nil {
-		t.Errorf("Expecting no error but got %s", err)
-	}
-
+	assert.NoError(t, err)
 	assert.Equal(t, "Deployment", obj[0].GetObjectKind().GroupVersionKind().Kind)
+}
+
+func TestParseKubernetesObjects_InvalidYAML(t *testing.T) {
+	_, err := YamlToObject(`"`)
+	assert.Error(t, err)
+}
+
+func TestParseKubernetesObjects_MoreThanOne(t *testing.T) {
+	objects, err := YamlToObject(`apiVersion: foo
+kind: Foo
+metadata:
+  name: foo1
+---
+apiVersion: foo
+kind: Foo
+metadata:
+name: foo2`)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(objects))
+}
+
+func TestParseKubernetesObjects_EmptyListOfObjects(t *testing.T) {
+	tests := []struct {
+		name string
+		yaml string
+	}{
+		{"empty", ""},
+		{"comment", "#comment"},
+		{"empty line", `
+`},
+		{"empty lines", `
+`},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			objects, err := YamlToObject(test.yaml)
+			assert.NoError(t, err)
+			assert.Empty(t, objects)
+		})
+	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kudo/blob/master/CONTRIBUTING.md
2. Make sure you have added and ran the tests before submitting your PR
3. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What this PR does / why we need it**:
As described in #1397, large templates would cause package verification to fail. This is fixed by using the old approach of splitting input YAML in `YamlToObject`.

Note for reviewers:
Manually tested that `kubectl kudo package verify` works with the spark operator in the community repository. Merging https://github.com/kudobuilder/operators/pull/153 will make sure that this operator is tested with every PR against KUDO.

<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1397
