### PR TITLE
Check Controller-gen Version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,7 @@ deploy-clean:
 # Generate code
 generate:
 ifneq ($(shell go list -f '{{.Version}}' -m sigs.k8s.io/controller-tools), $(shell controller-gen --version | cut -b 10-))
+	@echo "(Re-)installing controller-gen. Current version:  $(controller-gen --version | cut -b 10-). Need $(go list -f '{{.Version}}' -m sigs.k8s.io/controller-tools)"
 	go get sigs.k8s.io/controller-tools/cmd/controller-gen@$$(go list -f '{{.Version}}' -m sigs.k8s.io/controller-tools)
 endif
 	controller-gen crd paths=./pkg/apis/... output:crd:dir=config/crds output:stdout

--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ deploy-clean:
 .PHONY: generate
 # Generate code
 generate:
-ifeq (, $(shell which controller-gen))
+ifneq ($(shell go list -f '{{.Version}}' -m sigs.k8s.io/controller-tools), $(shell controller-gen --version | cut -b 10-))
 	go get sigs.k8s.io/controller-tools/cmd/controller-gen@$$(go list -f '{{.Version}}' -m sigs.k8s.io/controller-tools)
 endif
 	controller-gen crd paths=./pkg/apis/... output:crd:dir=config/crds output:stdout


### PR DESCRIPTION
Previously there was a check to see if controller-gen was missing, then it installed the version associated with controller tools.  Now it actually checks to see if this is the correct version otherwise gets the correct version.
I looked at doing the same for `go-bindata` but it's version output is challenging and likely needs `awk`.   This makes controller-gen much better which is the more likely change.

Signed-off-by: Ken Sipe <kensipe@gmail.com>