### PR TITLE
Use sigs.k8s.io/yaml rather than pkg.in/yaml.v2.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,6 @@ require (
 	github.com/gosuri/uitable v0.0.4
 	github.com/huandu/xstrings v1.2.0 // indirect
 	github.com/imdario/mergo v0.3.7 // indirect
-	github.com/jstemmer/go-junit-report v0.9.1 // indirect
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
 	github.com/manifoldco/promptui v0.6.0
 	github.com/mattn/go-colorable v0.1.4 // indirect
@@ -40,7 +39,6 @@ require (
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
 	golang.org/x/tools v0.0.0-20191025023517-2077df36852e // indirect
 	gopkg.in/yaml.v2 v2.2.8
-	gopkg.in/yaml.v3 v3.0.0-20191106092431-e228e37189d3
 	gotest.tools v2.2.0+incompatible
 	k8s.io/api v0.17.3
 	k8s.io/apiextensions-apiserver v0.17.2

--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
 	golang.org/x/tools v0.0.0-20191025023517-2077df36852e // indirect
 	gopkg.in/yaml.v2 v2.2.8
+	gopkg.in/yaml.v3 v3.0.0-20191106092431-e228e37189d3
 	gotest.tools v2.2.0+incompatible
 	k8s.io/api v0.17.3
 	k8s.io/apiextensions-apiserver v0.17.2

--- a/go.sum
+++ b/go.sum
@@ -301,8 +301,6 @@ github.com/json-iterator/go v1.1.8 h1:QiWkFLKq0T7mpzwOTu6BzNDbfTE8OLrYhVKYMLF46O
 github.com/json-iterator/go v1.1.8/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024 h1:rBMNdlhTLzJjJSDIjNEXX1Pz3Hmwmz91v+zycvx9PJc=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
-github.com/jstemmer/go-junit-report v0.9.1 h1:6QPYqodiu3GuPL+7mfx+NwDdp2eTkp9IfEUpgAwUN0o=
-github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a h1:FaWFmfWdAUKbSCtOU2QjDaorUexogfaMgbipgYATUMU=
 github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a/go.mod h1:UJSiEoRfvx3hP73CvoARgeLjaIOjybY9vj8PUPPFGeU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=

--- a/pkg/kudoctl/cmd/params/parser.go
+++ b/pkg/kudoctl/cmd/params/parser.go
@@ -6,9 +6,10 @@ import (
 	"strings"
 
 	"github.com/spf13/afero"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 
 	"github.com/kudobuilder/kudo/pkg/apis/kudo/v1beta1"
+	"github.com/kudobuilder/kudo/pkg/kudoctl/clog"
 	"github.com/kudobuilder/kudo/pkg/util/convert"
 )
 
@@ -56,7 +57,9 @@ func getParamsFromFiles(fs afero.Fs, filePaths []string, errs []string) (map[str
 			errs = append(errs, fmt.Sprintf("error unmarshalling content of parameter file %s: %v", filePath, err))
 			continue
 		}
+		clog.V(2).Printf("Unmarshalling %q...", filePath)
 		for key, value := range data {
+			clog.V(3).Printf("Value of parameter %q is a %T: %v", key, value, value)
 			var valueType v1beta1.ParameterType
 			switch value.(type) {
 			case map[string]interface{}:

--- a/pkg/kudoctl/cmd/params/parser.go
+++ b/pkg/kudoctl/cmd/params/parser.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/spf13/afero"
-	"gopkg.in/yaml.v3"
+	"sigs.k8s.io/yaml"
 
 	"github.com/kudobuilder/kudo/pkg/apis/kudo/v1beta1"
 	"github.com/kudobuilder/kudo/pkg/kudoctl/clog"
@@ -52,7 +52,7 @@ func getParamsFromFiles(fs afero.Fs, filePaths []string, errs []string) (map[str
 			continue
 		}
 		data := make(map[string]interface{})
-		err = yaml.Unmarshal(rawData, data)
+		err = yaml.Unmarshal(rawData, &data)
 		if err != nil {
 			errs = append(errs, fmt.Sprintf("error unmarshalling content of parameter file %s: %v", filePath, err))
 			continue

--- a/pkg/kudoctl/cmd/params/parser_test.go
+++ b/pkg/kudoctl/cmd/params/parser_test.go
@@ -112,6 +112,18 @@ func TestGetParameterMap(t *testing.T) {
 			"error reading from parameter file missing-file: open missing-file: file does not exist",
 			nil,
 		},
+		{
+			"regression test for #14337",
+			nil,
+			[]string{"param-file"},
+			map[string]string{
+				"param-file": "A:\n- foo: bar\n",
+			},
+			"",
+			map[string]string{
+				"A": "- foo: bar\n",
+			},
+		},
 	}
 	for _, test := range tests {
 		test := test

--- a/pkg/kudoctl/cmd/params/parser_test.go
+++ b/pkg/kudoctl/cmd/params/parser_test.go
@@ -113,7 +113,7 @@ func TestGetParameterMap(t *testing.T) {
 			nil,
 		},
 		{
-			"regression test for #14337",
+			"regression test for #1437",
 			nil,
 			[]string{"param-file"},
 			map[string]string{


### PR DESCRIPTION
**What this PR does / why we need it**:

Turns out that [`yaml.v2` unmarshals maps into `map[interface{}]interface{}`](https://github.com/go-yaml/yaml/issues/139) rather
than try to insist on a most narrow possible key type (i.e. string). Such values
are then rejected by sigs.k8s.io/yaml.Marshal that `WrapParamValue` uses,
because it does a conversion to JSON first, and JSON does not support
non-string keys.

It seems like `yaml.v3` works better in that regard. However comments on the
aforementioned issue seem to imply that it's still not all rosy.

Moreover, using the same package for unmarshalling as we do for marshalling
seems like a more stable choice long-term.

This also adds some vlog statements and tidies up go.mod.

<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1437