### PR TITLE
 golangci-lint upgrade

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ DATE_FMT := "%Y-%m-%dT%H:%M:%SZ"
 BUILD_DATE := $(shell date -u -d "@$SOURCE_DATE_EPOCH" "+${DATE_FMT}" 2>/dev/null || date -u -r "${SOURCE_DATE_EPOCH}" "+${DATE_FMT}" 2>/dev/null || date -u "+${DATE_FMT}")
 LDFLAGS := -X ${GIT_VERSION_PATH}=${GIT_VERSION} -X ${GIT_COMMIT_PATH}=${GIT_COMMIT} -X ${BUILD_DATE_PATH}=${BUILD_DATE}
 ENABLE_WEBHOOKS ?= false
+GOLANGCI_LINT_VER = "1.24.0"
 
 export GO111MODULE=on
 
@@ -47,7 +48,7 @@ test-clean:
 
 .PHONY: lint
 lint:
-ifeq (, $(shell which golangci-lint))
+ifneq (${GOLANGCI_LINT_VER}, "$(shell golangci-lint --version | cut -b 27-32)")
 	./hack/install-golangcilint.sh
 endif
 	golangci-lint run
@@ -147,7 +148,7 @@ docker-push:
 .PHONY: imports
 # used to update imports on project.  NOT a linter.
 imports:
-ifeq (, $(shell which golangci-lint))
+ifneq (${GOLANGCI_LINT_VER}, "$(shell golangci-lint --version | cut -b 27-32)")
 	./hack/install-golangcilint.sh
 endif
 	golangci-lint run --disable-all -E goimports --fix

--- a/hack/install-golangcilint.sh
+++ b/hack/install-golangcilint.sh
@@ -4,6 +4,6 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-GOLANGCILINT_VERSION=${GOLANGCILINT_VERSION:-v1.23.7}
+GOLANGCILINT_VERSION=${GOLANGCILINT_VERSION:-v1.24.0}
 
 curl -sSfL "https://raw.githubusercontent.com/golangci/golangci-lint/${GOLANGCILINT_VERSION}/install.sh" | sh -s -- -b "$(go env GOPATH)/bin" "${GOLANGCILINT_VERSION}"

--- a/pkg/kudoctl/cmd/verify/verify_test.go
+++ b/pkg/kudoctl/cmd/verify/verify_test.go
@@ -23,11 +23,11 @@ func TestDuplicateVerifier(t *testing.T) {
 		{"duplicate parameter", []packages.Parameter{
 			{Name: "Foo"},
 			{Name: "Foo"},
-		}, []string{}, []string{fmt.Sprintf("parameter \"Foo\" has a duplicate")}},
+		}, []string{}, []string{"parameter \"Foo\" has a duplicate"}},
 		{"duplicate with different casing", []packages.Parameter{
 			{Name: "Foo"},
 			{Name: "foo"},
-		}, []string{}, []string{fmt.Sprintf("parameter \"foo\" has a duplicate")}},
+		}, []string{}, []string{"parameter \"foo\" has a duplicate"}},
 	}
 
 	verifier := DuplicateVerifier{}


### PR DESCRIPTION
bump to latest go lint, which catch unnecessary code.  added a better check to ensure that all devs are on the latest

Signed-off-by: Ken Sipe <kensipe@gmail.com>

