### PR TITLE
Keep plan name in instance aggregatedStatus when plan is terminal

### DIFF
--- a/pkg/apis/kudo/v1beta1/instance_types_helpers.go
+++ b/pkg/apis/kudo/v1beta1/instance_types_helpers.go
@@ -67,9 +67,6 @@ func (i *Instance) UpdateInstanceStatus(planStatus *PlanStatus, updatedTimestamp
 			planStatus.LastUpdatedTimestamp = updatedTimestamp
 			i.Status.PlanStatus[k] = *planStatus
 			i.Status.AggregatedStatus.Status = planStatus.Status
-			if planStatus.Status.IsTerminal() {
-				i.Status.AggregatedStatus.ActivePlanName = ""
-			}
 		}
 	}
 }


### PR DESCRIPTION
Summary:
we were resetting `Status.AggregatedStatus.ActivePlanName` field when the plan was terminal. This lead to this field looking like this:
```
Status:
  Aggregated Status:
    Status:  COMPLETE
```
The idea of the field is to keep information about the last/current plan including plan name and status.

Signed-off-by: Aleksey Dukhovniy <alex.dukhovniy@googlemail.com>