### PR TITLE
golangci-lint memory issue fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ DATE_FMT := "%Y-%m-%dT%H:%M:%SZ"
 BUILD_DATE := $(shell date -u -d "@$SOURCE_DATE_EPOCH" "+${DATE_FMT}" 2>/dev/null || date -u -r "${SOURCE_DATE_EPOCH}" "+${DATE_FMT}" 2>/dev/null || date -u "+${DATE_FMT}")
 LDFLAGS := -X ${GIT_VERSION_PATH}=${GIT_VERSION} -X ${GIT_COMMIT_PATH}=${GIT_COMMIT} -X ${BUILD_DATE_PATH}=${BUILD_DATE}
 ENABLE_WEBHOOKS ?= false
-GOLANGCI_LINT_VER = "1.24.0"
+GOLANGCI_LINT_VER = "1.23.8"
 
 export GO111MODULE=on
 

--- a/hack/install-golangcilint.sh
+++ b/hack/install-golangcilint.sh
@@ -4,6 +4,6 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-GOLANGCILINT_VERSION=${GOLANGCILINT_VERSION:-v1.24.0}
+GOLANGCILINT_VERSION=${GOLANGCILINT_VERSION:-v1.23.8}
 
 curl -sSfL "https://raw.githubusercontent.com/golangci/golangci-lint/${GOLANGCILINT_VERSION}/install.sh" | sh -s -- -b "$(go env GOPATH)/bin" "${GOLANGCILINT_VERSION}"


### PR DESCRIPTION
golangci-lint v1.24.0 seems to have memory issues resulting in CI failure on circleci, which we are limited to 4GB without a paid for account.
these issues do not exist in v1.23.8

Signed-off-by: Ken Sipe <kensipe@gmail.com>
