### PR TITLE
Package Verify Support for Template Range

### DIFF
--- a/pkg/kudoctl/packages/verifier/template/parser.go
+++ b/pkg/kudoctl/packages/verifier/template/parser.go
@@ -99,8 +99,11 @@ func walkNodes(node parse.Node, fname string, nodeMap map[string]map[string]bool
 		for _, n := range node.Nodes {
 			walkNodes(n, fname, nodeMap)
 		}
-	case *parse.RangeNode: // no support for Range, Template or TextNodes
-	case *parse.TemplateNode:
+	case *parse.RangeNode:
+		walkNodes(node.List, fname, nodeMap)
+		walkPipes(node.Pipe, nodeMap)
+	case *parse.TemplateNode: // no support Template or TextNodes
+		clog.V(2).Printf("file %q has a template node: node: %s", fname, node)
 	case *parse.TextNode:
 	default:
 		clog.V(2).Printf("file %q has unknown node: %s", fname, node)
@@ -158,6 +161,9 @@ func walkPipes(node *parse.PipeNode, nodeMap map[string]map[string]bool) {
 				if len(n.Ident) > 3 {
 					clog.V(3).Printf("template node %v has more elements than is supported", arg.String())
 				}
+			//	RangeNode have PipeNode that have PipeNode
+			case *parse.PipeNode:
+				walkPipes(n, nodeMap)
 			}
 		}
 	}


### PR DESCRIPTION
After fixing this I was hesitate to call this a bug as recorded... since it is documented as `// no support for Range, Template or TextNodes` :)   We didn't document that outside of code and it is worth having this feature (and needed for our kafka operator).  Thanks @zmalik for being awesome and reporting this.

`kudo package verify` now supports range.  Tests provided.

Fixes #1432 
