### PR TITLE
Package Verify of Versions

### DIFF
--- a/pkg/kudoctl/cmd/testdata/invalid-params.golden
+++ b/pkg/kudoctl/cmd/testdata/invalid-params.golden
@@ -4,4 +4,5 @@ parameter "comma," defined but not used.
 Errors                                                            
 parameter "Cpus" has a duplicate                                  
 parameter "comma," contains invalid character ','                 
+"operatorVersion" is required and must be semver                  
 plan "not-existing-plan" used in parameter "comma," is not defined

--- a/pkg/kudoctl/cmd/verify/verify.go
+++ b/pkg/kudoctl/cmd/verify/verify.go
@@ -15,7 +15,7 @@ import (
 var verifiers = []packages.Verifier{
 	DuplicateVerifier{},
 	InvalidCharVerifier{";,"},
-	K8sVersionVerifier{},
+	VersionVerifier{},
 	task.BuildVerifier{},
 	task.ReferenceVerifier{},
 	plan.ReferenceVerifier{},
@@ -68,20 +68,34 @@ func (v InvalidCharVerifier) Verify(pf *packages.Files) verifier.Result {
 	return res
 }
 
-// K8sVersionVerifier verifies the kubernetesVersion of operator.yaml
-type K8sVersionVerifier struct{}
+// VersionVerifier verifies the version in operator.yaml, kubernetesVersion, operatorVersion and kudoVersion
+type VersionVerifier struct{}
 
-func (K8sVersionVerifier) Verify(pf *packages.Files) verifier.Result {
+func (VersionVerifier) Verify(pf *packages.Files) verifier.Result {
 	res := verifier.NewResult()
 	if pf.Operator == nil {
-		res.AddErrors("Operator not defined.")
+		res.AddErrors("operator not defined.")
 		return res
 	}
-	_, err := version.New(pf.Operator.KubernetesVersion)
-	if err != nil {
-		res.AddErrors(fmt.Sprintf("Unable to parse operators kubernetes version: %v", err))
-		return res
+	verifySemVer(pf.Operator.OperatorVersion, "operatorVersion", &res, true)
+	verifySemVer(pf.Operator.KubernetesVersion, "kubernetesVersion", &res, true)
+	verifySemVer(pf.Operator.KUDOVersion, "kudoVersion", &res, false)
+	return res
+}
+
+func verifySemVer(ver string, name string, res *verifier.Result, required bool) {
+	v := strings.TrimSpace(ver)
+	if !required && v == "" {
+		return
 	}
 
-	return res
+	if required && v == "" {
+		res.AddErrors(fmt.Sprintf("%q is required and must be semver", name))
+		return
+	}
+
+	_, err := version.New(ver)
+	if err != nil {
+		res.AddErrors(fmt.Sprintf("unable to parse %q: %v", name, err))
+	}
 }

--- a/pkg/kudoctl/cmd/verify/verify_test.go
+++ b/pkg/kudoctl/cmd/verify/verify_test.go
@@ -82,19 +82,68 @@ func TestK8sVersionVerifier(t *testing.T) {
 		expectedWarnings []string
 		expectedErrors   []string
 	}{
-		{"no warning or error", &packages.OperatorFile{
+		{"no warning or error with all versions", &packages.OperatorFile{
 			APIVersion:        packages.APIVersion,
 			Name:              "kafka",
 			KubernetesVersion: "1.15",
+			KUDOVersion:       "0.12.0",
+			OperatorVersion:   "0.1.0",
 		}, []string{}, []string{}},
-		{"no warning or error", &packages.OperatorFile{
+		{"no warning or error without kudo version", &packages.OperatorFile{
+			APIVersion:        packages.APIVersion,
+			Name:              "kafka",
+			KubernetesVersion: "1.15",
+			OperatorVersion:   "0.1.0",
+		}, []string{}, []string{}},
+		{"kubernetesVersion required", &packages.OperatorFile{
 			APIVersion:        packages.APIVersion,
 			Name:              "kafka",
 			KubernetesVersion: "",
-		}, []string{}, []string{"Unable to parse operators kubernetes version: Invalid Semantic Version"}},
+			KUDOVersion:       "0.12.0",
+			OperatorVersion:   "0.1.0",
+		}, []string{}, []string{"\"kubernetesVersion\" is required and must be semver"}},
+		{"kubernetesVersion must be semver", &packages.OperatorFile{
+			APIVersion:        packages.APIVersion,
+			Name:              "kafka",
+			KubernetesVersion: "1.",
+			KUDOVersion:       "0.12.0",
+			OperatorVersion:   "0.1.0",
+		}, []string{}, []string{"unable to parse \"kubernetesVersion\": Invalid Semantic Version"}},
+		{"kubernetesVersion required", &packages.OperatorFile{
+			APIVersion:        packages.APIVersion,
+			Name:              "kafka",
+			KubernetesVersion: "1.15",
+			KUDOVersion:       "0.12.0",
+			OperatorVersion:   "",
+		}, []string{}, []string{"\"operatorVersion\" is required and must be semver"}},
+		{"kubernetesVersion must be semver", &packages.OperatorFile{
+			APIVersion:        packages.APIVersion,
+			Name:              "kafka",
+			KubernetesVersion: "1.15",
+			KUDOVersion:       "0.12.0",
+			OperatorVersion:   "0.1.",
+		}, []string{}, []string{"unable to parse \"operatorVersion\": Invalid Semantic Version"}},
+		{"kudoVersion must be semver", &packages.OperatorFile{
+			APIVersion:        packages.APIVersion,
+			Name:              "kafka",
+			KubernetesVersion: "1.15",
+			KUDOVersion:       "0.12.",
+			OperatorVersion:   "0.1.0",
+		}, []string{}, []string{"unable to parse \"kudoVersion\": Invalid Semantic Version"}},
+		{"kubernetesVersion and OperatorVersion missing", &packages.OperatorFile{
+			APIVersion:  packages.APIVersion,
+			Name:        "kafka",
+			KUDOVersion: "0.12.0",
+		}, []string{}, []string{"\"operatorVersion\" is required and must be semver", "\"kubernetesVersion\" is required and must be semver"}},
+		{"kubernetesVersion missing and OperatorVersion not semver", &packages.OperatorFile{
+			APIVersion:      packages.APIVersion,
+			Name:            "kafka",
+			KUDOVersion:     "0.12.0",
+			OperatorVersion: "0.1.",
+		}, []string{}, []string{"unable to parse \"operatorVersion\": Invalid Semantic Version", "\"kubernetesVersion\" is required and must be semver"}},
 	}
 
-	verifier := K8sVersionVerifier{}
+	verifier := VersionVerifier{}
 	for _, tt := range tests {
 		res := verifier.Verify(packageFileForOperator(tt.operatorFile))
 		assert.Equal(t, tt.expectedWarnings, res.Warnings, tt.name)


### PR DESCRIPTION
we should be verifying all the versions
AND provide better messaging... if the version is missing, it should be clear
additionally the name of the 2nd test around this looked to be a copy+paste error, it had the same name as the 1st test and it was an incorrect name for the test.

Signed-off-by: Ken Sipe <kensipe@gmail.com>

Fixes #1419 
