### PR TITLE
Man's Search for Operators

### DIFF
--- a/pkg/kudoctl/cmd/root.go
+++ b/pkg/kudoctl/cmd/root.go
@@ -62,6 +62,7 @@ and serves as an API aggregation layer.
 	cmd.AddCommand(newGetCmd())
 	cmd.AddCommand(newPlanCmd(cmd.OutOrStdout()))
 	cmd.AddCommand(newRepoCmd(fs, cmd.OutOrStdout()))
+	cmd.AddCommand(newSearchCmd(fs, cmd.OutOrStdout()))
 	cmd.AddCommand(newTestCmd())
 	cmd.AddCommand(newVersionCmd())
 

--- a/pkg/kudoctl/cmd/search.go
+++ b/pkg/kudoctl/cmd/search.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"sort"
 
 	"github.com/gosuri/uitable"
 	"github.com/spf13/afero"
@@ -71,7 +70,6 @@ func (s *searchCmd) run(criteria string) error {
 		fmt.Fprint(s.out, "no operators found\n")
 		return nil
 	}
-	sort.Sort(found)
 	table := uitable.New()
 	table.AddRow("Name", "Operator Version", "App Version")
 	preName := ""

--- a/pkg/kudoctl/cmd/search.go
+++ b/pkg/kudoctl/cmd/search.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"sort"
 
 	"github.com/gosuri/uitable"
 	"github.com/spf13/afero"
@@ -70,6 +71,7 @@ func (s *searchCmd) run(criteria string) error {
 		fmt.Fprint(s.out, "no operators found\n")
 		return nil
 	}
+	sort.Sort(found)
 	table := uitable.New()
 	table.AddRow("Name", "Operator Version", "App Version")
 	preName := ""

--- a/pkg/kudoctl/cmd/search.go
+++ b/pkg/kudoctl/cmd/search.go
@@ -29,6 +29,7 @@ type searchCmd struct {
 	repoName    string
 	home        kudohome.Home
 	allVersions bool
+	repoClient  *repo.Client
 }
 
 // newSearchCmd search for operator searches based on names
@@ -57,12 +58,15 @@ func newSearchCmd(fs afero.Fs, out io.Writer) *cobra.Command {
 
 // run initializes local config and installs KUDO manager to Kubernetes cluster.
 func (s *searchCmd) run(criteria string) error {
-	repository, err := repo.ClientFromSettings(fs, s.home, s.repoName)
-	if err != nil {
-		return err
+	var err error
+	if s.repoClient == nil {
+		s.repoClient, err = repo.ClientFromSettings(fs, s.home, s.repoName)
+		if err != nil {
+			return err
+		}
 	}
 
-	found, err := repository.Find(criteria, s.allVersions)
+	found, err := s.repoClient.Find(criteria, s.allVersions)
 	if err != nil {
 		return err
 	}

--- a/pkg/kudoctl/cmd/search.go
+++ b/pkg/kudoctl/cmd/search.go
@@ -1,0 +1,86 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/gosuri/uitable"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+
+	"github.com/kudobuilder/kudo/pkg/kudoctl/kudohome"
+	"github.com/kudobuilder/kudo/pkg/kudoctl/util/repo"
+)
+
+const searchDesc = `
+This command searches the repository for a match on "contains" search criteria
+
+Given an operator named foo-demo, a search for 'foo' or 'demo' would include this operator.
+`
+
+const searchExamples = `  kubectl kudo search foo
+  kubectl kudo --repo community foo
+`
+
+type searchCmd struct {
+	out         io.Writer
+	fs          afero.Fs
+	repoName    string
+	home        kudohome.Home
+	allVersions bool
+}
+
+// newSearchCmd search for operator searches based on names
+func newSearchCmd(fs afero.Fs, out io.Writer) *cobra.Command {
+	searchCmd := &searchCmd{fs: fs, out: out}
+
+	cmd := &cobra.Command{
+		Use:     "search [criteria]",
+		Short:   "Search for operators in repository.",
+		Long:    searchDesc,
+		Example: searchExamples,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 1 {
+				return errors.New("this command must have only 1 search criterion")
+			}
+			searchCmd.home = Settings.Home
+			return searchCmd.run(args[0])
+		},
+	}
+
+	f := cmd.Flags()
+	f.StringVar(&searchCmd.repoName, "repo", "", "Name of repository configuration to use. (default defined by context)")
+	f.BoolVarP(&searchCmd.allVersions, "all-versions", "a", false, "Return all versions of found operators.")
+	return cmd
+}
+
+// run initializes local config and installs KUDO manager to Kubernetes cluster.
+func (s *searchCmd) run(criteria string) error {
+	repository, err := repo.ClientFromSettings(fs, s.home, s.repoName)
+	if err != nil {
+		return err
+	}
+
+	found, err := repository.Find(criteria, s.allVersions)
+	if err != nil {
+		return err
+	}
+	if len(found) == 0 {
+		fmt.Fprint(s.out, "no operators found\n")
+		return nil
+	}
+	table := uitable.New()
+	table.AddRow("Name", "Operator Version", "App Version")
+	preName := ""
+	for _, operator := range found {
+		if preName != operator.Name {
+			table.AddRow(operator.Name, operator.OperatorVersion, operator.AppVersion)
+			preName = operator.Name
+		} else {
+			table.AddRow("", operator.OperatorVersion, operator.AppVersion)
+		}
+	}
+	fmt.Fprintln(s.out, table)
+	return nil
+}

--- a/pkg/kudoctl/cmd/search_test.go
+++ b/pkg/kudoctl/cmd/search_test.go
@@ -1,0 +1,119 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/kudobuilder/kudo/pkg/kudoctl/util/repo"
+)
+
+func TestSearchArgValidation(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	out := &bytes.Buffer{}
+
+	var tests = []struct {
+		name         string
+		args         []string
+		errorMessage string
+	}{
+		{name: "no valid arguments", args: []string{}, errorMessage: "this command must have only 1 search criterion"},
+		{name: "2 arguments", args: []string{"arg1", "arg2"}, errorMessage: "this command must have only 1 search criterion"},
+	}
+
+	for _, test := range tests {
+		cmd := newSearchCmd(fs, out)
+		err := cmd.RunE(cmd, test.args)
+		assert.EqualError(t, err, test.errorMessage)
+	}
+}
+
+func TestSearchIndex(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	out := &bytes.Buffer{}
+
+	abs, _ := filepath.Abs("testdata")
+	c := repo.Configuration{
+		URL:  fmt.Sprintf("file://%s", abs),
+		Name: "testdata",
+	}
+
+	r, err := repo.NewClient(&c)
+	assert.NoError(t, err)
+	search := searchCmd{
+		out:         out,
+		fs:          fs,
+		repoName:    "",
+		home:        "",
+		allVersions: false,
+		repoClient:  r,
+	}
+
+	// search for mysql output
+	err = search.run("mysql")
+	assert.NoError(t, err)
+
+	gp := filepath.Join("testdata", "search1"+".golden")
+
+	if *updateGolden {
+		t.Log("update golden file")
+		if err := ioutil.WriteFile(gp, out.Bytes(), 0644); err != nil {
+			t.Fatalf("failed to update golden file: %s", err)
+		}
+	}
+	g, err := ioutil.ReadFile(gp)
+	if err != nil {
+		t.Fatalf("failed reading .golden: %s", err)
+	}
+
+	// assert mysql search
+	assert.Equal(t, out.String(), string(g), "cmd output does not match .golden file %s", gp)
+	out.Reset()
+
+	// search for "" output, which is all operators
+	err = search.run("")
+	assert.NoError(t, err)
+
+	gp = filepath.Join("testdata", "search2"+".golden")
+
+	if *updateGolden {
+		t.Log("update golden file")
+		if err := ioutil.WriteFile(gp, out.Bytes(), 0644); err != nil {
+			t.Fatalf("failed to update golden file: %s", err)
+		}
+	}
+	g, err = ioutil.ReadFile(gp)
+	if err != nil {
+		t.Fatalf("failed reading .golden: %s", err)
+	}
+
+	// assert "" search
+	assert.Equal(t, out.String(), string(g), "cmd output does not match .golden file %s", gp)
+	out.Reset()
+
+	search.allVersions = true
+	// search for mysql output again with all versions
+	err = search.run("mysql")
+	assert.NoError(t, err)
+
+	gp = filepath.Join("testdata", "search3"+".golden")
+
+	if *updateGolden {
+		t.Log("update golden file")
+		if err := ioutil.WriteFile(gp, out.Bytes(), 0644); err != nil {
+			t.Fatalf("failed to update golden file: %s", err)
+		}
+	}
+	g, err = ioutil.ReadFile(gp)
+	if err != nil {
+		t.Fatalf("failed reading .golden: %s", err)
+	}
+
+	// assert mysql search
+	assert.Equal(t, out.String(), string(g), "cmd output does not match .golden file %s", gp)
+}

--- a/pkg/kudoctl/cmd/testdata/index.yaml
+++ b/pkg/kudoctl/cmd/testdata/index.yaml
@@ -10,6 +10,15 @@ entries:
       operatorVersion: 0.1.0
       urls:
         - https://kudo-repository.storage.googleapis.com/0.7.0/mysql-0.1.0.tgz
+    - appVersion: "5.8"
+      digest: aafe419e62065c5a3dc2f5d1458f1b5977137918236c3812ba90b5c7f6b8fb20
+      maintainers:
+        - email: kensipe@gmail.com
+          name: Ken Sipe
+      name: mysql
+      operatorVersion: 0.2.0
+      urls:
+        - https://kudo-repository.storage.googleapis.com/0.7.0/mysql-0.2.0.tgz
   redis:
     - appVersion: 5.0.1
       digest: 24012b833b8c864f24c03f5d792c986143b031c6783dd410538040d672813cd1

--- a/pkg/kudoctl/cmd/testdata/merge-index.yaml.golden
+++ b/pkg/kudoctl/cmd/testdata/merge-index.yaml.golden
@@ -10,6 +10,15 @@ entries:
     urls:
     - https://kudo-repository.storage.googleapis.com/0.7.0/elastic-0.1.0.tgz
   mysql:
+  - appVersion: "5.8"
+    digest: aafe419e62065c5a3dc2f5d1458f1b5977137918236c3812ba90b5c7f6b8fb20
+    maintainers:
+    - email: kensipe@gmail.com
+      name: Ken Sipe
+    name: mysql
+    operatorVersion: 0.2.0
+    urls:
+    - https://kudo-repository.storage.googleapis.com/0.7.0/mysql-0.2.0.tgz
   - appVersion: "5.7"
     digest: aafe419e62065c5a3dc2f5d1458f1b5977137918236c3812ba90b5c7f6b8fb20
     maintainers:

--- a/pkg/kudoctl/cmd/testdata/search1.golden
+++ b/pkg/kudoctl/cmd/testdata/search1.golden
@@ -1,0 +1,2 @@
+Name 	Operator Version	App Version
+mysql	0.2.0           	5.8        

--- a/pkg/kudoctl/cmd/testdata/search2.golden
+++ b/pkg/kudoctl/cmd/testdata/search2.golden
@@ -1,0 +1,3 @@
+Name 	Operator Version	App Version
+mysql	0.2.0           	5.8        
+redis	0.1.0           	5.0.1      

--- a/pkg/kudoctl/cmd/testdata/search3.golden
+++ b/pkg/kudoctl/cmd/testdata/search3.golden
@@ -1,0 +1,3 @@
+Name 	Operator Version	App Version
+mysql	0.2.0           	5.8        
+     	0.1.0           	5.7        

--- a/pkg/kudoctl/util/repo/repo_operator.go
+++ b/pkg/kudoctl/util/repo/repo_operator.go
@@ -1,6 +1,7 @@
 package repo
 
 import (
+	"bytes"
 	"fmt"
 	"io/ioutil"
 	"net/url"
@@ -57,8 +58,13 @@ func (c *Client) DownloadIndexFile() (*IndexFile, error) {
 	parsedURL.Path = fmt.Sprintf("%s/index.yaml", strings.TrimSuffix(parsedURL.Path, "/"))
 
 	indexURL = parsedURL.String()
-
-	resp, err := c.Client.Get(indexURL)
+	var resp *bytes.Buffer
+	if strings.HasPrefix(indexURL, "file:") {
+		b, _ := ioutil.ReadFile(parsedURL.Path)
+		resp = bytes.NewBuffer(b)
+	} else {
+		resp, err = c.Client.Get(indexURL)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("getting index url: %w", err)
 	}

--- a/pkg/kudoctl/util/repo/resolver_repo.go
+++ b/pkg/kudoctl/util/repo/resolver_repo.go
@@ -19,6 +19,20 @@ type EntrySummary struct {
 	AppVersion      string
 }
 
+// Len returns the number of entry summaries.
+// This is needed to allow sorting of entries.
+func (b EntrySummaries) Len() int { return len(b) }
+
+// Swap swaps the position of two items in the entry summaries slice.
+// This is needed to allow sorting of entry summaries.
+func (b EntrySummaries) Swap(i, j int) { b[i], b[j] = b[j], b[i] }
+
+// Less returns true if the version of entry a is less than the version of entry b.
+// This is needed to allow sorting of entry summaries.
+func (b EntrySummaries) Less(x, y int) bool {
+	return b[x].Name < b[y].Name
+}
+
 // Resolve returns a Package for a passed package name and optional version. This is an implementation
 // of the Resolver interface located in packages/resolver/resolver.go
 func (c *Client) Resolve(name string, appVersion string, operatorVersion string) (*packages.Package, error) {

--- a/pkg/kudoctl/util/repo/resolver_repo_test.go
+++ b/pkg/kudoctl/util/repo/resolver_repo_test.go
@@ -43,6 +43,34 @@ func TestIndexFile_FindFirstMatch(t *testing.T) {
 
 }
 
+func TestIndexFile_Find(t *testing.T) {
+
+	index := createTestIndexFile()
+
+	// first operator version should be the latest app version
+	summaries, _ := index.Find("Foo", false)
+	assert.Equal(t, 1, len(summaries))
+	assert.Equal(t, "1.0.1", summaries[0].OperatorVersion)
+
+	// find all operator versions with Foo in name
+	summaries, _ = index.Find("Foo", true)
+	assert.Equal(t, 4, len(summaries))
+
+	// find all operator versions with 'B' in name (Bar and Buzz)
+	summaries, _ = index.Find("B", false)
+	assert.Equal(t, 2, len(summaries))
+	assert.Equal(t, "Bar", summaries[0].Name)
+	assert.Equal(t, "Buzz", summaries[1].Name)
+
+	// finds all 3 Foo, Bar, Buzz
+	summaries, _ = index.Find("", false)
+	assert.Equal(t, 3, len(summaries))
+
+	// finds none
+	summaries, _ = index.Find("NotValid", false)
+	assert.Equal(t, 0, len(summaries))
+}
+
 func createTestIndexFile() *IndexFile {
 
 	index := &IndexFile{}
@@ -58,6 +86,8 @@ func createTestIndexFile() *IndexFile {
 	pv = createPackageVersion("Buzz", "", "1.0.1")
 	addToIndex(index, pv)
 	pv = createPackageVersion("Buzz", "", "1.0.2")
+	addToIndex(index, pv)
+	pv = createPackageVersion("Bar", "", "1.0.0")
 	addToIndex(index, pv)
 
 	index.sortPackages()


### PR DESCRIPTION
KUDO search for Operators

*new command*: `kudo search <fo>`
Provides ability to search for operators in the repository.
The search is a "contains" in the name of the operator and does not require a `*`
By default it returns the firstMatch based on install criteria, which means the result will be any match with operator and app version that is "current"
```
go run cmd/kubectl-kudo/main.go search kafka
Name 	Operator Version	App Version
kafka	1.2.0           	2.4.0    
```

It is possible to get all the versions with `-a` flag
```
go run cmd/kubectl-kudo/main.go search kafka -a
Name 	Operator Version	App Version
kafka	1.2.0           	2.4.0      
     	1.1.1           	2.4.0      
     	1.1.0           	2.4.0      
     	1.0.2           	2.3.1      
     	1.0.1           	2.3.1      
     	1.0.0           	2.3.0      
     	0.1.3           	2.2.1    
```

names are skipped if a list contains multiple version of the same operator name
```
 $ go run cmd/kubectl-kudo/main.go search fl -a
Name                     	Operator Version	App Version
confluent-rest-proxy     	0.2.0           	5.3.2      
                         	0.1.0           	5.3.2      
flink-demo               	0.1.4           	           
confluent-schema-registry	0.2.0           	5.3.2      
                         	0.1.0           	5.3.2      
flink                    	0.2.1           	1.7.2      
                         	0.2.0           	1.7.2      
                         	0.1.2           	1.7.2      
                         	0.1.1           	1.7.2 
```

you can get all operators with `go run cmd/kubectl-kudo/main.go search ""`

you can switch repos with the `--repo=xyz` flag
```
$ go run cmd/kubectl-kudo/main.go search fl --repo private
Name                    	Operator Version	App Version
kubeflow                	0.1.0           	1.0.0      
flink                   	0.2.1           	1.7.2      
kubeflow-knative-serving	0.1.0           	0.7        
```
Signed-off-by: Ken Sipe <kensipe@gmail.com>

Fixes #332 
