### PR TITLE
Always Docker Push on Release Including RC

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -43,7 +43,6 @@ dockers:
     image_templates:
       - "kudobuilder/controller:latest"
       - "kudobuilder/controller:{{ .Tag }}"
-    skip_push: auto
 archives:
   - id: kubectl-kudo-tarball
     builds:


### PR DESCRIPTION
`skip_push: auto` means that goreleaser will not push to docker for rc releases and will push for full releases.  Our process expects RC images.

details from [docs](https://goreleaser.com/docker/)
```
    # Skips the docker push. Could be useful if you also do draft releases.
    # If set to auto, the release will not be pushed to the docker repository
    # in case there is an indicator for prerelease in the tag e.g. v1.0.0-rc1
    # Defaults to false.
    skip_push: false
```
The default is false, which is what we want... 

Signed-off-by: Ken Sipe <kensipe@gmail.com>

Fixes #1466
