### PR TITLE
Docker publishing updates

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -37,12 +37,19 @@ builds:
       - amd64
       - arm
 dockers:
+  # always push a docker image on release for the .Tag version
+  - dockerfile: Dockerfile.goreleaser
+    binaries:
+      - manager
+    image_templates:
+      - "kudobuilder/controller:{{ .Tag }}"
+  # only update the docker :latest for a full release (not RC)
   - dockerfile: Dockerfile.goreleaser
     binaries:
       - manager
     image_templates:
       - "kudobuilder/controller:latest"
-      - "kudobuilder/controller:{{ .Tag }}"
+    skip_push: auto
 archives:
   - id: kubectl-kudo-tarball
     builds:


### PR DESCRIPTION
Better solution to #1468 
The solution here is to always push the release tag (even if it is an RC release) but to only bump the `:latest` tag for full releases.

Signed-off-by: Ken Sipe <kensipe@gmail.com>

Fixes #1466 
