### PR TITLE
Providing Repo Include Feature

### DIFF
--- a/pkg/kudoctl/cmd/repo_index.go
+++ b/pkg/kudoctl/cmd/repo_index.go
@@ -140,7 +140,10 @@ func (ri *repoIndexCmd) run() error {
 		if err != nil {
 			return err
 		}
-		client.Merge(index, mergeIndex)
+		err = client.Merge(index, mergeIndex)
+		if err != nil {
+			return err
+		}
 	}
 
 	if err := index.WriteFile(ri.fs, target); err != nil {

--- a/pkg/kudoctl/cmd/repo_index.go
+++ b/pkg/kudoctl/cmd/repo_index.go
@@ -140,7 +140,7 @@ func (ri *repoIndexCmd) run() error {
 		if err != nil {
 			return err
 		}
-		merge(index, mergeIndex)
+		client.Merge(index, mergeIndex)
 	}
 
 	if err := index.WriteFile(ri.fs, target); err != nil {
@@ -148,20 +148,6 @@ func (ri *repoIndexCmd) run() error {
 	}
 	fmt.Fprintf(ri.out, "index %v created.\n", target)
 	return nil
-}
-
-func merge(index *repo.IndexFile, mergeIndex *repo.IndexFile) {
-	// index is the master, any dups in the merged in index will have what is local replace those entries
-	for _, pvs := range mergeIndex.Entries {
-		for _, pv := range pvs {
-			err := index.AddPackageVersion(pv)
-			// this is most likely to be a duplicate pv, which we ignore (but will log at the right v)
-			if err != nil {
-				// todo: add verbose logging here
-				continue
-			}
-		}
-	}
 }
 
 func (ri *repoIndexCmd) mergeRepoConfig() (*repo.Configuration, error) {

--- a/pkg/kudoctl/cmd/repo_index_test.go
+++ b/pkg/kudoctl/cmd/repo_index_test.go
@@ -102,7 +102,8 @@ func TestRepoIndexCmd_MergeIndex(t *testing.T) {
 	client, err := repo.NewClient(config)
 	assert.NoError(t, err)
 
-	client.Merge(indexFile, mergeFile)
+	err = client.Merge(indexFile, mergeFile)
+	assert.NoError(t, err)
 	if err := indexFile.Write(resultBuf); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/kudoctl/cmd/repo_index_test.go
+++ b/pkg/kudoctl/cmd/repo_index_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"fmt"
 	"io/ioutil"
 	"path/filepath"
 	"testing"
@@ -92,7 +93,16 @@ func TestRepoIndexCmd_MergeIndex(t *testing.T) {
 	mergeFile, _ := repo.ParseIndexFile(mergeBytes)
 
 	resultBuf := &bytes.Buffer{}
-	merge(indexFile, mergeFile)
+
+	p, err := filepath.Abs("testdata/include-index")
+	assert.NoError(t, err)
+	config := &repo.Configuration{
+		URL: fmt.Sprintf("file://%s", p),
+	}
+	client, err := repo.NewClient(config)
+	assert.NoError(t, err)
+
+	client.Merge(indexFile, mergeFile)
 	if err := indexFile.Write(resultBuf); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/kudoctl/util/repo/index.go
+++ b/pkg/kudoctl/util/repo/index.go
@@ -22,6 +22,7 @@ const defaultURL = "http://localhost/"
 type IndexFile struct {
 	APIVersion string                     `json:"apiVersion"`
 	Entries    map[string]PackageVersions `json:"entries"`
+	Includes   []string                   `json:"includes,omitempty"`
 	Generated  *time.Time                 `json:"generated"`
 }
 

--- a/pkg/kudoctl/util/repo/index.go
+++ b/pkg/kudoctl/util/repo/index.go
@@ -105,13 +105,29 @@ func (i IndexFile) Write(w io.Writer) error {
 	return err
 }
 
+// DuplicateError is returned for a duplicate entry
+type DuplicateError struct {
+	pv *PackageVersion
+}
+
+// Implement the Error interface.
+func (e *DuplicateError) Error() string {
+	return fmt.Sprintf("operator %q version: %v_%v already exists", e.pv.Name, e.pv.AppVersion, e.pv.OperatorVersion)
+}
+
+// Defines what is is
+func (e *DuplicateError) Is(target error) bool {
+	_, ok := target.(*DuplicateError)
+	return ok
+}
+
 // AddPackageVersion adds an entry to the IndexFile (does not allow dups)
 func (i *IndexFile) AddPackageVersion(pv *PackageVersion) error {
 	name := pv.Name
 	appVersion := pv.AppVersion
 	operatorVersion := pv.OperatorVersion
 	if operatorVersion == "" {
-		return fmt.Errorf("operator '%v' is missing operator version", name)
+		return fmt.Errorf("operator %q is missing operator version", name)
 	}
 	if i.Entries == nil {
 		i.Entries = make(map[string]PackageVersions)
@@ -127,7 +143,7 @@ func (i *IndexFile) AddPackageVersion(pv *PackageVersion) error {
 	// loop thru all... don't allow dups
 	for _, ver := range vs {
 		if ver.AppVersion == appVersion && ver.OperatorVersion == operatorVersion {
-			return fmt.Errorf("operator '%v' version: %v_%v already exists", name, appVersion, operatorVersion)
+			return &DuplicateError{ver}
 		}
 	}
 

--- a/pkg/kudoctl/util/repo/index_test.go
+++ b/pkg/kudoctl/util/repo/index_test.go
@@ -174,8 +174,8 @@ func TestAddPackageVersionErrorConditions(t *testing.T) {
 		pv   *PackageVersion
 		err  string
 	}{
-		{"duplicate version", dup, "operator 'flink' version: 0.7.0_0.3.0 already exists"},
-		{"no version", &missing, "operator 'flink' is missing operator version"},
+		{"duplicate version", dup, "operator \"flink\" version: 0.7.0_0.3.0 already exists"},
+		{"no version", &missing, "operator \"flink\" is missing operator version"},
 		{"good additional version", &good, ""},
 		{"good additional package", &g2, ""},
 	}

--- a/pkg/kudoctl/util/repo/repo_operator.go
+++ b/pkg/kudoctl/util/repo/repo_operator.go
@@ -105,6 +105,8 @@ func (c *Client) downloadIndexFile(parent *IndexFile, url *url.URL) (*IndexFile,
 	return indexFile, err
 }
 
+// Merge combines the Entries of 2 index files.   The first index file is the master
+// the second is merged into the first.  Any duplicates are ignored.
 func (c *Client) Merge(index *IndexFile, mergeIndex *IndexFile) {
 	// index is the master, any dups in the merged in index will have what is local replace those entries
 	for _, pvs := range mergeIndex.Entries {

--- a/pkg/kudoctl/util/repo/repo_test.go
+++ b/pkg/kudoctl/util/repo/repo_test.go
@@ -42,3 +42,29 @@ func TestLoadRepositories(t *testing.T) {
 	assert.Equal(t, r.CurrentConfiguration().Name, Default.Name)
 	assert.Equal(t, r.CurrentConfiguration().URL, Default.URL)
 }
+
+func TestDownloadMultiRepo(t *testing.T) {
+
+	p, err := filepath.Abs("testdata/include-index")
+	assert.NoError(t, err)
+	config := &Configuration{
+		URL: fmt.Sprintf("file://%s", p),
+	}
+	client, err := NewClient(config)
+	assert.NoError(t, err)
+	index, err := client.DownloadIndexFile()
+	assert.NoError(t, err)
+	// mysql package only there, if include worked
+	assert.NotNil(t, index.Entries["mysql"])
+
+	// the merge for flink will have 1 dup that doesn't merge
+	flink, err := index.FindFirstMatch("flink", "", "0.3.0")
+	assert.NoError(t, err)
+	assert.Equal(t, "correct flink", flink.Description)
+
+	// and a new version that does merge
+	flink, err = index.FindFirstMatch("flink", "", "0.4.0")
+	assert.NoError(t, err)
+	assert.Equal(t, "0.4.0", flink.OperatorVersion)
+
+}

--- a/pkg/kudoctl/util/repo/repo_test.go
+++ b/pkg/kudoctl/util/repo/repo_test.go
@@ -67,4 +67,10 @@ func TestDownloadMultiRepo(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "0.4.0", flink.OperatorVersion)
 
+	// and a version that is nested in a repository
+	flink, err = index.FindFirstMatch("flink", "", "0.4.1")
+	assert.NoError(t, err)
+	assert.Equal(t, "0.4.1", flink.OperatorVersion)
+	assert.Equal(t, "this merges and overwrites the version in nested-included-repo", flink.Description)
+
 }

--- a/pkg/kudoctl/util/repo/testdata/include-index/index.yaml
+++ b/pkg/kudoctl/util/repo/testdata/include-index/index.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+entries:
+  flink:
+    - appVersion: 0.7.0
+      description: correct flink
+      digest: 0787a078e64c73064287751b833d63ca3d1d284b4f494ebf670443683d5b96dd
+      maintainers:
+        - email: <runyontr@gmail.com>
+          name: Tom Runyon
+        - email: <kensipe@gmail.com>
+          name: Ken Sipe
+      name: flink
+      operatorVersion: 0.3.0
+      urls:
+        - http://kudo.dev/flink
+includes:
+  - ../included-repo
+generated: "2020-04-19T15:04:00Z"

--- a/pkg/kudoctl/util/repo/testdata/included-repo/index.yaml
+++ b/pkg/kudoctl/util/repo/testdata/included-repo/index.yaml
@@ -1,0 +1,39 @@
+apiVersion: v1
+entries:
+  mysql:
+    - appVersion: "5.7"
+      digest: ad2451eaf68896490a2864afbb3fcd81e6fe3368e4bf001f8a23dc9cbcddf49a
+      maintainers:
+        - email: nick@dischord.org
+          name: Nick Jones
+      name: mysql
+      operatorVersion: 0.2.0
+      urls:
+        - https://kudo-repository.storage.googleapis.com/0.10.0/mysql-5.7_0.2.0.tgz
+  flink:
+    - appVersion: 0.7.0
+      description: wrong flink (should NOT be included)
+      digest: 0787a078e64c73064287751b833d63ca3d1d284b4f494ebf670443683d5b96dd
+      maintainers:
+        - email: <runyontr@gmail.com>
+          name: Tom Runyon
+        - email: <kensipe@gmail.com>
+          name: Ken Sipe
+      name: flink
+      operatorVersion: 0.3.0
+    - appVersion: 0.8.0
+      description: this merges because the version doesn't exist in parent
+      digest: 0787a078e64c73064287751b833d63ca3d1d284b4f494ebf670443683d5b96dd
+      maintainers:
+        - email: <runyontr@gmail.com>
+          name: Tom Runyon
+        - email: <kensipe@gmail.com>
+          name: Ken Sipe
+      name: flink
+      operatorVersion: 0.4.0
+      urls:
+        - http://kudo.dev/flink
+
+generated: "2020-04-19T15:04:00Z"
+
+

--- a/pkg/kudoctl/util/repo/testdata/nested-included-repo/index.yaml
+++ b/pkg/kudoctl/util/repo/testdata/nested-included-repo/index.yaml
@@ -21,20 +21,8 @@ entries:
           name: Ken Sipe
       name: flink
       operatorVersion: 0.3.0
-    - appVersion: 0.8.0
-      description: this merges because the version doesn't exist in parent
-      digest: 0787a078e64c73064287751b833d63ca3d1d284b4f494ebf670443683d5b96dd
-      maintainers:
-        - email: <runyontr@gmail.com>
-          name: Tom Runyon
-        - email: <kensipe@gmail.com>
-          name: Ken Sipe
-      name: flink
-      operatorVersion: 0.4.0
-      urls:
-        - http://kudo.dev/flink
     - appVersion: 0.8.1
-      description: this merges and overwrites the version in nested-included-repo
+      description: this will get overwritten by included-repo
       digest: 0787a078e64c73064287751b833d63ca3d1d284b4f494ebf670443683d5b96dd
       maintainers:
         - email: <runyontr@gmail.com>
@@ -45,8 +33,7 @@ entries:
       operatorVersion: 0.4.1
       urls:
         - http://kudo.dev/flink
-includes:
-  - ../nested-included-repo
+
 generated: "2020-04-19T15:04:00Z"
 
 


### PR DESCRIPTION
This provides the ability for 1 repo index to include another (or multiple).  This changes in code is backward compatible... if the new field "include:" is missing, it works fine.

The new index file might look like:

```
apiVersion: v1
entries:
  flink:
    - appVersion: 0.7.0
      name: flink
      operatorVersion: 0.3.0
      urls:
        - http://kudo.dev/flink
includes:
  - https://kudo-repository.storage.googleapis.com/
```

The "includes" is a list of urls... for testing file locations are also possible.
It is designed and tested so that duplicates are ignored and the root / parent repo entries take precedence.    The includes are recursive so repoA could include repoB which includes repoC.

The value of this model is that a private repo user today is required to maintain all the versions of all the entries in the community repo in their private repo which is a burden.   This will allow a private repo to have 1 entry of their operator and reference the community repo (with all it's updates and changes).

For the user searching or installing there is no perceived difference. 

There are 2 things left todo (which are marked with `todo` in code.

1. Error handling... I am hoping that we will agree that errors of includes will be ignored / clogged ... if a connection is down we don't want the whole operation to not be useful... although this creates odd edge cases.
2. I want to pass a map to the recursive function and ignore (with clog messages) duplicate entries or urls which have already been processed... this is mainly to prevent infinite loops... but it will also be more efficient. 