### PR TITLE
fix: Use namespace specified by current config context

### DIFF
--- a/pkg/kudoctl/env/environment.go
+++ b/pkg/kudoctl/env/environment.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spf13/pflag"
 	"k8s.io/client-go/util/homedir"
 
+	"github.com/kudobuilder/kudo/pkg/kudoctl/kube"
 	"github.com/kudobuilder/kudo/pkg/kudoctl/kudohome"
 	"github.com/kudobuilder/kudo/pkg/kudoctl/util/kudo"
 )
@@ -54,9 +55,11 @@ var DefaultSettings = &Settings{
 
 // AddFlags binds flags to the given flagset.
 func (s *Settings) AddFlags(fs *pflag.FlagSet) {
+	namespace, _, _ := kube.GetConfig(s.KubeConfig).Namespace()
+
 	fs.StringVar((*string)(&s.Home), "home", kudoHome(), "Location of your KUDO config.")
 	fs.StringVar(&s.KubeConfig, "kubeconfig", kubeConfigHome(), "Path to your Kubernetes configuration file.")
-	fs.StringVarP(&s.Namespace, "namespace", "n", "default", "Target namespace for the object.")
+	fs.StringVarP(&s.Namespace, "namespace", "n", namespace, "Target namespace for the object.")
 	fs.Int64Var(&s.RequestTimeout, "request-timeout", 0, "Request timeout value, in seconds.  Defaults to 0 (unlimited)")
 	fs.BoolVar(&s.Validate, "validate-install", true, "Validate KUDO installation before running.")
 }

--- a/pkg/kudoctl/kube/config.go
+++ b/pkg/kudoctl/kube/config.go
@@ -19,8 +19,8 @@ type Client struct {
 	DynamicClient dynamic.Interface
 }
 
-// getConfig returns a Kubernetes client config for a given kubeconfig.
-func getConfig(kubeconfig string) clientcmd.ClientConfig {
+// GetConfig returns a Kubernetes client config for a given kubeconfig.
+func GetConfig(kubeconfig string) clientcmd.ClientConfig {
 	rules := clientcmd.NewDefaultClientConfigLoadingRules()
 	rules.DefaultClientConfig = &clientcmd.DefaultClientConfig
 
@@ -34,7 +34,7 @@ func getConfig(kubeconfig string) clientcmd.ClientConfig {
 }
 
 func getRestConfig(kubeconfig string) (*rest.Config, error) {
-	config, err := getConfig(kubeconfig).ClientConfig()
+	config, err := GetConfig(kubeconfig).ClientConfig()
 	if err != nil {
 		return nil, fmt.Errorf("could not get Kubernetes config using configuration %q: %s", kubeconfig, err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Use the namespace defined in the current context, if it's been set.

Otherwise default to 'default'.

Signed-off-by: Nick Jones <nick@dischord.org>

<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1477 
