### PR TITLE
Apply labels and annotations only in the correct paths

### DIFF
--- a/pkg/engine/renderer/consts.go
+++ b/pkg/engine/renderer/consts.go
@@ -1,0 +1,66 @@
+package renderer
+
+import (
+	"strings"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+type ResourcePath struct {
+	Group   string
+	Version string
+	Kind    string
+	path    string
+}
+
+func (lp *ResourcePath) pathFields() []string {
+	return strings.Split(lp.path, "/")
+}
+
+func (lp *ResourcePath) matches(gvk schema.GroupVersionKind) bool {
+	if lp.Group != "" && lp.Group != gvk.Group {
+		return false
+	}
+	if lp.Version != "" && lp.Version != gvk.Version {
+		return false
+	}
+	if lp.Kind != "" && lp.Kind != gvk.Kind {
+		return false
+	}
+	return true
+}
+
+var (
+	// CommonLabelPaths is a list of locations in an object type where labels should be added.
+	// Taken from here: https://github.com/kubernetes-sigs/kustomize/blob/master/api/konfig/builtinpluginconsts/commonlabels.go
+	CommonLabelPaths = []ResourcePath{
+		{Group: "", Kind: "", path: "metadata/labels"},
+		{Group: "apps", Kind: "StatefulSet", path: "spec/template/metadata/labels"},
+		{Group: "apps", Kind: "StatefulSet", path: "spec/volumeClaimTemplates[]/metadata/labels"},
+		{Group: "apps", Kind: "Deployment", path: "spec/template/metadata/labels"},
+		{Group: "", Kind: "ReplicaSet", path: "spec/template/metadata/labels"},
+		{Group: "", Kind: "ReplicationController", path: "spec/template/metadata/labels"},
+		{Group: "", Kind: "DaemonSet", path: "spec/template/metadata/labels"},
+		{Group: "batch", Kind: "Job", path: "spec/template/metadata/labels"},
+		{Group: "batch", Kind: "CronJob", path: "spec/template/metadata/labels"},
+		{Group: "batch", Kind: "CronJob", path: "spec/jobTemplate/spec/template/metadata/labels"},
+	}
+
+	// CommonAnnotationPaths is a list of locations for annotations to add in all resources
+	CommonAnnotationPaths = []ResourcePath{
+		{Group: "", Kind: "", path: "metadata/annotations"},
+	}
+
+	// TemplateAnnotationPaths is a list of locations specific to objects where annotations should be added in
+	// templates. Taken from here https://github.com/kubernetes-sigs/kustomize/blob/master/api/konfig/builtinpluginconsts/commonannotations.go
+	TemplateAnnotationPaths = []ResourcePath{
+		{Group: "", Kind: "ReplicationController", path: "spec/template/metadata/annotations"},
+		{Group: "apps", Kind: "StatefulSet", path: "spec/template/metadata/annotations"},
+		{Group: "apps", Kind: "Deployment", path: "spec/template/metadata/annotations"},
+		{Group: "", Kind: "ReplicaSet", path: "spec/template/metadata/annotations"},
+		{Group: "", Kind: "DaemonSet", path: "spec/template/metadata/annotations"},
+		{Group: "batch", Kind: "Job", path: "spec/template/metadata/annotations"},
+		{Group: "batch", Kind: "CronJob", path: "spec/template/metadata/annotations"},
+		{Group: "batch", Kind: "CronJob", path: "spec/jobTemplate/spec/template/metadata/annotations"},
+	}
+)

--- a/pkg/engine/renderer/dependencies_test.go
+++ b/pkg/engine/renderer/dependencies_test.go
@@ -107,6 +107,9 @@ func TestSetDependenciesHash(t *testing.T) {
 			assert.NilError(t, err)
 			assert.DeepEqual(t, pod("somename", "namespace"), p)
 		}},
+		{name: "no change in unstructured CRD", obj: unstructuredCrd("crd", "namespace"), assert: func(us *unstructured.Unstructured) {
+			assert.DeepEqual(t, unstructuredCrd("crd", "namespace"), us)
+		}},
 	}
 	for _, tt := range tests {
 		tt := tt

--- a/pkg/engine/renderer/enhancer_test.go
+++ b/pkg/engine/renderer/enhancer_test.go
@@ -140,8 +140,13 @@ func TestEnhancerApply_noAdditionalMetadata(t *testing.T) {
 			t.Errorf("failed to parse object to unstructured: %s", err)
 		}
 
-		f, ok, _ := unstructured.NestedFieldNoCopy(unstructMap, "spec", "template")
+		// Make sure the top-level metadata is there
+		uo := unstructured.Unstructured{Object: unstructMap}
+		assert.Equal(t, string(meta.PlanUID), uo.GetAnnotations()[kudo.PlanUIDAnnotation])
+		assert.Equal(t, "kudo", uo.GetLabels()[kudo.HeritageLabel])
 
+		// But no nested fields
+		f, ok, _ := unstructured.NestedFieldNoCopy(unstructMap, "spec", "template")
 		assert.Nil(t, f)
 		assert.False(t, ok, "%s struct contains template field", o.GetObjectKind())
 	}

--- a/pkg/test/fake/client.go
+++ b/pkg/test/fake/client.go
@@ -24,51 +24,58 @@ func (d *CachedDiscovery) Invalidate() {
 
 }
 
-// CachedDiscoveryClient returns a fake discovery client that is populated with some types for use in
-// unit tests.
-func CachedDiscoveryClient() discovery.CachedDiscoveryInterface {
+func CustomCachedDiscoveryClient(additionalResources ...*metav1.APIResourceList) discovery.CachedDiscoveryInterface {
+	commonResources := []*metav1.APIResourceList{
+		{
+			GroupVersion: corev1.SchemeGroupVersion.String(),
+			APIResources: []metav1.APIResource{
+				{Name: "pod", Namespaced: true, Kind: "Pod"},
+				{Name: "namespace", Namespaced: false, Kind: "Namespace"},
+				{Name: "service", Namespaced: true, Kind: "Service"},
+				{Name: "configmap", Namespaced: true, Kind: "ConfigMap"},
+				{Name: "secret", Namespaced: true, Kind: "Secret"},
+			},
+		},
+		{
+			GroupVersion: appsv1.SchemeGroupVersion.String(),
+			APIResources: []metav1.APIResource{
+				{Name: "statefulset", Namespaced: true, Kind: "StatefulSet"},
+				{Name: "deployment", Namespaced: true, Kind: "Deployment"},
+			},
+		},
+		{
+			GroupVersion: batchv1.SchemeGroupVersion.String(),
+			APIResources: []metav1.APIResource{
+				{Name: "job", Namespaced: true, Kind: "Job"},
+			},
+		},
+		{
+			GroupVersion: batchv1beta1.SchemeGroupVersion.String(),
+			APIResources: []metav1.APIResource{
+				{Name: "job", Namespaced: true, Kind: "CronJob"},
+			},
+		},
+		{
+			GroupVersion: apiextensions.SchemeGroupVersion.String(),
+			APIResources: []metav1.APIResource{
+				{Name: "customresourcedefinitions", Namespaced: false, Kind: "CustomResourceDefinition"},
+			},
+		},
+	}
+
+	resources := append(commonResources, additionalResources...)
 
 	return &CachedDiscovery{
 		FakeDiscovery: fakediscovery.FakeDiscovery{
 			Fake: &coretesting.Fake{
-				Resources: []*metav1.APIResourceList{
-					{
-						GroupVersion: corev1.SchemeGroupVersion.String(),
-						APIResources: []metav1.APIResource{
-							{Name: "pod", Namespaced: true, Kind: "Pod"},
-							{Name: "namespace", Namespaced: false, Kind: "Namespace"},
-							{Name: "service", Namespaced: true, Kind: "Service"},
-							{Name: "configmap", Namespaced: true, Kind: "ConfigMap"},
-							{Name: "secret", Namespaced: true, Kind: "Secret"},
-						},
-					},
-					{
-						GroupVersion: appsv1.SchemeGroupVersion.String(),
-						APIResources: []metav1.APIResource{
-							{Name: "statefulset", Namespaced: true, Kind: "StatefulSet"},
-							{Name: "deployment", Namespaced: true, Kind: "Deployment"},
-						},
-					},
-					{
-						GroupVersion: batchv1.SchemeGroupVersion.String(),
-						APIResources: []metav1.APIResource{
-							{Name: "job", Namespaced: true, Kind: "Job"},
-						},
-					},
-					{
-						GroupVersion: batchv1beta1.SchemeGroupVersion.String(),
-						APIResources: []metav1.APIResource{
-							{Name: "job", Namespaced: true, Kind: "CronJob"},
-						},
-					},
-					{
-						GroupVersion: apiextensions.SchemeGroupVersion.String(),
-						APIResources: []metav1.APIResource{
-							{Name: "customresourcedefinitions", Namespaced: false, Kind: "CustomResourceDefinition"},
-						},
-					},
-				},
+				Resources: resources,
 			},
 		},
 	}
+}
+
+// CachedDiscoveryClient returns a fake discovery client that is populated with some types for use in
+// unit tests.
+func CachedDiscoveryClient() discovery.CachedDiscoveryInterface {
+	return CustomCachedDiscoveryClient()
 }


### PR DESCRIPTION
Adding labels/annotations in all possible paths and relying on conversion to typed objects to remove invalid paths obviously only works for resources where we have the typed objects available. For almost all CRDs this leaves the resources with unwanted labels and annotations in multiple locations.

We now have custom lists for locations based on the G(V)K.


Signed-off-by: Andreas Neumann <aneumann@mesosphere.com>

Fixes #1498 
