### PR TITLE
Uncached client for instance admission webhook

### DIFF
--- a/pkg/webhook/instance_admission.go
+++ b/pkg/webhook/instance_admission.go
@@ -22,7 +22,7 @@ import (
 
 // InstanceAdmission validates updates to an Instance, guarding from conflicting plan executions
 type InstanceAdmission struct {
-	client  client.Client
+	Client  client.Client
 	decoder *admission.Decoder
 }
 
@@ -57,7 +57,7 @@ func handleCreate(ia *InstanceAdmission, req admission.Request) admission.Respon
 
 	// since we don't yet enforce the existence of the 'deploy' plan in the OV, we check for its existence
 	// and decline Instance creation if the plan is not found
-	ov, err := instance.GetOperatorVersion(new, ia.client)
+	ov, err := instance.GetOperatorVersion(new, ia.Client)
 	if err != nil {
 		log.Printf("InstanceAdmission: Error getting operatorVersion %s for instance %s/%s: %v", new.Spec.OperatorVersion.Name, new.Namespace, new.Name, err)
 		return admission.Errored(http.StatusInternalServerError, err)
@@ -103,7 +103,7 @@ func handleUpdate(ia *InstanceAdmission, req admission.Request) admission.Respon
 
 	// fetch new OperatorVersion: we always fetch the new one, since if it's an update it's the same as the old one
 	// and if it's an upgrade, we need the new one anyway
-	ov, err := instance.GetOperatorVersion(new, ia.client)
+	ov, err := instance.GetOperatorVersion(new, ia.Client)
 	if err != nil {
 		log.Printf("InstanceAdmission: Error getting operatorVersion %s for instance %s/%s: %v", new.Spec.OperatorVersion.Name, new.Namespace, new.Name, err)
 		return admission.Errored(http.StatusInternalServerError, err)
@@ -339,15 +339,6 @@ func changedParameterDefinitions(old map[string]string, new map[string]string, o
 	rpd, _ := kudov1beta1.GetParamDefinitions(r, ov)
 
 	return append(cpd, rpd...), nil
-}
-
-// InstanceAdmission implements inject.Client.
-// A client will be automatically injected.
-
-// InjectClient injects the client.
-func (ia *InstanceAdmission) InjectClient(c client.Client) error {
-	ia.client = c
-	return nil
 }
 
 // InstanceAdmission implements admission.DecoderInjector.

--- a/pkg/webhook/instance_admission_integration_test.go
+++ b/pkg/webhook/instance_admission_integration_test.go
@@ -82,23 +82,23 @@ var _ = Describe("Test", func() {
 		err = apis.AddToScheme(mgr.GetScheme())
 		Expect(err).NotTo(HaveOccurred())
 
-		// 3. registering instance admission controller
+		// 3. creating the client. **Note:** client.New method will create an uncached client, a cached one
+		// (e.g. mgr.GetClient) leads to caching issues in this test.
+		log.Print("test.BeforeEach: initializing client")
+		c, err = client.New(env.Config, client.Options{Scheme: mgr.GetScheme()})
+		Expect(err).NotTo(HaveOccurred())
+
+		// 4. registering instance admission controller
 		log.Print("test.BeforeEach: initializing webhook server")
 		server := mgr.GetWebhookServer()
-		server.Register(instanceAdmissionWebhookPath, &ctrhook.Admission{Handler: &InstanceAdmission{}})
+		server.Register(instanceAdmissionWebhookPath, &ctrhook.Admission{Handler: &InstanceAdmission{Client: c}})
 
-		// 4. starting the manager
+		// 5. starting the manager
 		stop = make(chan struct{})
 		go func() {
 			err = mgr.Start(stop)
 			Expect(err).NotTo(HaveOccurred())
 		}()
-
-		// 5. creating the client. **Note:** client.New method will create an uncached client, a cached one
-		// (e.g. mgr.GetClient) leads to caching issues in this test.
-		log.Print("test.BeforeEach: initializing client")
-		c, err = client.New(env.Config, client.Options{Scheme: mgr.GetScheme()})
-		Expect(err).NotTo(HaveOccurred())
 	})
 
 	AfterEach(func() {

--- a/pkg/webhook/instance_admission_integration_test.go
+++ b/pkg/webhook/instance_admission_integration_test.go
@@ -91,7 +91,7 @@ var _ = Describe("Test", func() {
 		// 4. registering instance admission controller
 		log.Print("test.BeforeEach: initializing webhook server")
 		server := mgr.GetWebhookServer()
-		server.Register(instanceAdmissionWebhookPath, &ctrhook.Admission{Handler: &InstanceAdmission{Client: c}})
+		server.Register(instanceAdmissionWebhookPath, &ctrhook.Admission{Handler: &InstanceAdmission{client: c}})
 
 		// 5. starting the manager
 		stop = make(chan struct{})


### PR DESCRIPTION
Summary:
we've seen increased flakiness lately with some ITs e.g. `terminal-failed-job` and `dependencies-hash` where a previously created `OperatorVersion` is not observed by the instance admission webhook. This PR switches to an uncached client for the IAW which should alleviate the problem.

Signed-off-by: Aleksey Dukhovniy <alex.dukhovniy@googlemail.com>