### PR TITLE
Skip resources that are NotFound for dependency calculation

### DIFF
--- a/pkg/engine/renderer/dependencies.go
+++ b/pkg/engine/renderer/dependencies.go
@@ -188,7 +188,7 @@ func sanitizeAndSerialize(origObj *unstructured.Unstructured) (string, error) {
 	obj.SetSelfLink("")
 	obj.SetUID("")
 
-	// This may be set or not, depending if the original object is typed or unstructured. To be safe we nil it
+	// This may be set or not, depending if the original object is typed or unstructured. To be safe we clear it
 	obj.SetGroupVersionKind(schema.GroupVersionKind{})
 
 	// Annotations are notorious for containing quickly changing strings: plan/phase/task names, uids, dates, etc.
@@ -197,9 +197,8 @@ func sanitizeAndSerialize(origObj *unstructured.Unstructured) (string, error) {
 	return ToYaml(obj)
 }
 
-// resourceDependency returns the resource of type t with the given namespace/name, either from the passed in list of
-// objects or the last applied configuration from the API server. If the resource is not found, the func returns
-// nil and no error
+// resourceDependency returns the specified resource, either from the passed in list of objects or the last applied
+// configuration from the API server.
 func (de *dependencyCalculator) resourceDependency(d resourceDependency) (*unstructured.Unstructured, error) {
 
 	// First try to find the dependency in the local list, if it's deployed in the same task we'll find it here

--- a/pkg/engine/renderer/dependencies.go
+++ b/pkg/engine/renderer/dependencies.go
@@ -198,7 +198,7 @@ func sanitizeAndSerialize(origObj *unstructured.Unstructured) (string, error) {
 }
 
 // resourceDependency returns the specified resource, either from the passed in list of objects or the last applied
-// configuration from the API server.
+// configuration from the API server. If the resource is NotFound, the func returns nil and no error
 func (de *dependencyCalculator) resourceDependency(d resourceDependency) (*unstructured.Unstructured, error) {
 
 	// First try to find the dependency in the local list, if it's deployed in the same task we'll find it here
@@ -211,7 +211,6 @@ func (de *dependencyCalculator) resourceDependency(d resourceDependency) (*unstr
 	}
 
 	// We haven't found it, so we need to query the api server to get the current version
-	//dep, _ := reflect.New(t).Interface().(metav1.Object)
 	dep := &unstructured.Unstructured{}
 	dep.SetGroupVersionKind(d.gvk)
 

--- a/pkg/engine/renderer/dependencies_test.go
+++ b/pkg/engine/renderer/dependencies_test.go
@@ -33,6 +33,7 @@ func TestGetResources(t *testing.T) {
 			"key": "value",
 		},
 	}
+	cmWithoutAnnotation := cm.DeepCopy()
 	cmString, _ := runtime.Encode(unstructured.UnstructuredJSONScheme, &cm)
 	cm.Annotations[kudo.LastAppliedConfigAnnotation] = string(cmString)
 
@@ -46,6 +47,7 @@ func TestGetResources(t *testing.T) {
 	}{
 		{name: "from api server", taskObjects: []*unstructured.Unstructured{}, client: fake.NewFakeClientWithScheme(scheme.Scheme, &cm)},
 		{name: "from task objects", taskObjects: []*unstructured.Unstructured{&cmUnstructured}, client: fake.NewFakeClientWithScheme(scheme.Scheme)},
+		{name: "from api server without annotation", taskObjects: []*unstructured.Unstructured{}, client: fake.NewFakeClientWithScheme(scheme.Scheme, cmWithoutAnnotation)},
 	}
 
 	for _, tt := range tests {

--- a/pkg/engine/renderer/enhancer_test.go
+++ b/pkg/engine/renderer/enhancer_test.go
@@ -14,12 +14,15 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/uuid"
+	clientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/yaml"
 
+	"github.com/kudobuilder/kuttl/pkg/test/utils"
+
+	"github.com/kudobuilder/kudo/pkg/client/clientset/versioned/scheme"
 	"github.com/kudobuilder/kudo/pkg/engine"
 	"github.com/kudobuilder/kudo/pkg/test/fake"
 	"github.com/kudobuilder/kudo/pkg/util/kudo"
-	"github.com/kudobuilder/kuttl/pkg/test/utils"
 )
 
 func TestEnhancerApply_embeddedMetadataStatefulSet(t *testing.T) {
@@ -183,6 +186,52 @@ func TestEnhancerApply_dependencyHash_noDependencies(t *testing.T) {
 
 	hash := annotations[kudo.DependenciesHashAnnotation]
 	assert.Nil(t, hash, "Pod template spec annotations contains a dependency hash but no dependencies")
+}
+
+func TestEnhancerApply_dependencyHash_unavailableResource(t *testing.T) {
+	// Test that the dependency calculation does not error out on a resource that is NotAvailable at the moment
+
+	ss := statefulSet("statefulset", "default")
+
+	ss.Spec.Template.Spec.Volumes = append(ss.Spec.Template.Spec.Volumes, corev1.Volume{
+		Name: "configMap",
+		VolumeSource: corev1.VolumeSource{
+			ConfigMap: &corev1.ConfigMapVolumeSource{
+				LocalObjectReference: corev1.LocalObjectReference{Name: "unvailableConfigMap"},
+			},
+		},
+	})
+
+	tpls := map[string]string{
+		"statefulset": resourceAsString(ss),
+	}
+
+	meta := metadata()
+	meta.PlanUID = uuid.NewUUID()
+
+	e := &DefaultEnhancer{
+		Client:    clientfake.NewFakeClientWithScheme(scheme.Scheme),
+		Scheme:    utils.Scheme(),
+		Discovery: fake.CachedDiscoveryClient(),
+	}
+
+	objs, err := e.Apply(tpls, meta)
+	if err != nil {
+		t.Errorf("failed to apply template %s", err)
+	}
+
+	ssApplied := funk.Find(objs, func(o runtime.Object) bool {
+		return o.GetObjectKind().GroupVersionKind() == schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "StatefulSet"}
+	})
+
+	unstructMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(ssApplied)
+	assert.Nil(t, err, "failed to parse object to unstructured: %s", err)
+
+	annotations, _, _ := unstructured.NestedMap(unstructMap, "spec", "template", "metadata", "annotations")
+	assert.NotNil(t, annotations, "Statefulset pod template spec contains no annotations")
+
+	hash := annotations[kudo.DependenciesHashAnnotation]
+	assert.NotNil(t, hash, "Pod template spec annotations contains no dependency hash field")
 }
 
 func TestEnhancerApply_dependencyHash_changes(t *testing.T) {

--- a/test/e2e/dependencies-hash/01-assert.yaml
+++ b/test/e2e/dependencies-hash/01-assert.yaml
@@ -7,7 +7,7 @@ spec:
   template:
     metadata:
       annotations:
-        kudo.dev/dependencies-hash: af5aeaa4a7dbc49b5d5fd9090541c141
+        kudo.dev/dependencies-hash: 6fa812afe527bdb6c9a5fbfcba8193bb
         kudo.dev/operator-version: 0.1.0
     spec:
       containers:

--- a/test/e2e/dependencies-hash/02-assert.yaml
+++ b/test/e2e/dependencies-hash/02-assert.yaml
@@ -8,7 +8,7 @@ spec:
     metadata:
       annotations:
         # This update to the deployment must have the same hash as 00-assert.yaml
-        kudo.dev/dependencies-hash: af5aeaa4a7dbc49b5d5fd9090541c141
+        kudo.dev/dependencies-hash: 6fa812afe527bdb6c9a5fbfcba8193bb
         kudo.dev/operator-version: 0.1.0
     spec:
       containers:

--- a/test/e2e/dependencies-hash/04-assert.yaml
+++ b/test/e2e/dependencies-hash/04-assert.yaml
@@ -8,7 +8,7 @@ spec:
     metadata:
       annotations:
         # After the second update to replicas the hash should change, based on the last deployed version of the config map
-        kudo.dev/dependencies-hash: 932a6cf74881302904011a9ad09cfe6e
+        kudo.dev/dependencies-hash: da9f56a62d3c4af2596bebace008d845
         kudo.dev/operator-version: 0.1.0
     spec:
       containers:

--- a/test/e2e/dependencies-hash/06-assert.yaml
+++ b/test/e2e/dependencies-hash/06-assert.yaml
@@ -8,7 +8,7 @@ spec:
     metadata:
       annotations:
         # After this config map update the hash should change, as the deployment was applied as well
-        kudo.dev/dependencies-hash: 5cbc3d2ae8bc41ebc23192af530566b6
+        kudo.dev/dependencies-hash: 1510654b540619228b477bdd56d44175
         kudo.dev/operator-version: 0.1.0
     spec:
       containers:


### PR DESCRIPTION
**What this PR does / why we need it**:
The easiest fix for the referenced issue is to simply ignore resources that are reported as "NotFound" from the API server. The deployment/statefulset/etc can still be applied, and k8s will correctly use the referenced config maps/secrets as soon as they are available, therefore not blocking KUDO.

The downside is that the next time the deployment/statefulset/etc gets deployed the hash changes and triggers a pod reload, but I think that's an acceptable downside.

Additionally, we can't rely on the `LastAppliedTemplateAnnotation`, as this annotation is only available on resources deployed by KUDO. We may encounter references that are applied either manually or by other controllers that don't have this annotation. 

The fix for this is to fall back to the object itself if the annotation is not available, and `nil` most fields on the `Unstructured` object that may affect the hash calculation.


Fixes #1517 #1521 

Signed-off-by: Andreas Neumann <aneumann@mesosphere.com>