### PR TITLE
Rename `UnknownTaskKind` to `TaskBuildError`

### DIFF
--- a/pkg/engine/workflow/engine.go
+++ b/pkg/engine/workflow/engine.go
@@ -19,7 +19,7 @@ import (
 
 var (
 	unknownTaskNameEventName = "UnknownTaskName"
-	unknownTaskKindEventName = "UnknownTaskKind"
+	taskBuildError           = "TaskBuildError"
 	missingPhaseStatus       = "MissingPhaseStatus"
 	missingStepStatus        = "MissingStepStatus"
 )
@@ -160,7 +160,7 @@ func Execute(pl *ActivePlan, em *engine.Metadata, c client.Client, di discovery.
 					phaseStatus.Set(v1beta1.ExecutionFatalError)
 					return planStatus, engine.ExecutionError{
 						Err:       err,
-						EventName: unknownTaskKindEventName,
+						EventName: taskBuildError,
 					}
 				}
 


### PR DESCRIPTION
Summary:
previously, building a task would only fail for `UnknownTaskKind` reason. However, we're past that and have more error reasons e.g. validation. For now, the reason is kept generic, but we might revisit this should the need arise.

Signed-off-by: Aleksey Dukhovniy <alex.dukhovniy@googlemail.com>