### PR TITLE
Add Tool Gen version Info to output for CI

### DIFF
--- a/hack/verify-generate.sh
+++ b/hack/verify-generate.sh
@@ -4,6 +4,10 @@ set -o nounset
 set -o pipefail
 # intentionally not setting 'set -o errexit' because we want to print custom error messages
 
+# versions of tools
+echo "controller-gen $(controller-gen --version)"
+go-bindata -version
+
 # make sure make generate can be invoked
 make generate
 RETVAL=$?


### PR DESCRIPTION
I had a recent fight with CI over "verifying" codegen.   This was due to a homebrew update of go-bindata which was out of sync with the CI env.   It was more challenging than it needed to be and this information in our CI logs would have made it easy.

Signed-off-by: Ken Sipe <kensipe@gmail.com>

