### PR TITLE
Namespace Package Verify

### DIFF
--- a/pkg/kudoctl/cmd/verify/verify.go
+++ b/pkg/kudoctl/cmd/verify/verify.go
@@ -22,6 +22,7 @@ var verifiers = []packages.Verifier{
 	template.ParametersVerifier{},
 	template.ReferenceVerifier{},
 	template.RenderVerifier{},
+	template.NamespaceVerifier{},
 }
 
 // PackageFiles verifies operator package files

--- a/pkg/kudoctl/packages/verifier/template/verify_namespace.go
+++ b/pkg/kudoctl/packages/verifier/template/verify_namespace.go
@@ -1,0 +1,65 @@
+package template
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/kudobuilder/kudo/pkg/engine/renderer"
+	"github.com/kudobuilder/kudo/pkg/kudoctl/packages"
+	"github.com/kudobuilder/kudo/pkg/kudoctl/verifier"
+)
+
+var _ packages.Verifier = &NamespaceVerifier{}
+
+type NamespaceVerifier struct{}
+
+func (n NamespaceVerifier) Verify(pf *packages.Files) verifier.Result {
+	res := verifier.NewResult()
+
+	n.namespaceKindNotUsed(pf, &res)
+	n.checkNamespaceManifest(pf, &res)
+
+	return res
+}
+
+func (n NamespaceVerifier) checkNamespaceManifest(pf *packages.Files, res *verifier.Result) {
+	if pf.Operator.NamespaceManifest != "" {
+		val, ok := pf.Templates[pf.Operator.NamespaceManifest]
+		if !ok {
+			res.AddErrors(fmt.Sprintf("NamespaceManifest %q not found in /templates folder", pf.Operator.NamespaceManifest))
+			return
+		}
+		ns, err := renderer.YamlToObject(val)
+		if err != nil {
+			res.AddErrors(fmt.Sprintf("Unable to marshal NamespaceManifest %q ", pf.Operator.NamespaceManifest))
+		}
+		switch count := len(ns); {
+		case count == 0:
+			res.AddErrors(fmt.Sprintf("NamespaceManifest %q found but does not contain a manifest", pf.Operator.NamespaceManifest))
+		case count == 1:
+			if ns[0].GetObjectKind().GroupVersionKind().Kind != "Namespace" {
+				res.AddErrors(fmt.Sprintf("NamespaceManifest %q found but manifest is not kind: Namespace", pf.Operator.NamespaceManifest))
+			}
+		case count > 1:
+			res.AddErrors(fmt.Sprintf("NamespaceManifest %q found but contains %v manifests which is greater than 1", pf.Operator.NamespaceManifest, count))
+		}
+	}
+}
+
+func (n NamespaceVerifier) namespaceKindNotUsed(pf *packages.Files, res *verifier.Result) {
+	// it would be great if we could marshal the templates into an unstructured runtime.Object to confirm Namespace
+	// however with templating we don't have the ability to have all required information to do so.
+	// best effort is to confirm that "kind: Namespace" is not used.
+	// kind: + (0 to many <spaces>) + Namespace
+	nsRegex := regexp.MustCompile(`kind:\s*Namespace`)
+	// scan through all files for `kind: Namespace`
+	for name, file := range pf.Templates {
+		// ignore the namespace manifest
+		if name == pf.Operator.NamespaceManifest {
+			continue
+		}
+		if nsRegex.MatchString(file) {
+			res.AddErrors(fmt.Sprintf("template %q contains 'kind: Namespace' not allowed unless specified as 'NamespaceManifest'", name))
+		}
+	}
+}

--- a/pkg/kudoctl/packages/verifier/template/verify_namespace.go
+++ b/pkg/kudoctl/packages/verifier/template/verify_namespace.go
@@ -32,6 +32,7 @@ func (n NamespaceVerifier) checkNamespaceManifest(pf *packages.Files, res *verif
 		ns, err := renderer.YamlToObject(val)
 		if err != nil {
 			res.AddErrors(fmt.Sprintf("Unable to marshal NamespaceManifest %q ", pf.Operator.NamespaceManifest))
+			return
 		}
 		switch count := len(ns); {
 		case count == 0:

--- a/pkg/kudoctl/packages/verifier/template/verify_namespace_test.go
+++ b/pkg/kudoctl/packages/verifier/template/verify_namespace_test.go
@@ -1,0 +1,154 @@
+package template
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/kudobuilder/kudo/pkg/kudoctl/packages"
+)
+
+func TestNamespaceUsedInTemplate(t *testing.T) {
+
+	templates := make(map[string]string)
+	templates["foo.yaml"] = `
+## this template contains a namespace
+kind: Namespace
+
+{{ Name }}
+`
+	pf := packages.Files{
+		Templates: templates,
+		Operator:  &packages.OperatorFile{},
+	}
+	verifier := NamespaceVerifier{}
+	res := verifier.Verify(&pf)
+
+	assert.Equal(t, 0, len(res.Warnings))
+	assert.Equal(t, 1, len(res.Errors))
+	assert.Equal(t, "template \"foo.yaml\" contains 'kind: Namespace' not allowed unless specified as 'NamespaceManifest'", res.Errors[0])
+}
+
+func TestNamespaceNotUsedInTemplate(t *testing.T) {
+
+	templates := make(map[string]string)
+	templates["foo.yaml"] = `
+## this template contains a namespace
+kind: Name
+
+{{ Name }}
+`
+	pf := packages.Files{
+		Templates: templates,
+		Operator:  &packages.OperatorFile{},
+	}
+	verifier := NamespaceVerifier{}
+	res := verifier.Verify(&pf)
+
+	assert.Equal(t, 0, len(res.Warnings))
+	assert.Equal(t, 0, len(res.Errors))
+}
+
+func TestNamespaceManifestFileMissing(t *testing.T) {
+
+	templates := make(map[string]string)
+	templates["foo.yaml"] = `
+## this template contains a namespace
+kind: Name
+
+{{ Name }}
+`
+	pf := packages.Files{
+		Templates: templates,
+		Operator:  &packages.OperatorFile{NamespaceManifest: "bar.yaml"},
+	}
+	verifier := NamespaceVerifier{}
+	res := verifier.Verify(&pf)
+
+	assert.Equal(t, 0, len(res.Warnings))
+	assert.Equal(t, 1, len(res.Errors))
+	assert.Equal(t, "NamespaceManifest \"bar.yaml\" not found in /templates folder", res.Errors[0])
+}
+
+func TestNamespaceManifestFileEmpty(t *testing.T) {
+
+	templates := make(map[string]string)
+	templates["foo.yaml"] = `
+`
+	pf := packages.Files{
+		Templates: templates,
+		Operator:  &packages.OperatorFile{NamespaceManifest: "foo.yaml"},
+	}
+	verifier := NamespaceVerifier{}
+	res := verifier.Verify(&pf)
+
+	assert.Equal(t, 0, len(res.Warnings))
+	assert.Equal(t, 1, len(res.Errors))
+	assert.Equal(t, "NamespaceManifest \"foo.yaml\" found but does not contain a manifest", res.Errors[0])
+}
+
+func TestNamespaceManifestNotNamespace(t *testing.T) {
+
+	templates := make(map[string]string)
+	templates["foo.yaml"] = `apiVersion: v1
+kind: Pod
+metadata:
+ labels:
+    app: my-app`
+
+	pf := packages.Files{
+		Templates: templates,
+		Operator:  &packages.OperatorFile{NamespaceManifest: "foo.yaml"},
+	}
+	verifier := NamespaceVerifier{}
+	res := verifier.Verify(&pf)
+
+	assert.Equal(t, 0, len(res.Warnings))
+	assert.Equal(t, 1, len(res.Errors))
+	assert.Equal(t, "NamespaceManifest \"foo.yaml\" found but manifest is not kind: Namespace", res.Errors[0])
+}
+
+func TestNamespaceManifestMultiNamespace(t *testing.T) {
+
+	templates := make(map[string]string)
+	templates["foo.yaml"] = `apiVersion: foo
+kind: Foo
+metadata:
+  name: foo1
+---
+apiVersion: foo
+kind: Foo
+metadata:
+name: foo2`
+
+	pf := packages.Files{
+		Templates: templates,
+		Operator:  &packages.OperatorFile{NamespaceManifest: "foo.yaml"},
+	}
+	verifier := NamespaceVerifier{}
+	res := verifier.Verify(&pf)
+
+	assert.Equal(t, 0, len(res.Warnings))
+	assert.Equal(t, 1, len(res.Errors))
+	assert.Equal(t, "NamespaceManifest \"foo.yaml\" found but contains 2 manifests which is greater than 1", res.Errors[0])
+}
+
+func TestNamespaceManifestGood(t *testing.T) {
+
+	templates := make(map[string]string)
+	templates["foo.yaml"] = `apiVersion: v1
+kind: Namespace
+metadata:
+ labels:
+    app: my-app`
+
+	pf := packages.Files{
+		Templates: templates,
+		Operator:  &packages.OperatorFile{NamespaceManifest: "foo.yaml"},
+	}
+	verifier := NamespaceVerifier{}
+	res := verifier.Verify(&pf)
+
+	assert.Equal(t, 0, len(res.Warnings))
+	assert.Equal(t, 0, len(res.Errors))
+}

--- a/pkg/kudoctl/packages/verifier/template/verify_references.go
+++ b/pkg/kudoctl/packages/verifier/template/verify_references.go
@@ -42,6 +42,10 @@ func (ReferenceVerifier) Verify(pf *packages.Files) verifier.Result {
 	}
 
 	for template := range templates {
+		// skip manifest file as it is already accounted for
+		if template == pf.Operator.NamespaceManifest {
+			continue
+		}
 		if _, ok := requiredTemplates[template]; !ok {
 			res.AddWarnings(fmt.Sprintf("template %q is not referenced from any task", template))
 		}


### PR DESCRIPTION
Package Verify now includes namespace checks

1. No `kind: Namespace` allowed in an operator
2. namespace manifest is specified must exist, must be 1 manifest in the yaml file, it must be `kind: Namespace`

Signed-off-by: Ken Sipe <kensipe@gmail.com>

Fixes #
