### PR TITLE
Fix namespace create without manifest

### DIFF
--- a/pkg/kudoctl/util/kudo/kudo.go
+++ b/pkg/kudoctl/util/kudo/kudo.go
@@ -420,6 +420,10 @@ func (c *Client) CreateNamespace(namespace, manifest string) error {
 	}
 	ns.TypeMeta.Kind = "Namespace"
 	ns.Name = namespace
+
+	if ns.Annotations == nil {
+		ns.Annotations = map[string]string{}
+	}
 	ns.Annotations["created-by"] = "kudo-cli"
 
 	_, err := c.kubeClientset.CoreV1().Namespaces().Create(ns)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kudo/blob/master/CONTRIBUTING.md
2. Make sure you have added and ran the tests before submitting your PR
3. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What this PR does / why we need it**:
If a namespace was created without a manifest, KUDO would fail with a segfault, because it tries to add an annotation to a nil map. This has been fixed and tests have been added for namespace creation.

<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
