### PR TITLE
Simplify instance controller reconciliation

### DIFF
--- a/pkg/apis/kudo/v1beta1/instance_types_helpers.go
+++ b/pkg/apis/kudo/v1beta1/instance_types_helpers.go
@@ -13,7 +13,6 @@ import (
 
 const (
 	instanceCleanupFinalizerName = "kudo.dev.instance.cleanup"
-	snapshotAnnotation           = "kudo.dev/last-applied-instance-state"
 )
 
 // ScheduledPlan returns plan status of currently active plan or nil if no plan is running. In most cases this method

--- a/pkg/apis/kudo/v1beta1/instance_types_helpers.go
+++ b/pkg/apis/kudo/v1beta1/instance_types_helpers.go
@@ -75,23 +75,25 @@ func (i *Instance) NoPlanEverExecuted() bool {
 }
 
 // UpdateInstanceStatus updates `Status.PlanStatus` and `Status.AggregatedStatus` property based on the given plan
-func (i *Instance) UpdateInstanceStatus(planStatus *PlanStatus, updatedTimestamp *metav1.Time) {
+func (i *Instance) UpdateInstanceStatus(ps *PlanStatus, updatedTimestamp *metav1.Time) {
 	for k, v := range i.Status.PlanStatus {
-		if v.Name == planStatus.Name {
-			planStatus.LastUpdatedTimestamp = updatedTimestamp
-			i.Status.PlanStatus[k] = *planStatus
-			i.Spec.PlanExecution.Status = planStatus.Status
+		if v.Name == ps.Name {
+			ps.LastUpdatedTimestamp = updatedTimestamp
+			i.Status.PlanStatus[k] = *ps
+			i.Spec.PlanExecution.Status = ps.Status
 		}
 	}
 }
 
+// ResetPlanStatus method resets a PlanStatus for a passed plan name and instance. Plan/phase/step statuses
+// are set to ExecutionPending meaning that the controller will restart plan execution.
 func (i *Instance) ResetPlanStatus(ps *PlanStatus, uid types.UID, updatedTimestamp *metav1.Time) {
 	ps.UID = uid
 	ps.Status = ExecutionPending
-	for i, ph := range ps.Phases {
+	for i := range ps.Phases {
 		ps.Phases[i].Set(ExecutionPending)
 
-		for j := range ph.Steps {
+		for j := range ps.Phases[i].Steps {
 			ps.Phases[i].Steps[j].Set(ExecutionPending)
 		}
 	}

--- a/pkg/apis/kudo/v1beta1/instance_types_helpers_test.go
+++ b/pkg/apis/kudo/v1beta1/instance_types_helpers_test.go
@@ -21,12 +21,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/uuid"
 )
 
 var (
 	testTime = time.Date(2019, 10, 17, 1, 1, 1, 1, time.UTC)
-	testUUID = uuid.NewUUID()
 )
 
 func TestGetLastExecutedPlanStatus(t *testing.T) {

--- a/pkg/controller/instance/instance_controller.go
+++ b/pkg/controller/instance/instance_controller.go
@@ -472,11 +472,6 @@ func ensurePlanStatusInitialized(i *v1beta1.Instance, ov *v1beta1.OperatorVersio
 	}
 }
 
-// isUpgradePlan returns true if this could be an upgrade plan - this is just an approximation because deploy plan can be used for both
-func isUpgradePlan(planName string) bool {
-	return planName == v1beta1.DeployPlanName || planName == v1beta1.UpgradePlanName
-}
-
 // scheduledPlan method returns currently scheduled plan and its UID from Instance.Spec.PlanExecution field. However, due
 // to an edge case with instance deletion, this method also schedules the 'cleanup' plan if necessary (see the comments below)
 func scheduledPlan(i *v1beta1.Instance, ov *v1beta1.OperatorVersion) (string, types.UID) {

--- a/pkg/controller/instance/instance_controller.go
+++ b/pkg/controller/instance/instance_controller.go
@@ -175,6 +175,7 @@ func (r *Reconciler) Reconcile(request ctrl.Request) (ctrl.Result, error) {
 	}
 
 	// ---------- 2. Get currently scheduled plan if it exists ----------
+
 	ensurePlanStatusInitialized(instance, ov)
 
 	// get the scheduled plan
@@ -442,7 +443,6 @@ func resetPlanStatusIfPlanIsNew(i *v1beta1.Instance, plan string, uid types.UID)
 // after OV was updated
 func ensurePlanStatusInitialized(i *v1beta1.Instance, ov *v1beta1.OperatorVersion) {
 	if i.Status.PlanStatus == nil {
-		a
 		i.Status.PlanStatus = make(map[string]v1beta1.PlanStatus)
 	}
 

--- a/pkg/controller/instance/instance_controller_test.go
+++ b/pkg/controller/instance/instance_controller_test.go
@@ -437,14 +437,14 @@ func Test_resetPlanStatusIfThePlanIsNew(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := resetPlanStatusIfThePlanIsNew(tt.i, tt.plan, tt.uid)
+			got, err := resetPlanStatusIfPlanIsNew(tt.i, tt.plan, tt.uid)
 
-			assert.True(t, (err != nil) == tt.wantErr, "resetPlanStatusIfThePlanIsNew() error = %v, wantErr %v", err, tt.wantErr)
+			assert.True(t, (err != nil) == tt.wantErr, "resetPlanStatusIfPlanIsNew() error = %v, wantErr %v", err, tt.wantErr)
 
 			if got != nil {
-				assert.Equal(t, tt.want.Name, got.Name, "resetPlanStatusIfThePlanIsNew() got plan = %v, want %v", got.Name, tt.want.Name)
-				assert.Equal(t, tt.want.Status, got.Status, "resetPlanStatusIfThePlanIsNew() got status = %v, want %v", got.Status, tt.want.Status)
-				assert.Equal(t, tt.want.UID, got.UID, "resetPlanStatusIfThePlanIsNew() got uid = %v, want %v", got.UID, tt.want.UID)
+				assert.Equal(t, tt.want.Name, got.Name, "resetPlanStatusIfPlanIsNew() got plan = %v, want %v", got.Name, tt.want.Name)
+				assert.Equal(t, tt.want.Status, got.Status, "resetPlanStatusIfPlanIsNew() got status = %v, want %v", got.Status, tt.want.Status)
+				assert.Equal(t, tt.want.UID, got.UID, "resetPlanStatusIfPlanIsNew() got uid = %v, want %v", got.UID, tt.want.UID)
 			}
 		})
 	}

--- a/pkg/controller/instance/instance_controller_test.go
+++ b/pkg/controller/instance/instance_controller_test.go
@@ -313,14 +313,14 @@ func Test_scheduledPlan(t *testing.T) {
 		i        *v1beta1.Instance
 		ov       *v1beta1.OperatorVersion
 		wantPlan string
-		wantUid  types.UID
+		wantUID  types.UID
 	}{
 		{
 			name:     "idle instance return an empty plan and uid",
 			i:        idle,
 			ov:       ov,
 			wantPlan: "",
-			wantUid:  "",
+			wantUID:  "",
 		},
 		{
 			name: "scheduled instance return the scheduled plan and uid",
@@ -332,7 +332,7 @@ func Test_scheduledPlan(t *testing.T) {
 			}(),
 			ov:       ov,
 			wantPlan: "deploy",
-			wantUid:  "111-222-333-444",
+			wantUID:  "111-222-333-444",
 		},
 		{
 			name: "instance that is being deleted returns the cleanup plan and uid",
@@ -344,7 +344,7 @@ func Test_scheduledPlan(t *testing.T) {
 			}(),
 			ov:       ov,
 			wantPlan: "cleanup",
-			wantUid:  "",
+			wantUID:  "",
 		},
 		{
 			name: "cleanup is not scheduled again when already running",
@@ -358,7 +358,7 @@ func Test_scheduledPlan(t *testing.T) {
 			}(),
 			ov:       ov,
 			wantPlan: "cleanup",
-			wantUid:  "111-222-333-444",
+			wantUID:  "111-222-333-444",
 		},
 	}
 	for _, tt := range tests {
@@ -367,8 +367,8 @@ func Test_scheduledPlan(t *testing.T) {
 			plan, uid := scheduledPlan(tt.i, tt.ov)
 
 			assert.Equal(t, tt.wantPlan, plan, "scheduledPlan() got plan = %v, want %v", plan, tt.wantPlan)
-			if tt.wantUid != "" {
-				assert.Equal(t, tt.wantUid, uid, "scheduledPlan() got uid = %v, want %v", uid, tt.wantUid)
+			if tt.wantUID != "" {
+				assert.Equal(t, tt.wantUID, uid, "scheduledPlan() got uid = %v, want %v", uid, tt.wantUID)
 			}
 		})
 	}

--- a/pkg/webhook/instance_admission.go
+++ b/pkg/webhook/instance_admission.go
@@ -83,11 +83,6 @@ func handleCreate(ia *InstanceAdmission, req admission.Request) admission.Respon
 		new.TryAddFinalizer()
 	}
 
-	// add an instance snapshot *BEFORE* setting new Spec.PlanExecution. this way the controller will recognize the plan as newly scheduled
-	if err = new.AnnotateSnapshot(); err != nil {
-		return admission.Errored(http.StatusInternalServerError, fmt.Errorf("failed to create an Instance snapshot %s/%s: %v", new.Namespace, new.Name, err))
-	}
-
 	// schedule 'deploy' plan for execution (and fail if it doesn't exist)
 	if !kudov1beta1.PlanExists(kudov1beta1.DeployPlanName, ov) {
 		return admission.Denied(fmt.Sprintf("failed to create an Instance %s/%s: couldn't find '%s' plan in the operatorVersion", new.Namespace, new.Name, kudov1beta1.DeployPlanName))


### PR DESCRIPTION
Summary:
current instance controller reconciliation logic with regard to detecting currently active plan can be much simpler now that we have IAW (instance admission webhook) controlling the scheduled plan.

Signed-off-by: Aleksey Dukhovniy <alex.dukhovniy@googlemail.com>