### PR TITLE
Filter unknown custom resources in Delete- and ToggleTask

### DIFF
--- a/pkg/engine/renderer/enhancer_test.go
+++ b/pkg/engine/renderer/enhancer_test.go
@@ -16,7 +16,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/kubectl/pkg/scheme"
 	clientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"sigs.k8s.io/yaml"
 
 	"github.com/kudobuilder/kuttl/pkg/test/utils"
 
@@ -27,8 +26,8 @@ import (
 
 func TestEnhancerApply_embeddedMetadataStatefulSet(t *testing.T) {
 
-	tpls := map[string]string{
-		"deployment": resourceAsString(statefulSet("sfs1", "default")),
+	tpls := []runtime.Object{
+		statefulSet("sfs1", "default"),
 	}
 
 	meta := metadata()
@@ -72,8 +71,8 @@ func TestEnhancerApply_embeddedMetadataStatefulSet(t *testing.T) {
 
 func TestEnhancerApply_embeddedMetadataCronjob(t *testing.T) {
 
-	tpls := map[string]string{
-		"cron": resourceAsString(cronjob("cronjob", "default")),
+	tpls := []runtime.Object{
+		cronjob("cronjob", "default"),
 	}
 
 	meta := metadata()
@@ -113,9 +112,9 @@ func TestEnhancerApply_embeddedMetadataCronjob(t *testing.T) {
 
 func TestEnhancerApply_noAdditionalMetadata(t *testing.T) {
 
-	tpls := map[string]string{
-		"pod": resourceAsString(pod("pod", "default")),
-		"crd": resourceAsString(unstructuredCrd("crd", "default")),
+	tpls := []runtime.Object{
+		pod("pod", "default"),
+		unstructuredCrd("crd", "default"),
 	}
 
 	meta := metadata()
@@ -157,9 +156,7 @@ func TestEnhancerApply_noAdditionalMetadata(t *testing.T) {
 func TestEnhancerApply_dependencyHash_noDependencies(t *testing.T) {
 	ss := statefulSet("statefulset", "default")
 
-	tpls := map[string]string{
-		"statefulset": resourceAsString(ss),
-	}
+	tpls := []runtime.Object{ss}
 
 	meta := metadata()
 	meta.PlanUID = uuid.NewUUID()
@@ -202,9 +199,7 @@ func TestEnhancerApply_dependencyHash_unavailableResource(t *testing.T) {
 		},
 	})
 
-	tpls := map[string]string{
-		"statefulset": resourceAsString(ss),
-	}
+	tpls := []runtime.Object{ss}
 
 	meta := metadata()
 	meta.PlanUID = uuid.NewUUID()
@@ -250,9 +245,7 @@ func TestEnhancerApply_dependencyHash_calculatedOnResourceWithoutLastAppliedConf
 		},
 	})
 
-	tpls := map[string]string{
-		"statefulset": resourceAsString(ss),
-	}
+	tpls := []runtime.Object{ss}
 
 	meta := metadata()
 	meta.PlanUID = uuid.NewUUID()
@@ -295,10 +288,7 @@ func TestEnhancerApply_dependencyHash_changes(t *testing.T) {
 		},
 	})
 
-	tpls := map[string]string{
-		"statefulset": resourceAsString(ss),
-		"configmap":   resourceAsString(cm),
-	}
+	tpls := []runtime.Object{ss, cm}
 
 	meta := metadata()
 	meta.PlanUID = uuid.NewUUID()
@@ -327,10 +317,7 @@ func TestEnhancerApply_dependencyHash_changes(t *testing.T) {
 	assert.NotNil(t, hash, "Pod template spec annotations contains no dependency hash field")
 
 	cm.Data["newkey"] = "newvalue"
-	tpls = map[string]string{
-		"statefulset": resourceAsString(ss),
-		"configmap":   resourceAsString(cm),
-	}
+	tpls = []runtime.Object{ss, cm}
 
 	objs, err = e.Apply(tpls, meta)
 	assert.Nil(t, err)
@@ -378,11 +365,6 @@ func owner() *corev1.Pod {
 		Spec:       corev1.PodSpec{},
 		Status:     corev1.PodStatus{},
 	}
-}
-
-func resourceAsString(resource runtime.Object) string {
-	bytes, _ := yaml.Marshal(resource)
-	return string(bytes)
 }
 
 func configMap(name string, namespace string) *corev1.ConfigMap {

--- a/pkg/engine/task/render.go
+++ b/pkg/engine/task/render.go
@@ -38,10 +38,25 @@ func render(resourceNames []string, ctx Context) (map[string]string, error) {
 	return resources, nil
 }
 
-// enhance method takes a slice of rendered templates, applies conventions using Enhancer and
-// returns a slice of k8s objects.
-func enhance(rendered map[string]string, meta renderer.Metadata, enhancer renderer.Enhancer) ([]runtime.Object, error) {
-	enhanced, err := enhancer.Apply(rendered, meta)
+// convert takes a map of rendered yaml templates and converts them to k8s objects
+func convert(rendered map[string]string) ([]runtime.Object, error) {
+	objs := make([]runtime.Object, 0, len(rendered))
+
+	for name, v := range rendered {
+		parsed, err := renderer.YamlToObject(v)
+		if err != nil {
+			return nil, fmt.Errorf("%wparsing YAML from %s: %v", engine.ErrFatalExecution, name, err)
+		}
+		objs = append(objs, parsed...)
+	}
+
+	return objs, nil
+}
+
+// enhance method takes a slice of rendered k8s objects, applies conventions using Enhancer and
+// returns a slice of enhanced k8s objects.
+func enhance(objs []runtime.Object, meta renderer.Metadata, enhancer renderer.Enhancer) ([]runtime.Object, error) {
+	enhanced, err := enhancer.Apply(objs, meta)
 
 	switch {
 	case errors.Is(err, engine.ErrFatalExecution):

--- a/pkg/engine/task/task_apply.go
+++ b/pkg/engine/task/task_apply.go
@@ -45,8 +45,14 @@ func (at ApplyTask) Run(ctx Context) (bool, error) {
 		return false, fatalExecutionError(err, taskRenderingError, ctx.Meta)
 	}
 
+	// 2. - Convert to objects
+	objs, err := convert(rendered)
+	if err != nil {
+		return false, fatalExecutionError(err, taskRenderingError, ctx.Meta)
+	}
+
 	// 2. - Enhance them with metadata -
-	enhanced, err := enhance(rendered, ctx.Meta, ctx.Enhancer)
+	enhanced, err := enhance(objs, ctx.Meta, ctx.Enhancer)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/engine/task/task_apply_test.go
+++ b/pkg/engine/task/task_apply_test.go
@@ -198,26 +198,18 @@ func resourceAsString(resource metav1.Object) string {
 
 type testEnhancer struct{}
 
-func (k *testEnhancer) Apply(templates map[string]string, metadata renderer.Metadata) ([]runtime.Object, error) {
-	result := make([]runtime.Object, 0)
-	for _, t := range templates {
-		objsToAdd, err := renderer.YamlToObject(t)
-		if err != nil {
-			return nil, fmt.Errorf("error parsing kubernetes objects after applying enhance: %w", err)
-		}
-		result = append(result, objsToAdd[0])
-	}
-	return result, nil
+func (k *testEnhancer) Apply(objs []runtime.Object, metadata renderer.Metadata) ([]runtime.Object, error) {
+	return objs, nil
 }
 
 type fatalErrorEnhancer struct{}
 
-func (k *fatalErrorEnhancer) Apply(templates map[string]string, metadata renderer.Metadata) ([]runtime.Object, error) {
+func (k *fatalErrorEnhancer) Apply(objs []runtime.Object, metadata renderer.Metadata) ([]runtime.Object, error) {
 	return nil, fmt.Errorf("%wsomething fatally bad happens every time", engine.ErrFatalExecution)
 }
 
 type transientErrorEnhancer struct{}
 
-func (k *transientErrorEnhancer) Apply(templates map[string]string, metadata renderer.Metadata) ([]runtime.Object, error) {
+func (k *transientErrorEnhancer) Apply(objs []runtime.Object, metadata renderer.Metadata) ([]runtime.Object, error) {
 	return nil, fmt.Errorf("something transiently bad happens every time")
 }

--- a/pkg/engine/task/task_delete.go
+++ b/pkg/engine/task/task_delete.go
@@ -6,6 +6,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kudobuilder/kudo/pkg/engine/resource"
 )
 
 // DeleteTask will delete a set of given resources from the cluster. See Run method for more details.
@@ -29,14 +31,40 @@ func (dt DeleteTask) Run(ctx Context) (bool, error) {
 		return false, fatalExecutionError(err, taskRenderingError, ctx.Meta)
 	}
 
-	// 3. - Delete them using the client -
+	// 3. - Filter unknown objects
+	objs, err = filterUnknownObjectTypes(objs, ctx)
+	if err != nil {
+		return false, fatalExecutionError(err, taskRenderingError, ctx.Meta)
+	}
+
+	// 4. - Enhance objects, required for namespaces
+	objs, err = ctx.Enhancer.Apply(objs, ctx.Meta)
+	if err != nil {
+		return false, err
+	}
+
+	// 5. - Delete them using the client -
 	err = deleteResource(objs, ctx.Client)
 	if err != nil {
 		return false, err
 	}
 
-	// 4. - Check health: always true for Delete task -
+	// 6. - Check health: always true for Delete task -
 	return true, nil
+}
+
+func filterUnknownObjectTypes(objs []runtime.Object, ctx Context) ([]runtime.Object, error) {
+	knownObjs := make([]runtime.Object, len(objs))
+	for _, o := range objs {
+		isKnown, err := resource.IsKnownObjectType(o, ctx.Discovery)
+		if err != nil {
+			return nil, err
+		}
+		if isKnown {
+			knownObjs = append(knownObjs, o)
+		}
+	}
+	return knownObjs, nil
 }
 
 func deleteResource(ro []runtime.Object, c client.Client) error {

--- a/pkg/engine/task/task_delete.go
+++ b/pkg/engine/task/task_delete.go
@@ -23,14 +23,14 @@ func (dt DeleteTask) Run(ctx Context) (bool, error) {
 		return false, fatalExecutionError(err, taskRenderingError, ctx.Meta)
 	}
 
-	// 2. - Enhance them with metadata -
-	enhanced, err := enhance(rendered, ctx.Meta, ctx.Enhancer)
+	// 2. - Convert to objs
+	objs, err := convert(rendered)
 	if err != nil {
-		return false, err
+		return false, fatalExecutionError(err, taskRenderingError, ctx.Meta)
 	}
 
 	// 3. - Delete them using the client -
-	err = deleteResource(enhanced, ctx.Client)
+	err = deleteResource(objs, ctx.Client)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/engine/task/task_delete.go
+++ b/pkg/engine/task/task_delete.go
@@ -1,6 +1,8 @@
 package task
 
 import (
+	"fmt"
+
 	"golang.org/x/net/context"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -54,11 +56,11 @@ func (dt DeleteTask) Run(ctx Context) (bool, error) {
 }
 
 func filterUnknownObjectTypes(objs []runtime.Object, ctx Context) ([]runtime.Object, error) {
-	knownObjs := make([]runtime.Object, len(objs))
+	knownObjs := make([]runtime.Object, 0)
 	for _, o := range objs {
 		isKnown, err := resource.IsKnownObjectType(o, ctx.Discovery)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to detect if object type is known for %s: %v", o.GetObjectKind(), err)
 		}
 		if isKnown {
 			knownObjs = append(knownObjs, o)

--- a/pkg/engine/task/task_delete_test.go
+++ b/pkg/engine/task/task_delete_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/kudobuilder/kudo/pkg/engine"
 	"github.com/kudobuilder/kudo/pkg/engine/renderer"
+	kudofake "github.com/kudobuilder/kudo/pkg/test/fake"
 )
 
 func TestDeleteTask_Run(t *testing.T) {
@@ -45,9 +46,10 @@ func TestDeleteTask_Run(t *testing.T) {
 			done:    true,
 			wantErr: false,
 			ctx: Context{
-				Client:   fake.NewFakeClientWithScheme(scheme.Scheme),
-				Enhancer: &testEnhancer{},
-				Meta:     renderer.Metadata{},
+				Client:    fake.NewFakeClientWithScheme(scheme.Scheme),
+				Discovery: kudofake.CustomCachedDiscoveryClient(),
+				Enhancer:  &testEnhancer{},
+				Meta:      renderer.Metadata{},
 			},
 		},
 		{
@@ -61,22 +63,24 @@ func TestDeleteTask_Run(t *testing.T) {
 			fatal:   true,
 			ctx: Context{
 				Client:    fake.NewFakeClientWithScheme(scheme.Scheme),
+				Discovery: kudofake.CustomCachedDiscoveryClient(),
 				Enhancer:  &testEnhancer{},
 				Meta:      meta,
 				Templates: map[string]string{},
 			},
 		},
 		{
-			name: "does not fail when a kustomizing error occurs",
+			name: "fails when a kustomizing error occurs",
 			task: DeleteTask{
 				Name:      "task",
 				Resources: []string{"pod"},
 			},
-			done:    true,
-			wantErr: false,
-			fatal:   false,
+			done:    false,
+			wantErr: true,
+			fatal:   true,
 			ctx: Context{
 				Client:    fake.NewFakeClientWithScheme(scheme.Scheme),
+				Discovery: kudofake.CustomCachedDiscoveryClient(),
 				Enhancer:  &fatalErrorEnhancer{},
 				Meta:      meta,
 				Templates: map[string]string{"pod": resourceAsString(pod("pod1", "default"))},
@@ -92,6 +96,7 @@ func TestDeleteTask_Run(t *testing.T) {
 			wantErr: false,
 			ctx: Context{
 				Client:    fake.NewFakeClientWithScheme(scheme.Scheme),
+				Discovery: kudofake.CustomCachedDiscoveryClient(),
 				Enhancer:  &testEnhancer{},
 				Meta:      meta,
 				Templates: map[string]string{"pod": resourceAsString(pod("pod1", "default"))},

--- a/pkg/engine/workflow/engine_test.go
+++ b/pkg/engine/workflow/engine_test.go
@@ -1,7 +1,6 @@
 package workflow
 
 import (
-	"fmt"
 	"reflect"
 	"testing"
 	"time"
@@ -663,14 +662,6 @@ func instance() *v1beta1.Instance {
 
 type testEnhancer struct{}
 
-func (k *testEnhancer) Apply(templates map[string]string, metadata renderer.Metadata) ([]runtime.Object, error) {
-	result := make([]runtime.Object, 0)
-	for _, t := range templates {
-		objsToAdd, err := renderer.YamlToObject(t)
-		if err != nil {
-			return nil, fmt.Errorf("error parsing kubernetes objects after applying enhance: %v", err)
-		}
-		result = append(result, objsToAdd[0])
-	}
-	return result, nil
+func (k *testEnhancer) Apply(objs []runtime.Object, metadata renderer.Metadata) ([]runtime.Object, error) {
+	return objs, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
For the `DeleteTask` and `ToggleTask` we use the enhance process - but this fails when the resource to delete is a custom resource for a CRD which is not installed in the cluster. This is especially problematic for the `ToggleTask` which is often used to guard deployment of features.

We need to filter the rendered templates - If one of them is of an unknown type, we shouldn't try to delete it as it can't be there anyway.

This PR splits the convert functionality from the enhancer and skips enhancing for the DeleteTask, then filters the resources for unknown types

Fixes #1547 
Signed-off-by: Andreas Neumann <aneumann@mesosphere.com>