### PR TITLE
KEP-29: Install dependencies of operators.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/stretchr/testify v1.5.1
 	github.com/thoas/go-funk v0.6.0
 	github.com/xlab/treeprint v1.0.0
+	github.com/yourbasic/graph v0.0.0-20170921192928-40eb135c0b26
 	golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e
 	golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a
 	golang.org/x/sys v0.0.0-20200408040146-ea54a3c99b9b // indirect

--- a/go.sum
+++ b/go.sum
@@ -506,6 +506,8 @@ github.com/xlab/handysort v0.0.0-20150421192137-fb3537ed64a1/go.mod h1:QcJo0QPSf
 github.com/xlab/treeprint v1.0.0 h1:J0TkWtiuYgtdlrkkrDLISYBQ92M+X5m4LrIIMKrbDTs=
 github.com/xlab/treeprint v1.0.0/go.mod h1:IoImgRak9i3zJyuxOKUP1v4UZd1tMoKkq/Cimt1uhCg=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
+github.com/yourbasic/graph v0.0.0-20170921192928-40eb135c0b26 h1:4u7nCRnWizT8R6xOP7cGaq+Ov0oBGkKMsLWZKiwDFas=
+github.com/yourbasic/graph v0.0.0-20170921192928-40eb135c0b26/go.mod h1:Rfzr+sqaDreiCaoQbFCu3sTXxeFq/9kXRuyOoSlGQHE=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/etcd v0.0.0-20191023171146-3cf2f69b5738/go.mod h1:dnLIgRNXwCJa5e+c6mIZCrds/GIG4ncV9HhK5PX7jPg=

--- a/pkg/apis/kudo/v1beta1/operatorversion_types_helpers.go
+++ b/pkg/apis/kudo/v1beta1/operatorversion_types_helpers.go
@@ -13,7 +13,7 @@ func OperatorVersionName(operatorName, version string) string {
 }
 
 func (ov *OperatorVersion) FullyQualifiedName() string {
-	return fmt.Sprintf("%s:%s", ov.Name, ov.Spec.AppVersion)
+	return fmt.Sprintf("%s-%s", ov.Name, ov.Spec.AppVersion)
 }
 
 func (some *OperatorVersion) EqualOperatorVersion(other *OperatorVersion) bool {

--- a/pkg/apis/kudo/v1beta1/operatorversion_types_helpers.go
+++ b/pkg/apis/kudo/v1beta1/operatorversion_types_helpers.go
@@ -11,3 +11,11 @@ func OperatorInstanceName(operatorName string) string {
 func OperatorVersionName(operatorName, version string) string {
 	return fmt.Sprintf("%s-%s", operatorName, version)
 }
+
+func (ov *OperatorVersion) FullyQualifiedName() string {
+	return fmt.Sprintf("%s:%s", ov.Name, ov.Spec.AppVersion)
+}
+
+func (some *OperatorVersion) EqualOperatorVersion(other *OperatorVersion) bool {
+	return some.FullyQualifiedName() == other.FullyQualifiedName()
+}

--- a/pkg/apis/kudo/v1beta1/operatorversion_types_helpers.go
+++ b/pkg/apis/kudo/v1beta1/operatorversion_types_helpers.go
@@ -16,6 +16,6 @@ func (ov *OperatorVersion) FullyQualifiedName() string {
 	return fmt.Sprintf("%s-%s", ov.Name, ov.Spec.AppVersion)
 }
 
-func (some *OperatorVersion) EqualOperatorVersion(other *OperatorVersion) bool {
-	return some.FullyQualifiedName() == other.FullyQualifiedName()
+func (ov *OperatorVersion) EqualOperatorVersion(other *OperatorVersion) bool {
+	return ov.FullyQualifiedName() == other.FullyQualifiedName()
 }

--- a/pkg/kudoctl/cmd/install/install.go
+++ b/pkg/kudoctl/cmd/install/install.go
@@ -95,5 +95,6 @@ func installOperator(operatorArgument string, options *Options, fs afero.Fs, set
 		settings.Namespace,
 		*pkg.Resources,
 		options.Parameters,
+		resolver,
 		installOpts)
 }

--- a/pkg/kudoctl/packages/install/dependencies.go
+++ b/pkg/kudoctl/packages/install/dependencies.go
@@ -1,0 +1,143 @@
+package install
+
+import (
+	"fmt"
+
+	"github.com/thoas/go-funk"
+	"github.com/yourbasic/graph"
+
+	"github.com/kudobuilder/kudo/pkg/apis/kudo/v1beta1"
+	engtask "github.com/kudobuilder/kudo/pkg/engine/task"
+	"github.com/kudobuilder/kudo/pkg/kudoctl/clog"
+	"github.com/kudobuilder/kudo/pkg/kudoctl/packages"
+	pkgresolver "github.com/kudobuilder/kudo/pkg/kudoctl/packages/resolver"
+)
+
+// dependencyGraph is modeled after 'graph.Mutable' but allows to add vertices.
+type dependencyGraph struct {
+	edges []map[int]struct{}
+}
+
+// AddVertex adds a new vertex to the dependency graph.
+func (g *dependencyGraph) AddVertex() {
+	g.edges = append(g.edges, map[int]struct{}{})
+}
+
+// AddEdge adds an edge from vertex v to w to the dependency graph.
+func (g *dependencyGraph) AddEdge(v, w int) {
+	g.edges[v][w] = struct{}{}
+}
+
+// Order returns the number of vertices of the dependency graph.
+func (g *dependencyGraph) Order() int {
+	return len(g.edges)
+}
+
+func (g *dependencyGraph) Visit(v int, do func(w int, c int64) bool) bool {
+	for w := range g.edges[v] {
+		if do(w, 1) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// gatherDependencies resolved all dependencies of a package.
+// Dependencies are resolved recursively.
+// Cyclic dependencies are detected and result in an error.
+func gatherDependencies(root packages.Resources, resolver pkgresolver.Resolver) ([]packages.Resources, error) {
+	pkgs := []packages.Resources{
+		root,
+	}
+
+	// Each vertex in 'g' matches an index in 'pkgs'.
+	g := dependencyGraph{
+		edges: []map[int]struct{}{{}},
+	}
+
+	if err := dependencyWalk(&pkgs, &g, root, resolver); err != nil {
+		return nil, err
+	}
+
+	return pkgs, nil
+}
+
+func dependencyWalk(
+	pkgs *[]packages.Resources,
+	g *dependencyGraph,
+	parent packages.Resources,
+	resolver pkgresolver.Resolver) error {
+	//nolint:errcheck // False positive, 'funk.Filter' doesn't return an error.
+	operatorTasks := funk.Filter(parent.OperatorVersion.Spec.Tasks, func(task v1beta1.Task) bool {
+		return task.Kind == engtask.KudoOperatorTaskKind
+	}).([]v1beta1.Task)
+
+	versionOf := func(pkg packages.Resources) func(packages.Resources) bool {
+		return func(r packages.Resources) bool {
+			return r.Operator.Name == pkg.Operator.Name &&
+				r.OperatorVersion.Spec.AppVersion == pkg.OperatorVersion.Spec.AppVersion &&
+				r.OperatorVersion.Spec.Version == pkg.OperatorVersion.Spec.Version
+		}
+	}
+
+	for _, task := range operatorTasks {
+		pkg, err := resolver.Resolve(
+			task.Spec.Package,
+			task.Spec.AppVersion,
+			task.Spec.OperatorVersion)
+		if err != nil {
+			return fmt.Errorf(
+				"failed to resolve package %s-%s-%s, dependency of package %s-%s-%s: %v",
+				task.Spec.Package,
+				task.Spec.AppVersion,
+				task.Spec.OperatorVersion,
+				parent.Operator.Name,
+				parent.OperatorVersion.Spec.AppVersion,
+				parent.OperatorVersion.Spec.Version,
+				err)
+		}
+
+		parentIndex := funk.IndexOf(*pkgs, funk.Find(*pkgs, versionOf(parent)))
+		if parentIndex == -1 {
+			panic("failed to find parent index in dependency graph")
+		}
+
+		if funk.Find(*pkgs, versionOf(*pkg.Resources)) == nil {
+			clog.Printf(
+				"Adding new dependency %s-%s-%s",
+				pkg.Resources.Operator.Name,
+				pkg.Resources.OperatorVersion.Spec.AppVersion,
+				pkg.Resources.OperatorVersion.Spec.Version)
+
+			*pkgs = append(*pkgs, *pkg.Resources)
+
+			// The number of vertices in 'g' has to match the number of packages
+			// we're tracking.
+			g.AddVertex()
+		}
+
+		pkgIndex := funk.IndexOf(*pkgs, funk.Find(*pkgs, versionOf(*pkg.Resources)))
+		if pkgIndex == -1 {
+			panic("failed to find package index in dependency graph")
+		}
+
+		// This is a directed graph. The edge represents a dependency of
+		// the parent package on the current package.
+		g.AddEdge(parentIndex, pkgIndex)
+
+		if !graph.Acyclic(g) {
+			return fmt.Errorf(
+				"cyclic package dependency found when adding package %s-%s-%s",
+				pkg.Resources.Operator.Name,
+				pkg.Resources.OperatorVersion.Spec.AppVersion,
+				pkg.Resources.OperatorVersion.Spec.Version)
+		}
+
+		if err := dependencyWalk(pkgs, g, *pkg.Resources, resolver); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/kudoctl/packages/install/dependencies.go
+++ b/pkg/kudoctl/packages/install/dependencies.go
@@ -60,6 +60,9 @@ func gatherDependencies(root packages.Resources, resolver pkgresolver.Resolver) 
 		return nil, err
 	}
 
+	// Remove 'root' from the list of dependencies.
+	pkgs = funk.Drop(pkgs, 1).([]packages.Resources) //nolint:errcheck
+
 	return pkgs, nil
 }
 
@@ -68,7 +71,7 @@ func dependencyWalk(
 	g *dependencyGraph,
 	parent packages.Resources,
 	resolver pkgresolver.Resolver) error {
-	//nolint:errcheck // False positive, 'funk.Filter' doesn't return an error.
+	//nolint:errcheck
 	operatorTasks := funk.Filter(parent.OperatorVersion.Spec.Tasks, func(task v1beta1.Task) bool {
 		return task.Kind == engtask.KudoOperatorTaskKind
 	}).([]v1beta1.Task)

--- a/pkg/kudoctl/packages/install/dependencies_test.go
+++ b/pkg/kudoctl/packages/install/dependencies_test.go
@@ -68,42 +68,42 @@ func TestGatherDependencies(t *testing.T) {
 	}{
 		{
 			// A <---> A
-			"trivial circular dependency",
-			[]packages.Package{
+			name: "trivial circular dependency",
+			pkgs: []packages.Package{
 				createPackage("A", "A"),
 			},
-			[]string{},
-			"cyclic package dependency found when adding package A--",
+			expectedDeps: []string{},
+			expectedErr:  "cyclic package dependency found when adding package A--",
 		},
 		{
 			// A <---> B
-			"circular dependency",
-			[]packages.Package{
+			name: "circular dependency",
+			pkgs: []packages.Package{
 				createPackage("A", "B"),
 				createPackage("B", "A"),
 			},
-			[]string{},
-			"cyclic package dependency found when adding package B--",
+			expectedDeps: []string{},
+			expectedErr:  "cyclic package dependency found when adding package B--",
 		},
 		{
 			// A ---> (B)
-			"unknown dependency",
-			[]packages.Package{
+			name: "unknown dependency",
+			pkgs: []packages.Package{
 				createPackage("A", "B"),
 			},
-			[]string{},
-			"failed to resolve package B--, dependency of package A--: package not found",
+			expectedDeps: []string{},
+			expectedErr:  "failed to resolve package B--, dependency of package A--: package not found",
 		},
 		{
 			// A ---> B ---> C
-			"simple dependency",
-			[]packages.Package{
+			name: "simple dependency",
+			pkgs: []packages.Package{
 				createPackage("A", "B"),
 				createPackage("B", "C"),
 				createPackage("C"),
 			},
-			[]string{"B", "C"},
-			"",
+			expectedDeps: []string{"B", "C"},
+			expectedErr:  "",
 		},
 		{
 			//        B -----
@@ -115,16 +115,16 @@ func TestGatherDependencies(t *testing.T) {
 			// |      |      |
 			// \      v      v
 			//  ----> D ---> E
-			"complex dependency",
-			[]packages.Package{
+			name: "complex dependency",
+			pkgs: []packages.Package{
 				createPackage("A", "C", "D"),
 				createPackage("B", "C", "E"),
 				createPackage("C", "D"),
 				createPackage("D", "E"),
 				createPackage("E"),
 			},
-			[]string{"C", "D", "E"},
-			"",
+			expectedDeps: []string{"C", "D", "E"},
+			expectedErr:  "",
 		},
 	}
 

--- a/pkg/kudoctl/packages/install/dependencies_test.go
+++ b/pkg/kudoctl/packages/install/dependencies_test.go
@@ -71,35 +71,41 @@ func TestGatherDependencies(t *testing.T) {
 		expectedErr  string
 	}{
 		{
-			// A <---> A
+			// A
+			// └── A
 			name: "trivial circular dependency",
 			pkgs: []packages.Package{
 				createPackage("A", "A"),
 			},
 			expectedDeps: []string{},
-			expectedErr:  "cyclic package dependency found when adding package A-:",
+			expectedErr:  "cyclic package dependency found when adding package A-- -> A--",
 		},
 		{
-			// A <---> B
+			// A
+			// └── B
+			//     └── A
 			name: "circular dependency",
 			pkgs: []packages.Package{
 				createPackage("A", "B"),
 				createPackage("B", "A"),
 			},
 			expectedDeps: []string{},
-			expectedErr:  "cyclic package dependency found when adding package B-:",
+			expectedErr:  "cyclic package dependency found when adding package B-- -> A--",
 		},
 		{
-			// A ---> (B)
+			// A
+			// └── (B)
 			name: "unknown dependency",
 			pkgs: []packages.Package{
 				createPackage("A", "B"),
 			},
 			expectedDeps: []string{},
-			expectedErr:  "failed to resolve package B-:, dependency of package A-:: package not found",
+			expectedErr:  "failed to resolve package B--, dependency of package A--: package not found",
 		},
 		{
-			// A ---> B ---> C
+			// A
+			// └── B
+			//     └── C
 			name: "simple dependency",
 			pkgs: []packages.Package{
 				createPackage("A", "B"),
@@ -148,7 +154,7 @@ func TestGatherDependencies(t *testing.T) {
 				createPackage("F"),
 			},
 			expectedDeps: []string{},
-			expectedErr:  "cyclic package dependency found when adding package B-:",
+			expectedErr:  "cyclic package dependency found when adding package C-- -> A--",
 		},
 	}
 

--- a/pkg/kudoctl/packages/install/dependencies_test.go
+++ b/pkg/kudoctl/packages/install/dependencies_test.go
@@ -1,0 +1,144 @@
+package install
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/thoas/go-funk"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kudobuilder/kudo/pkg/apis/kudo/v1beta1"
+	engtask "github.com/kudobuilder/kudo/pkg/engine/task"
+	"github.com/kudobuilder/kudo/pkg/kudoctl/packages"
+)
+
+type nameResolver struct {
+	Pkgs []packages.Package
+}
+
+func (resolver nameResolver) Resolve(
+	name string,
+	appVersion string,
+	operatorVersion string) (*packages.Package, error) {
+	for _, pkg := range resolver.Pkgs {
+		if pkg.Resources.Operator.Name == name {
+			return &pkg, nil
+		}
+	}
+
+	return nil, fmt.Errorf("package not found")
+}
+
+func createPackage(name string, dependencies ...string) packages.Package {
+	p := packages.Package{
+		Resources: &packages.Resources{
+			Operator: &v1beta1.Operator{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: name,
+				},
+			},
+			OperatorVersion: &v1beta1.OperatorVersion{},
+		},
+	}
+
+	for _, dependency := range dependencies {
+		p.Resources.OperatorVersion.Spec.Tasks = append(
+			p.Resources.OperatorVersion.Spec.Tasks,
+			v1beta1.Task{
+				Name: "dependency",
+				Kind: engtask.KudoOperatorTaskKind,
+				Spec: v1beta1.TaskSpec{
+					KudoOperatorTaskSpec: v1beta1.KudoOperatorTaskSpec{
+						Package: dependency,
+					},
+				},
+			})
+	}
+
+	return p
+}
+
+func TestGatherDependencies(t *testing.T) {
+	tests := []struct {
+		name        string
+		pkgs        []packages.Package
+		expected    []string
+		expectedErr string
+	}{
+		{
+			"trivial circular dependency",
+			[]packages.Package{
+				createPackage("A", "A"),
+			},
+			[]string{},
+			"cyclic package dependency found when adding package A--",
+		},
+		{
+			"circular dependency",
+			[]packages.Package{
+				createPackage("A", "B"),
+				createPackage("B", "A"),
+			},
+			[]string{},
+			"cyclic package dependency found when adding package A--",
+		},
+		{
+			"unknown dependency",
+			[]packages.Package{
+				createPackage("A", "B"),
+			},
+			[]string{},
+			"failed to resolve package B--, dependency of package A--: package not found",
+		},
+		{
+			"simple dependency",
+			[]packages.Package{
+				createPackage("A", "B"),
+				createPackage("B", "C"),
+				createPackage("C"),
+			},
+			[]string{"A", "B", "C"},
+			"",
+		},
+		{
+			"complex dependency",
+			[]packages.Package{
+				createPackage("A", "C", "D"),
+				createPackage("B", "C", "E"),
+				createPackage("C", "D"),
+				createPackage("D", "E"),
+				createPackage("E"),
+			},
+			[]string{"A", "C", "D", "E"},
+			"",
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+
+		resolver := nameResolver{test.pkgs}
+
+		actual, err := gatherDependencies(*test.pkgs[0].Resources, resolver)
+		if err != nil {
+			if test.expectedErr == "" {
+				t.Errorf("%s: expected no error but got %v", test.name, err)
+			}
+
+			assert.EqualError(t, err, test.expectedErr, test.name)
+		} else {
+			if test.expectedErr != "" {
+				t.Errorf("%s: expected an error but got none", test.name)
+			}
+
+			for _, operatorName := range test.expected {
+				operatorName := operatorName
+
+				assert.NotNil(t, funk.Find(actual, func(p packages.Resources) bool {
+					return p.Operator.Name == operatorName
+				}), test.name)
+			}
+		}
+	}
+}

--- a/pkg/kudoctl/packages/install/dependencies_test.go
+++ b/pkg/kudoctl/packages/install/dependencies_test.go
@@ -148,7 +148,7 @@ func TestGatherDependencies(t *testing.T) {
 				createPackage("F"),
 			},
 			expectedDeps: []string{},
-			expectedErr:  "",
+			expectedErr:  "cyclic package dependency found when adding package B-:",
 		},
 	}
 

--- a/pkg/kudoctl/packages/install/dependencies_test.go
+++ b/pkg/kudoctl/packages/install/dependencies_test.go
@@ -38,7 +38,11 @@ func createPackage(name string, dependencies ...string) packages.Package {
 					Name: name,
 				},
 			},
-			OperatorVersion: &v1beta1.OperatorVersion{},
+			OperatorVersion: &v1beta1.OperatorVersion{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: v1beta1.OperatorVersionName(name, ""),
+				},
+			},
 		},
 	}
 
@@ -73,7 +77,7 @@ func TestGatherDependencies(t *testing.T) {
 				createPackage("A", "A"),
 			},
 			expectedDeps: []string{},
-			expectedErr:  "cyclic package dependency found when adding package A--",
+			expectedErr:  "cyclic package dependency found when adding package A-:",
 		},
 		{
 			// A <---> B
@@ -83,7 +87,7 @@ func TestGatherDependencies(t *testing.T) {
 				createPackage("B", "A"),
 			},
 			expectedDeps: []string{},
-			expectedErr:  "cyclic package dependency found when adding package B--",
+			expectedErr:  "cyclic package dependency found when adding package B-:",
 		},
 		{
 			// A ---> (B)
@@ -92,7 +96,7 @@ func TestGatherDependencies(t *testing.T) {
 				createPackage("A", "B"),
 			},
 			expectedDeps: []string{},
-			expectedErr:  "failed to resolve package B--, dependency of package A--: package not found",
+			expectedErr:  "failed to resolve package B-:, dependency of package A-:: package not found",
 		},
 		{
 			// A ---> B ---> C

--- a/pkg/kudoctl/packages/install/dependencies_test.go
+++ b/pkg/kudoctl/packages/install/dependencies_test.go
@@ -83,7 +83,7 @@ func TestGatherDependencies(t *testing.T) {
 				createPackage("B", "A"),
 			},
 			[]string{},
-			"cyclic package dependency found when adding package A--",
+			"cyclic package dependency found when adding package B--",
 		},
 		{
 			// A ---> (B)

--- a/pkg/kudoctl/packages/install/dependencies_test.go
+++ b/pkg/kudoctl/packages/install/dependencies_test.go
@@ -67,6 +67,7 @@ func TestGatherDependencies(t *testing.T) {
 		expectedErr string
 	}{
 		{
+			// A <---> A
 			"trivial circular dependency",
 			[]packages.Package{
 				createPackage("A", "A"),
@@ -75,6 +76,7 @@ func TestGatherDependencies(t *testing.T) {
 			"cyclic package dependency found when adding package A--",
 		},
 		{
+			// A <---> B
 			"circular dependency",
 			[]packages.Package{
 				createPackage("A", "B"),
@@ -84,6 +86,7 @@ func TestGatherDependencies(t *testing.T) {
 			"cyclic package dependency found when adding package A--",
 		},
 		{
+			// A ---> (B)
 			"unknown dependency",
 			[]packages.Package{
 				createPackage("A", "B"),
@@ -92,6 +95,7 @@ func TestGatherDependencies(t *testing.T) {
 			"failed to resolve package B--, dependency of package A--: package not found",
 		},
 		{
+			// A ---> B ---> C
 			"simple dependency",
 			[]packages.Package{
 				createPackage("A", "B"),
@@ -102,6 +106,15 @@ func TestGatherDependencies(t *testing.T) {
 			"",
 		},
 		{
+			//        B -----
+			//        |      \
+			//        |      |
+			//        v      |
+			// A ---> C      |
+			// |      |      |
+			// |      |      |
+			// \      v      v
+			//  ----> D ---> E
 			"complex dependency",
 			[]packages.Package{
 				createPackage("A", "C", "D"),

--- a/pkg/kudoctl/packages/install/dependencies_test.go
+++ b/pkg/kudoctl/packages/install/dependencies_test.go
@@ -61,10 +61,10 @@ func createPackage(name string, dependencies ...string) packages.Package {
 
 func TestGatherDependencies(t *testing.T) {
 	tests := []struct {
-		name        string
-		pkgs        []packages.Package
-		expected    []string
-		expectedErr string
+		name         string
+		pkgs         []packages.Package
+		expectedDeps []string
+		expectedErr  string
 	}{
 		{
 			// A <---> A
@@ -102,7 +102,7 @@ func TestGatherDependencies(t *testing.T) {
 				createPackage("B", "C"),
 				createPackage("C"),
 			},
-			[]string{"A", "B", "C"},
+			[]string{"B", "C"},
 			"",
 		},
 		{
@@ -123,7 +123,7 @@ func TestGatherDependencies(t *testing.T) {
 				createPackage("D", "E"),
 				createPackage("E"),
 			},
-			[]string{"A", "C", "D", "E"},
+			[]string{"C", "D", "E"},
 			"",
 		},
 	}
@@ -145,7 +145,7 @@ func TestGatherDependencies(t *testing.T) {
 				t.Errorf("%s: expected an error but got none", test.name)
 			}
 
-			for _, operatorName := range test.expected {
+			for _, operatorName := range test.expectedDeps {
 				operatorName := operatorName
 
 				assert.NotNil(t, funk.Find(actual, func(p packages.Resources) bool {

--- a/pkg/kudoctl/packages/install/package.go
+++ b/pkg/kudoctl/packages/install/package.go
@@ -65,6 +65,9 @@ func Package(
 	}
 
 	for _, dependency := range dependencies {
+		dependency.Operator.SetNamespace(namespace)
+		dependency.OperatorVersion.SetNamespace(namespace)
+
 		if err := installOperatorAndOperatorVersion(client, dependency); err != nil {
 			return err
 		}

--- a/pkg/kudoctl/packages/install/package.go
+++ b/pkg/kudoctl/packages/install/package.go
@@ -7,6 +7,7 @@ import (
 	"github.com/kudobuilder/kudo/pkg/apis/kudo/v1beta1"
 	"github.com/kudobuilder/kudo/pkg/kudoctl/clog"
 	"github.com/kudobuilder/kudo/pkg/kudoctl/packages"
+	"github.com/kudobuilder/kudo/pkg/kudoctl/packages/resolver"
 	"github.com/kudobuilder/kudo/pkg/kudoctl/util/kudo"
 )
 
@@ -23,12 +24,16 @@ type Options struct {
 // Instance name, namespace and operator parameters are applied to the
 // operator package resources. These rendered resources are then created
 // on the Kubernetes cluster.
+// Packages can have dependencies on other packages. In that case,
+// dependent packages are resolved and their Operator and
+// Operatorversion resources created on the Kubernetes cluster.
 func Package(
 	client *kudo.Client,
 	instanceName string,
 	namespace string,
 	resources packages.Resources,
 	parameters map[string]string,
+	resolver resolver.Resolver,
 	options Options) error {
 	clog.V(3).Printf(
 		"Preparing %s/%s:%s for installation",
@@ -50,6 +55,17 @@ func Package(
 
 	if options.CreateNamespace {
 		if err := installNamespace(client, resources, parameters); err != nil {
+			return err
+		}
+	}
+
+	dependencies, err := gatherDependencies(resources, resolver)
+	if err != nil {
+		return err
+	}
+
+	for _, dependency := range dependencies {
+		if err := installOperatorAndOperatorVersion(client, dependency); err != nil {
 			return err
 		}
 	}

--- a/pkg/kudoctl/packages/install/package_test.go
+++ b/pkg/kudoctl/packages/install/package_test.go
@@ -101,7 +101,7 @@ func Test_InstallPackage(t *testing.T) {
 			SkipInstance: tt.skipInstance,
 		}
 
-		err := Package(kc, "", namespace, testResources, tt.installParameters, options)
+		err := Package(kc, "", namespace, testResources, tt.installParameters, nil, options)
 		if tt.err != "" {
 			assert.EqualError(t, err, tt.err)
 		}

--- a/pkg/kudoctl/packages/resolver/resolver.go
+++ b/pkg/kudoctl/packages/resolver/resolver.go
@@ -10,7 +10,7 @@ import (
 // Resolver will try to resolve a given package name to either local tarball, folder, remote url or
 // an operator in the remote repository.
 type Resolver interface {
-	Resolve(name string, version string) (*packages.Package, error)
+	Resolve(name string, appVersion string, operatorVersion string) (*packages.Package, error)
 }
 
 // PackageResolver is the source of resolver of operator packages.

--- a/test/integration/operator-with-dependencies/01-install.yaml
+++ b/test/integration/operator-with-dependencies/01-install.yaml
@@ -1,7 +1,5 @@
 apiVersion: kudo.dev/v1beta1
 kind: TestStep
 commands:
-  - command: kubectl kudo install --skip-instance ./child-operator
-    namespaced: true
   - command: kubectl kudo install --instance dummy-instance ./parent-operator
     namespaced: true

--- a/test/integration/operator-with-dependencies/parent-operator/operator.yaml
+++ b/test/integration/operator-with-dependencies/parent-operator/operator.yaml
@@ -10,6 +10,7 @@ tasks:
   - name: deploy-child
     kind: KudoOperator
     spec:
+      package: "./child-operator"
       operatorName: child
       operatorVersion: 0.0.1
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kudo/blob/master/CONTRIBUTING.md
2. Make sure you have added and ran the tests before submitting your PR
3. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What this PR does / why we need it**:
When installing an operator package using the KUDO CLI, operator dependencies can be provided as _KudoOperator_ tasks. For each of these tasks, the respective package is resolved and its `Operator` and `OperatorVersion` installed on the cluster. Because dependent package can also have dependencies on packages, dependencies are resolved recursively. Cyclic dependencies are detected by modeling the dependencies as a directed graph and checking this graph for cycles when new dependencies are added.

<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes part of #1514

Co-authored-by: Aleksey Dukhovniy <adukhovniy@mesosphere.io>