### PR TITLE
Fail kudo init if version is unknown.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ DOCKER_IMG ?= kudobuilder/controller
 EXECUTABLE := manager
 CLI := kubectl-kudo
 GIT_VERSION_PATH := github.com/kudobuilder/kudo/pkg/version.gitVersion
-GIT_VERSION := $(shell git describe --abbrev=0 --tags --candidates=0 || echo not-built-on-tag)
+GIT_VERSION := $(shell git describe --abbrev=0 --tags --candidates=0 2>/dev/null || echo not-built-on-release)
 GIT_COMMIT_PATH := github.com/kudobuilder/kudo/pkg/version.gitCommit
 GIT_COMMIT := $(shell git rev-parse HEAD | cut -b -8)
 SOURCE_DATE_EPOCH := $(shell git show -s --format=format:%ct HEAD)

--- a/Makefile
+++ b/Makefile
@@ -5,14 +5,14 @@ DOCKER_IMG ?= kudobuilder/controller
 EXECUTABLE := manager
 CLI := kubectl-kudo
 GIT_VERSION_PATH := github.com/kudobuilder/kudo/pkg/version.gitVersion
-GIT_VERSION := $(shell git describe --abbrev=0 --tags | cut -b 2-)
+GIT_VERSION := $(shell git describe --abbrev=0 --tags --candidates=0 || echo not-built-on-tag)
 GIT_COMMIT_PATH := github.com/kudobuilder/kudo/pkg/version.gitCommit
 GIT_COMMIT := $(shell git rev-parse HEAD | cut -b -8)
 SOURCE_DATE_EPOCH := $(shell git show -s --format=format:%ct HEAD)
 BUILD_DATE_PATH := github.com/kudobuilder/kudo/pkg/version.buildDate
 DATE_FMT := "%Y-%m-%dT%H:%M:%SZ"
 BUILD_DATE := $(shell date -u -d "@$SOURCE_DATE_EPOCH" "+${DATE_FMT}" 2>/dev/null || date -u -r "${SOURCE_DATE_EPOCH}" "+${DATE_FMT}" 2>/dev/null || date -u "+${DATE_FMT}")
-LDFLAGS := -X ${GIT_VERSION_PATH}=${GIT_VERSION} -X ${GIT_COMMIT_PATH}=${GIT_COMMIT} -X ${BUILD_DATE_PATH}=${BUILD_DATE}
+LDFLAGS := -X ${GIT_VERSION_PATH}=${GIT_VERSION:v%=%} -X ${GIT_COMMIT_PATH}=${GIT_COMMIT} -X ${BUILD_DATE_PATH}=${BUILD_DATE}
 GOLANGCI_LINT_VER = "1.23.8"
 SUPPORTED_PLATFORMS = amd64 arm64
 

--- a/pkg/kudoctl/cmd/init.go
+++ b/pkg/kudoctl/cmd/init.go
@@ -142,6 +142,8 @@ func (initCmd *initCmd) run() error {
 	// if image provided switch to it.
 	if initCmd.image != "" {
 		opts.Image = initCmd.image
+	} else if opts.Version == "not-built-on-tag" {
+		return errors.New("non-release build detected, please override controller image version")
 	}
 	if initCmd.imagePullPolicy != "" {
 		switch initCmd.imagePullPolicy {

--- a/pkg/kudoctl/cmd/init.go
+++ b/pkg/kudoctl/cmd/init.go
@@ -142,8 +142,8 @@ func (initCmd *initCmd) run() error {
 	// if image provided switch to it.
 	if initCmd.image != "" {
 		opts.Image = initCmd.image
-	} else if opts.Version == "not-built-on-tag" {
-		return errors.New("cannot infer controller docker image to use, please override with --kudo-image")
+	} else if opts.Version == "not-built-on-release" {
+		return errors.New("cannot infer controller docker image to use - not a released binary; please override with a command-line flag")
 	}
 	if initCmd.imagePullPolicy != "" {
 		switch initCmd.imagePullPolicy {

--- a/pkg/kudoctl/cmd/init.go
+++ b/pkg/kudoctl/cmd/init.go
@@ -143,7 +143,7 @@ func (initCmd *initCmd) run() error {
 	if initCmd.image != "" {
 		opts.Image = initCmd.image
 	} else if opts.Version == "not-built-on-tag" {
-		return errors.New("non-release build detected, please override controller image version")
+		return errors.New("cannot infer controller docker image to use, please override with --kudo-image")
 	}
 	if initCmd.imagePullPolicy != "" {
 		switch initCmd.imagePullPolicy {

--- a/pkg/kudoctl/cmd/init_integration_test.go
+++ b/pkg/kudoctl/cmd/init_integration_test.go
@@ -111,6 +111,7 @@ func TestIntegInitForCRDs(t *testing.T) {
 		fs:      afero.NewMemMapFs(),
 		client:  kclient,
 		crdOnly: true,
+		version: "dev",
 	}
 	err = cmd.run()
 	assert.NoError(t, err)
@@ -156,6 +157,7 @@ func TestIntegInitWithNameSpace(t *testing.T) {
 		client:              kclient,
 		ns:                  namespace,
 		selfSignedWebhookCA: true,
+		version:             "dev",
 	}
 
 	// On first attempt, the namespace does not exist, so the error is expected.
@@ -282,6 +284,7 @@ func TestInitWithServiceAccount(t *testing.T) {
 				ns:                  namespace,
 				serviceAccount:      "test-account",
 				selfSignedWebhookCA: true,
+				version:             "dev",
 			}
 
 			ns := testutils.NewResource("v1", "Namespace", namespace, "")
@@ -368,6 +371,7 @@ func TestNoErrorOnReInit(t *testing.T) {
 		fs:      afero.NewMemMapFs(),
 		client:  kclient,
 		crdOnly: true,
+		version: "dev",
 	}
 	err = cmd.run()
 	assert.NoError(t, err)

--- a/pkg/kudoctl/cmd/init_test.go
+++ b/pkg/kudoctl/cmd/init_test.go
@@ -50,6 +50,7 @@ func TestInitCmd_exists(t *testing.T) {
 		out:                 &buf,
 		fs:                  afero.NewMemMapFs(),
 		client:              &kube.Client{KubeClient: fc, ExtClient: fc2},
+		image:               "fake",
 		selfSignedWebhookCA: true,
 	}
 	clog.InitWithFlags(nil, &buf)
@@ -81,11 +82,12 @@ func TestInitCmd_output(t *testing.T) {
 		var buf bytes.Buffer
 		var errOut bytes.Buffer
 		cmd := &initCmd{
-			out:    &buf,
-			errOut: &errOut,
-			client: client,
-			output: s,
-			dryRun: true,
+			out:     &buf,
+			errOut:  &errOut,
+			client:  client,
+			output:  s,
+			dryRun:  true,
+			version: "dev",
 		}
 		// ensure that we can marshal
 		if err := cmd.run(); err != nil {
@@ -159,9 +161,9 @@ func TestInitCmd_yamlOutput(t *testing.T) {
 		goldenFile string
 		flags      map[string]string
 	}{
-		{"custom namespace", "deploy-kudo-ns.yaml", map[string]string{"dry-run": "true", "output": "yaml", "namespace": "foo"}},
-		{"yaml output", "deploy-kudo.yaml", map[string]string{"dry-run": "true", "output": "yaml"}},
-		{"service account", "deploy-kudo-sa.yaml", map[string]string{"dry-run": "true", "output": "yaml", "service-account": "safoo", "namespace": "foo"}},
+		{"custom namespace", "deploy-kudo-ns.yaml", map[string]string{"dry-run": "true", "output": "yaml", "namespace": "foo", "version": "dev"}},
+		{"yaml output", "deploy-kudo.yaml", map[string]string{"dry-run": "true", "output": "yaml", "version": "dev"}},
+		{"service account", "deploy-kudo-sa.yaml", map[string]string{"dry-run": "true", "output": "yaml", "service-account": "safoo", "namespace": "foo", "version": "dev"}},
 	}
 
 	for _, tt := range tests {

--- a/pkg/kudoctl/cmd/testdata/newop/operator.yaml.golden
+++ b/pkg/kudoctl/cmd/testdata/newop/operator.yaml.golden
@@ -1,5 +1,5 @@
 apiVersion: kudo.dev/v1beta1
-kudoVersion: dev
+kudoVersion: not-built-on-release
 name: newop
 operatorVersion: 0.1.0
 plans: {}

--- a/pkg/kudoctl/kudoinit/options.go
+++ b/pkg/kudoctl/kudoinit/options.go
@@ -27,6 +27,9 @@ type Options struct {
 func NewOptions(v string, ns string, sa string, selfSignedWebhookCA bool) Options {
 	if v == "" {
 		v = version.Get().GitVersion
+		if v == "not-built-on-tag" {
+			panic("non-release build detected, please override version manually")
+		}
 	}
 	if ns == "" {
 		ns = DefaultNamespace

--- a/pkg/kudoctl/kudoinit/options.go
+++ b/pkg/kudoctl/kudoinit/options.go
@@ -27,9 +27,6 @@ type Options struct {
 func NewOptions(v string, ns string, sa string, selfSignedWebhookCA bool) Options {
 	if v == "" {
 		v = version.Get().GitVersion
-		if v == "not-built-on-tag" {
-			panic("non-release build detected, please override version manually")
-		}
 	}
 	if ns == "" {
 		ns = DefaultNamespace

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -36,10 +36,9 @@ func Get() Info {
 		// on dev box, lets use a env var for version
 		gitVersion = os.Getenv("KUDO_DEV_VERSION")
 		if gitVersion == "" {
-			gitVersion = "dev"
+			gitVersion = "not-built-on-release"
 		}
 		gitCommit = "dev"
-		//TODO (kensipe): add debug message!
 	}
 
 	return Info{


### PR DESCRIPTION
**What this PR does / why we need it**:

This hopefully should have no impact on developer workflows nor on how a (pre-)released build works. However in cases where a matching controller docker image does not exist, it will fail fast, rather than deploying a (potentially incompatible) controller from a docker image built for some earlier commit.

Implementation:
- first, set `pkg/version.gitVersion` to a version string using `$LDFLAGS` only when a tagged commit is checked out (this will always be true for release builds). In other cases, set it to a sentinel value.
- then refuse to `kudo init` unless the sentinel value is overridden explicitly.

<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1549 

Signed-off-by: Marcin Owsiany <mowsiany@D2iQ.com>