### PR TITLE
Set operator name of 'KudoOperator' tasks for dependencies

### DIFF
--- a/pkg/kudoctl/packages/install/dependencies.go
+++ b/pkg/kudoctl/packages/install/dependencies.go
@@ -133,7 +133,7 @@ func dependencyWalk(
 // its index or -1 if not found.
 func indexOf(dependencies *[]Dependency, dependency *Dependency) int {
 	for i, d := range *dependencies {
-		if p.OperatorVersion.EqualOperatorVersion(dependency.OperatorVersion) {
+		if d.OperatorVersion.EqualOperatorVersion(dependency.OperatorVersion) {
 			return i
 		}
 	}

--- a/pkg/kudoctl/packages/install/dependencies.go
+++ b/pkg/kudoctl/packages/install/dependencies.go
@@ -67,9 +67,7 @@ func gatherDependencies(root packages.Resources, resolver pkgresolver.Resolver) 
 	}
 
 	// Remove 'root' from the list of dependencies.
-	dependencies = funk.Drop(dependencies, 1).([]Dependency) //nolint:errcheck
-
-	return dependencies, nil
+	return dependencies[1:], nil
 }
 
 func dependencyWalk(

--- a/pkg/kudoctl/packages/install/dependencies.go
+++ b/pkg/kudoctl/packages/install/dependencies.go
@@ -132,7 +132,7 @@ func dependencyWalk(
 // OperatorVersion/AppVersion (using EqualOperatorVersion method) and returns
 // its index or -1 if not found.
 func indexOf(dependencies *[]Dependency, dependency *Dependency) int {
-	for i, p := range *dependencies {
+	for i, d := range *dependencies {
 		if p.OperatorVersion.EqualOperatorVersion(dependency.OperatorVersion) {
 			return i
 		}

--- a/pkg/kudoctl/packages/install/dependencies_test.go
+++ b/pkg/kudoctl/packages/install/dependencies_test.go
@@ -187,8 +187,8 @@ func TestGatherDependencies(t *testing.T) {
 			for _, operatorName := range tt.want {
 				operatorName := operatorName
 
-				assert.NotNil(t, funk.Find(got, func(p packages.Resources) bool {
-					return p.Operator.Name == operatorName
+				assert.NotNil(t, funk.Find(got, func(dep Dependency) bool {
+					return dep.Operator.Name == operatorName
 				}), tt.name)
 			}
 		})

--- a/pkg/kudoctl/packages/install/package.go
+++ b/pkg/kudoctl/packages/install/package.go
@@ -65,13 +65,13 @@ func Package(
 		return err
 	}
 
-	updateOperatorTasks(dependencies, resources.OperatorVersion)
+	updateKudoOperatorTaskPackageNames(dependencies, resources.OperatorVersion)
 
 	for _, dependency := range dependencies {
 		dependency.Operator.SetNamespace(namespace)
 		dependency.OperatorVersion.SetNamespace(namespace)
 
-		updateOperatorTasks(dependencies, dependency.OperatorVersion)
+		updateKudoOperatorTaskPackageNames(dependencies, dependency.OperatorVersion)
 
 		if err := installOperatorAndOperatorVersion(client, dependency.Resources); err != nil {
 			return err

--- a/pkg/kudoctl/packages/install/package.go
+++ b/pkg/kudoctl/packages/install/package.go
@@ -65,6 +65,16 @@ func Package(
 		return err
 	}
 
+	// The KUDO controller will create Instances for the dependencies. For this
+	// it needs to resolve the dependencies again from 'KudoOperatorTaskSpec'.
+	// But it cannot resolve packages like the CLI, because it may
+	// not have access to the referenced local files or URLs.
+	// It can however resolve the OperatorVersion from the name of the operator
+	// dependency. For this, we overwrite the 'Package' field describing
+	// dependencies in 'KudoOperatorTaskSpec' with the operator name of the
+	// dependency. This has to be done for the operator to install as well as in
+	// all of its dependencies.
+
 	updateKudoOperatorTaskPackageNames(dependencies, resources.OperatorVersion)
 
 	for _, dependency := range dependencies {
@@ -145,6 +155,9 @@ func validateParameters(instance v1beta1.Instance, parameters []v1beta1.Paramete
 	return nil
 }
 
+// updateKudoOperatorTaskPackageNames sets the 'Package' and 'OperatorName'
+// fields of the 'KudoOperatorTaskSpec' of an 'OperatorVersion' to the operator name
+// initially referenced in the 'Package' field.
 func updateKudoOperatorTaskPackageNames(pkgs []Dependency, operatorVersion *v1beta1.OperatorVersion) {
 	tasks := operatorVersion.Spec.Tasks
 

--- a/pkg/kudoctl/packages/install/package.go
+++ b/pkg/kudoctl/packages/install/package.go
@@ -145,7 +145,7 @@ func validateParameters(instance v1beta1.Instance, parameters []v1beta1.Paramete
 	return nil
 }
 
-func updateOperatorTasks(pkgs []Dependency, operatorVersion *v1beta1.OperatorVersion) {
+func updateKudoOperatorTaskPackageNames(pkgs []Dependency, operatorVersion *v1beta1.OperatorVersion) {
 	tasks := operatorVersion.Spec.Tasks
 
 	for i := range tasks {

--- a/test/integration/operator-with-dependencies/01-assert.yaml
+++ b/test/integration/operator-with-dependencies/01-assert.yaml
@@ -1,4 +1,16 @@
 apiVersion: kudo.dev/v1beta1
+kind: OperatorVersion
+metadata:
+  name: parent-0.1.0
+spec:
+  tasks:
+    - name: deploy-child
+      kind: KudoOperator
+      spec:
+        package: child
+        operatorName: child
+---
+apiVersion: kudo.dev/v1beta1
 kind: Instance
 metadata:
   name: dummy-instance

--- a/test/integration/operator-with-dependencies/parent-operator/operator.yaml
+++ b/test/integration/operator-with-dependencies/parent-operator/operator.yaml
@@ -11,7 +11,6 @@ tasks:
     kind: KudoOperator
     spec:
       package: "./child-operator"
-      operatorName: child
       operatorVersion: 0.0.1
 
 plans:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kudo/blob/master/CONTRIBUTING.md
2. Make sure you have added and ran the tests before submitting your PR
3. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What this PR does / why we need it**:
Package dependencies can reference operator packages from local files or arbitrary URLs. KUDO's controller doesn't know about the origin of packages once they have been resolved. But it needs to resolve instances from `KudoOperator` tasks. To solve this, the `Package` and `OperatorName` of these tasks are updated with the operator name before they are applied on a cluster.

<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
