### PR TITLE
Installing Local Operators Requires Abs or relative notation

### DIFF
--- a/pkg/kudoctl/cmd/install.go
+++ b/pkg/kudoctl/cmd/install.go
@@ -15,7 +15,7 @@ var (
   or a path to an unpacked package directory.
 
   # Install the most recent Flink package to your cluster.
-  kubectl kudo install flink
+  kubectl kudo install ./flink
   #*Note*: should you have a local  "flink" folder in the current directory it will take precedence over the remote repository.
 
   # Install operator from a local filesystem

--- a/pkg/kudoctl/packages/resolver/resolver.go
+++ b/pkg/kudoctl/packages/resolver/resolver.go
@@ -39,8 +39,10 @@ func New(repo *repo.Client) *PackageResolver {
 // - a local directory
 // - a url to a tgz
 // - an operator name in the remote repository
-// in that order. Should there exist a local folder e.g. `cassandra` it will take precedence
-// over the remote repository package with the same name.
+// in that order.
+// For local access there is a need to provide absolute or relative path as part of the name argument. `cassandra` without a path
+// component will resolve to the remote repo.  `./cassandra` will resolve to a folder which is expected to have the operator structure on the filesystem.
+// `../folder/cassandra.tgz` will resolve to the cassandra package tarball on the filesystem.
 func (m *PackageResolver) Resolve(name string, appVersion string, operatorVersion string) (p *packages.Package, err error) {
 
 	// Local files/folder have priority

--- a/pkg/kudoctl/packages/resolver/resolver.go
+++ b/pkg/kudoctl/packages/resolver/resolver.go
@@ -47,7 +47,7 @@ func (m *PackageResolver) Resolve(name string, appVersion string, operatorVersio
 	_, err = m.local.fs.Stat(name)
 	// force local operators usage to be either absolute or express a relative path
 	// or put another way, a name can NOT be mistaken to be the name of a local folder
-	if filepath.IsAbs(name) || (filepath.Base(name) != name && err == nil) {
+	if filepath.Base(name) != name && err == nil {
 		var abs string
 		abs, err = filepath.Abs(name)
 		if err != nil {


### PR DESCRIPTION
Please read #1557 for full context.   There has been confusion around specifying an operator name which is the same name as a folder in the CWD.  The issue makes a lot of sense.  There were a number of suggestions including sending details to STDOUT.

I'm not a fan of noisy CLIs... the information is there if you increase verbosity (`-v=2`).

The biggest issue is that if there is a folder with the same name as an operator, it is assumed to be what the user wants... all that was previously necessary is that `fs.Stat(name)` passes..  If this condition exists,  there is no attempt to go to a repo etc.

The change makes necessary to specify a local operator with more than just a name... if it is in the CWD than `install ./foo` or `install ./foo.tgz` is necessary.  It requires that more than the base name (go parlance) be supplied.  It also accepts an absolute path.  2 things are now required... 1) it isn't just a filename and 2) the file or folder exists.

Signed-off-by: Ken Sipe <kensipe@gmail.com>

Fixes #1557 
