### PR TITLE
Updatable webhook target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -166,3 +166,7 @@ todo:
 		--text \
 		--color \
 		-nRo -E " *[^\.]TODO.*|SkipNow" .
+
+.PHONY: update-wh
+update-wh:
+	./hack/update-webhook-config.sh 

--- a/config/admit-wh.yaml
+++ b/config/admit-wh.yaml
@@ -1,0 +1,23 @@
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  creationTimestamp: null
+  name: kudo-manager-instance-admission-webhook-config
+webhooks:
+- clientConfig:    
+    url: http://8c32c6c5bea7.ngrok.io/admit-kudo-dev-v1beta1-instance
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: instance-admission.kudo.dev
+  rules:
+  - apiGroups:
+    - kudo.dev
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - instances
+    scope: Namespaced
+  sideEffects: None

--- a/hack/update-webhook-config.sh
+++ b/hack/update-webhook-config.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+if ! command -v curl &> /dev/null
+then
+    echo "curl command NOT found"
+    exit 1
+fi
+
+
+CODE=`curl -s -o /dev/null -w "%{http_code}" localhost:4040`
+
+
+case "$CODE" in 
+    "000") 
+        echo "ngrok server is not up."
+        exit 1;;
+
+    "302") echo "ngrok up and running" ;;
+esac
+
+if ! command -v yq &> /dev/null
+then
+    echo "yq command NOT found"
+    exit 1
+fi
+
+#  need to update the webhook url to the current tunnel.  ngrok array order changes requiring a tunnel select for https and pull the public_url of that tunnel
+#  template webfile located at: config/admit-wh.yaml relative to the project root
+yq  w config/admit-wh.yaml webhooks[0].clientConfig.url "`curl -s localhost:4040/api/tunnels | jq '.tunnels[] | select(.proto == "https") | .public_url' -r`/admit-kudo-dev-v1beta1-instance" | kubectl apply -f -


### PR DESCRIPTION
Signed-off-by: Ken Sipe <kensipe@gmail.com>

For now, this provides a convenient way to update the tunnel to the webhook.  I would like to ensure that the manifest is from the current kudo cli.  The likelihood that this will change is low.