### PR TITLE
Darwin 32-bit is not supported any longer

### DIFF
--- a/hack/generate_krew.sh
+++ b/hack/generate_krew.sh
@@ -74,7 +74,6 @@ EOF
 generate_platform linux amd64 ./kubectl-kudo >> kudo.yaml
 generate_platform linux 386 ./kubectl-kudo >> kudo.yaml
 generate_platform darwin amd64 ./kubectl-kudo >> kudo.yaml
-generate_platform darwin 386 ./kubectl-kudo >> kudo.yaml
 
 ### KUDO is not currently built for Windows. Uncomment once it is.
 # generate_platform windows amd64 ./kubectl-kudo.exe >> kudo.yaml


### PR DESCRIPTION
Our release process removed the 32-bit darwin several releases ago... but the krew files still referenced it and needs to be removed.

Signed-off-by: Ken Sipe <kensipe@gmail.com>
