### PR TITLE
Mark instance as required parameter for diagnostics

### DIFF
--- a/pkg/kudoctl/cmd/diagnostics.go
+++ b/pkg/kudoctl/cmd/diagnostics.go
@@ -46,5 +46,7 @@ func newDiagnosticsCollectCmd(fs afero.Fs) *cobra.Command {
 	cmd.Flags().StringVar(&instance, "instance", "", "The instance name.")
 	cmd.Flags().DurationVar(&logSince, "log-since", 0, "Only return logs newer than a relative duration like 5s, 2m, or 3h. Defaults to all logs.")
 
+	_ = cobra.MarkFlagRequired(cmd.Flags(), "instance")
+
 	return cmd
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kudo/blob/main/CONTRIBUTING.md
2. Make sure you have added and ran the tests before submitting your PR
3. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What this PR does / why we need it**:
Currently it is not required and yields the following error:

```
./bin/kubectl-kudo diagnostics collect
Collect Logs for 1 pods
Error: failed to get instance default/: resource name may not be empty
```