### PR TITLE
Allow custom output directory for diagnostics collection

### DIFF
--- a/pkg/kudoctl/cmd/diagnostics.go
+++ b/pkg/kudoctl/cmd/diagnostics.go
@@ -44,7 +44,7 @@ func newDiagnosticsCollectCmd(fs afero.Fs) *cobra.Command {
 			return diagnostics.Collect(fs, instance, diagnostics.NewOptions(logSince, outputDir), c, &Settings)
 		},
 	}
-	cmd.Flags().StringVarP(&outputDir, "output-directory", "-O", diagnostics.DefaultDiagDir, "The output directory. Defaults to 'diag'")
+	cmd.Flags().StringVarP(&outputDir, "output-directory", "O", diagnostics.DefaultDiagDir, "The output directory. Defaults to 'diag'")
 	cmd.Flags().StringVar(&instance, "instance", "", "The instance name.")
 	cmd.Flags().DurationVar(&logSince, "log-since", 0, "Only return logs newer than a relative duration like 5s, 2m, or 3h. Defaults to all logs.")
 

--- a/pkg/kudoctl/cmd/diagnostics.go
+++ b/pkg/kudoctl/cmd/diagnostics.go
@@ -44,7 +44,7 @@ func newDiagnosticsCollectCmd(fs afero.Fs) *cobra.Command {
 			return diagnostics.Collect(fs, instance, diagnostics.NewOptions(logSince, outputDir), c, &Settings)
 		},
 	}
-	cmd.Flags().StringVar(&outputDir, "outputDir", "", "The output directory. Defaults to 'diag'")
+	cmd.Flags().StringVarP(&outputDir, "output-directory", "-O", diagnostics.DefaultDiagDir, "The output directory. Defaults to 'diag'")
 	cmd.Flags().StringVar(&instance, "instance", "", "The instance name.")
 	cmd.Flags().DurationVar(&logSince, "log-since", 0, "Only return logs newer than a relative duration like 5s, 2m, or 3h. Defaults to all logs.")
 

--- a/pkg/kudoctl/cmd/diagnostics.go
+++ b/pkg/kudoctl/cmd/diagnostics.go
@@ -30,6 +30,7 @@ func newDiagnosticsCmd(fs afero.Fs) *cobra.Command {
 func newDiagnosticsCollectCmd(fs afero.Fs) *cobra.Command {
 	var logSince time.Duration
 	var instance string
+	var outputDir string
 	cmd := &cobra.Command{
 		Use:     "collect",
 		Short:   "collect diagnostics",
@@ -40,9 +41,10 @@ func newDiagnosticsCollectCmd(fs afero.Fs) *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("failed to create kudo client: %v", err)
 			}
-			return diagnostics.Collect(fs, instance, diagnostics.NewOptions(logSince), c, &Settings)
+			return diagnostics.Collect(fs, instance, diagnostics.NewOptions(logSince, outputDir), c, &Settings)
 		},
 	}
+	cmd.Flags().StringVar(&outputDir, "outputDir", "", "The output directory. Defaults to 'diag'")
 	cmd.Flags().StringVar(&instance, "instance", "", "The instance name.")
 	cmd.Flags().DurationVar(&logSince, "log-since", 0, "Only return logs newer than a relative duration like 5s, 2m, or 3h. Defaults to all logs.")
 

--- a/pkg/kudoctl/cmd/diagnostics/diagnostics.go
+++ b/pkg/kudoctl/cmd/diagnostics/diagnostics.go
@@ -13,15 +13,14 @@ import (
 	"github.com/kudobuilder/kudo/pkg/version"
 )
 
+const DefaultDiagDir = "diag"
+
 type Options struct {
 	LogSince  *int64
 	outputDir string
 }
 
 func (o *Options) DiagDir() string {
-	if o.outputDir == "" {
-		return "diag"
-	}
 	return o.outputDir
 }
 
@@ -29,8 +28,15 @@ func (o *Options) KudoDir() string {
 	return path.Join(o.DiagDir(), "kudo")
 }
 
+func NewDefaultOptions() *Options {
+	return &Options{
+		LogSince:  nil,
+		outputDir: DefaultDiagDir,
+	}
+}
+
 func NewOptions(logSince time.Duration, outputDir string) *Options {
-	opts := Options{}
+	opts := NewDefaultOptions()
 	if logSince > 0 {
 		sec := int64(logSince.Round(time.Second).Seconds())
 		opts.LogSince = &sec
@@ -38,7 +44,7 @@ func NewOptions(logSince time.Duration, outputDir string) *Options {
 	if outputDir != "" {
 		opts.outputDir = outputDir
 	}
-	return &opts
+	return opts
 }
 
 func Collect(fs afero.Fs, instance string, options *Options, c *kudo.Client, s *env.Settings) error {

--- a/pkg/kudoctl/cmd/diagnostics/diagnostics_test.go
+++ b/pkg/kudoctl/cmd/diagnostics/diagnostics_test.go
@@ -217,7 +217,8 @@ func TestCollect_OK(t *testing.T) {
 		assert.True(t, exists, "file %s not found", name)
 	}
 	_ = afero.Walk(fs, "diag", func(path string, info os.FileInfo, err error) error {
-		if !info.IsDir() {
+		assert.NotNil(t, info, "No FileInfo for %s", path)
+		if info != nil && !info.IsDir() {
 			_, ok := fileNames[path]
 			assert.True(t, ok, "unexpected file: %s", path)
 		}
@@ -469,6 +470,8 @@ func TestCollect_PrintFailure(t *testing.T) {
 }
 
 func TestCollect_DiagDirExists(t *testing.T) {
+	DiagDir := "diag"
+
 	k8cs := kubefake.NewSimpleClientset()
 	kcs := fake.NewSimpleClientset()
 	client := kudo.NewClientFromK8s(kcs, k8cs)
@@ -503,7 +506,7 @@ func TestNewOptions(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.desc, func(t *testing.T) {
-			opts := NewOptions(tt.logSince)
+			opts := NewOptions(tt.logSince, "diag")
 			assert.True(t, (tt.exp > 0) == (opts.LogSince != nil))
 			if tt.exp > 0 {
 				assert.Equal(t, tt.exp, *opts.LogSince)

--- a/pkg/kudoctl/cmd/diagnostics/print.go
+++ b/pkg/kudoctl/cmd/diagnostics/print.go
@@ -17,11 +17,6 @@ import (
 	"github.com/kudobuilder/kudo/pkg/kudoctl/util/kudo"
 )
 
-const (
-	DiagDir = "diag"
-	KudoDir = "diag/kudo"
-)
-
 type printMode string
 
 const (

--- a/pkg/kudoctl/cmd/diagnostics/runner_helper.go
+++ b/pkg/kudoctl/cmd/diagnostics/runner_helper.go
@@ -9,11 +9,11 @@ import (
 func diagForInstance(instance string, options *Options, c *kudo.Client, info version.Info, s *env.Settings, p *nonFailingPrinter) error {
 	ir, err := newInstanceResources(instance, options, c, s)
 	if err != nil {
-		p.printError(err, DiagDir, "instance")
+		p.printError(err, options.DiagDir(), "instance")
 		return err
 	}
 
-	ctx := &processingContext{root: DiagDir, instanceName: instance}
+	ctx := &processingContext{root: options.DiagDir(), instanceName: instance}
 
 	runner := runnerForInstance(ir, ctx)
 	runner.addObjDump(info, ctx.rootDirectory, "version")
@@ -25,7 +25,7 @@ func diagForInstance(instance string, options *Options, c *kudo.Client, info ver
 
 	deps, err := newDependenciesResources(instance, options, c, s)
 	if err != nil {
-		p.printError(err, DiagDir, "instance")
+		p.printError(err, options.DiagDir(), "instance")
 		return err
 	}
 
@@ -49,7 +49,7 @@ func diagForKudoManager(options *Options, c *kudo.Client, p *nonFailingPrinter) 
 	if err != nil {
 		return err
 	}
-	ctx := &processingContext{root: KudoDir}
+	ctx := &processingContext{root: options.KudoDir()}
 
 	runner := runnerForKudoManager(kr, ctx)
 


### PR DESCRIPTION
Signed-off-by: Andreas Neumann <aneumann@mesosphere.com>

**What this PR does / why we need it**:
Allow `kudo diagnostics collect --outputDir instance1` so we can collect multiple diagnostics in the same directory



