### PR TITLE
Don't log anything when validating dummy task

### DIFF
--- a/pkg/kudoctl/packages/convert/resources.go
+++ b/pkg/kudoctl/packages/convert/resources.go
@@ -3,7 +3,6 @@ package convert
 import (
 	"errors"
 	"fmt"
-	"log"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -125,7 +124,7 @@ func validateTask(t v1beta1.Task, templates map[string]string) []string {
 			resources = append(resources, t.Spec.ParameterFile)
 		}
 	case task.DummyTaskKind:
-		log.Printf("no validation for task kind %s implemented", t.Kind)
+		// Nothing to validate for Dummy Task
 	default:
 		errs = append(errs, fmt.Sprintf("unknown task kind %s", t.Kind))
 	}


### PR DESCRIPTION
Signed-off-by: Andreas Neumann <aneumann@mesosphere.com>


**What this PR does / why we need it**:

There's no need for this log - it might confuse people that this is something they need to fix or adjust. Maybe we should add a warning in the `package verify` if a Dummy Task is used, as it should be only used for debugging though.