### PR TITLE
Improve UX of kudo package new

### DIFF
--- a/pkg/kudoctl/cmd/generate/operator.go
+++ b/pkg/kudoctl/cmd/generate/operator.go
@@ -10,6 +10,8 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"github.com/kudobuilder/kudo/pkg/apis/kudo/v1beta1"
+	"github.com/kudobuilder/kudo/pkg/engine/task"
+	"github.com/kudobuilder/kudo/pkg/kudoctl/clog"
 	"github.com/kudobuilder/kudo/pkg/kudoctl/packages"
 	"github.com/kudobuilder/kudo/pkg/kudoctl/packages/reader"
 )
@@ -56,8 +58,36 @@ func Operator(fs afero.Fs, dir string, op *packages.OperatorFile, overwrite bool
 	}
 
 	// required empty settings
-	op.Tasks = []v1beta1.Task{}
+	op.Tasks = []v1beta1.Task{
+		{
+			Name: "deploy",
+			Kind: task.ApplyTaskKind,
+			Spec: v1beta1.TaskSpec{
+				ResourceTaskSpec: v1beta1.ResourceTaskSpec{
+					Resources: []string{},
+				},
+			},
+		},
+	}
+
 	op.Plans = make(map[string]v1beta1.Plan)
+	op.Plans["deploy"] = v1beta1.Plan{
+		Strategy: "serial",
+		Phases: []v1beta1.Phase{
+			{
+				Name:     "deploy",
+				Strategy: "serial",
+				Steps: []v1beta1.Step{
+					{
+						Name: "deploy",
+						Tasks: []string{
+							"deploy",
+						},
+					},
+				},
+			},
+		},
+	}
 
 	err = writeOperator(fs, dir, op)
 	if err != nil {
@@ -78,7 +108,14 @@ func Operator(fs afero.Fs, dir string, op *packages.OperatorFile, overwrite bool
 		APIVersion: reader.APIVersion,
 		Parameters: []packages.Parameter{},
 	}
-	return writeParameters(fs, dir, p)
+	err = writeParameters(fs, dir, p)
+	if err != nil {
+		return err
+	}
+
+	clog.V(0).Printf("Operator created. Use \n - package add parameter\n - package add plan\n - package add task\nor other package add commands to extend it.")
+
+	return nil
 }
 
 func writeParameters(fs afero.Fs, dir string, params packages.ParamsFile) error {

--- a/pkg/kudoctl/cmd/package_new.go
+++ b/pkg/kudoctl/cmd/package_new.go
@@ -62,6 +62,7 @@ func newPackageNewCmd(fs afero.Fs, out io.Writer) *cobra.Command {
 
 func (pkg *packageNewCmd) validateOperatorArg(args []string) error {
 	if pkg.interactive {
+		// For interactive mode we use a default package name that can be adjusted with the prompt
 		if len(args) > 1 {
 			return errors.New("expecting at most one argument - name of the operator")
 		}

--- a/pkg/kudoctl/cmd/package_new.go
+++ b/pkg/kudoctl/cmd/package_new.go
@@ -1,11 +1,13 @@
 package cmd
 
 import (
+	"errors"
 	"io"
 
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 
+	"github.com/kudobuilder/kudo/pkg/apis/kudo/v1beta1"
 	"github.com/kudobuilder/kudo/pkg/kudoctl/cmd/generate"
 	"github.com/kudobuilder/kudo/pkg/kudoctl/cmd/prompt"
 	"github.com/kudobuilder/kudo/pkg/kudoctl/packages"
@@ -39,10 +41,12 @@ func newPackageNewCmd(fs afero.Fs, out io.Writer) *cobra.Command {
 		Long:    pkgNewDesc,
 		Example: pkgNewExample,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := validateOperatorArg(args); err != nil {
+			if err := pkg.validateOperatorArg(args); err != nil {
 				return err
 			}
-			pkg.name = args[0]
+			if len(args) > 0 {
+				pkg.name = args[0]
+			}
 			if err := pkg.run(); err != nil {
 				return err
 			}
@@ -56,20 +60,45 @@ func newPackageNewCmd(fs afero.Fs, out io.Writer) *cobra.Command {
 	return cmd
 }
 
+func (pkg *packageNewCmd) validateOperatorArg(args []string) error {
+	if pkg.interactive {
+		if len(args) > 1 {
+			return errors.New("expecting at most one argument - name of the operator")
+		}
+		return nil
+	}
+
+	if len(args) != 1 {
+		return errors.New("expecting exactly one argument - name of the operator. Or use -i for interactive mode")
+	}
+	return nil
+}
+
 // run returns the errors associated with cmd env
 func (pkg *packageNewCmd) run() error {
 
 	// defaults
 	pathDefault := "operator"
 	opDefault := packages.OperatorFile{
-		Name:            pkg.name,
-		APIVersion:      reader.APIVersion,
-		OperatorVersion: "0.1.0",
-		KUDOVersion:     version.Get().GitVersion,
+		Name:              "myoperator",
+		APIVersion:        reader.APIVersion,
+		OperatorVersion:   "0.1.0",
+		AppVersion:        "0.1.0",
+		KUDOVersion:       version.Get().GitVersion,
+		KubernetesVersion: "0.16.0",
+	}
+
+	if pkg.name != "" {
+		opDefault.Name = pkg.name
 	}
 
 	if !pkg.interactive {
-
+		opDefault.Maintainers = []*v1beta1.Maintainer{
+			{
+				Name:  "My Name",
+				Email: "MyEmail@invalid",
+			},
+		}
 		return generate.Operator(pkg.fs, pathDefault, &opDefault, pkg.overwrite)
 	}
 
@@ -78,6 +107,13 @@ func (pkg *packageNewCmd) run() error {
 	if err != nil {
 		return err
 	}
+
+	// Query First maintainer
+	maintainer, err := prompt.ForMaintainer()
+	if err != nil {
+		return err
+	}
+	op.Maintainers = append(op.Maintainers, maintainer)
 
 	return generate.Operator(pkg.fs, path, op, pkg.overwrite)
 }

--- a/pkg/kudoctl/cmd/package_new_test.go
+++ b/pkg/kudoctl/cmd/package_new_test.go
@@ -66,14 +66,28 @@ func TestPackageNew_validation(t *testing.T) {
 		args         []string
 		errorMessage string
 	}{
-		{name: "0 argument", args: []string{}, errorMessage: "expecting exactly one argument - directory of the operator or name of package"},
-		{name: "2 arguments", args: []string{"1", "2"}, errorMessage: "expecting exactly one argument - directory of the operator or name of package"},
+		{name: "0 argument", args: []string{}, errorMessage: "expecting exactly one argument - name of the operator. Or use -i for interactive mode"},
+		{name: "1 argument", args: []string{"my-operator"}, errorMessage: ""},
+		{name: "2 arguments", args: []string{"1", "2"}, errorMessage: "expecting exactly one argument - name of the operator. Or use -i for interactive mode"},
+		{name: "2 arguments and -i", args: []string{"-i", "my-operator", "add"}, errorMessage: "expecting at most one argument - name of the operator"},
+
+		// These return ^D as error, because they start the interactive mode which can't be tested here
+		{name: "0 argument and -i", args: []string{"-i"}, errorMessage: "^D"},
+		{name: "1 argument and -i", args: []string{"my-operator", "-i"}, errorMessage: "^D"},
 	}
 
-	for _, test := range tests {
-		cmd := newPackageNewCmd(fs, out)
-		err := cmd.RunE(cmd, test.args)
-		assert.EqualError(t, err, test.errorMessage)
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := newPackageNewCmd(fs, out)
+			cmd.SetArgs(tt.args)
+			err := cmd.Execute()
+			if tt.errorMessage == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.EqualError(t, err, tt.errorMessage)
+			}
+		})
 	}
 
 }

--- a/pkg/kudoctl/cmd/prompt/operator.go
+++ b/pkg/kudoctl/cmd/prompt/operator.go
@@ -71,18 +71,24 @@ func ForOperator(fs afero.Fs, pathDefault string, overwrite bool, operatorDefaul
 		return nil, "", err
 	}
 
+	kubernetesVersion, err := WithDefault("Required Kubernetes Version", operatorDefault.KubernetesVersion)
+	if err != nil {
+		return nil, "", err
+	}
+
 	url, err := WithDefault("Project URL", "")
 	if err != nil {
 		return nil, "", err
 	}
 
 	op := packages.OperatorFile{
-		Name:            name,
-		APIVersion:      operatorDefault.APIVersion,
-		OperatorVersion: opVersion,
-		AppVersion:      appVersion,
-		KUDOVersion:     kudoVersion,
-		URL:             url,
+		Name:              name,
+		APIVersion:        operatorDefault.APIVersion,
+		OperatorVersion:   opVersion,
+		AppVersion:        appVersion,
+		KUDOVersion:       kudoVersion,
+		KubernetesVersion: kubernetesVersion,
+		URL:               url,
 	}
 	return &op, path, nil
 }
@@ -177,7 +183,7 @@ func ForParameter(planNames []string, paramNameList []string) (*packages.Paramet
 	}
 
 	//PlanNameList
-	if Confirm("Add Trigger Plan") {
+	if Confirm("Add Trigger Plan (defaults to deploy)") {
 		var trigger string
 		if len(planNames) == 0 {
 			trigger, err = WithDefault("Trigger Plan", "")

--- a/pkg/kudoctl/cmd/testdata/newop/operator.yaml.golden
+++ b/pkg/kudoctl/cmd/testdata/newop/operator.yaml.golden
@@ -1,6 +1,23 @@
 apiVersion: kudo.dev/v1beta1
+appVersion: 0.1.0
+kubernetesVersion: 0.16.0
 kudoVersion: not-built-on-release
+maintainers:
+- email: MyEmail@invalid
+  name: My Name
 name: newop
 operatorVersion: 0.1.0
-plans: {}
-tasks: []
+plans:
+  deploy:
+    phases:
+    - name: deploy
+      steps:
+      - name: deploy
+        tasks:
+        - deploy
+      strategy: serial
+    strategy: serial
+tasks:
+- kind: Apply
+  name: deploy
+  spec: {}


### PR DESCRIPTION
**What this PR does / why we need it**:
After starting prototyping on a new operator I stumbled over `kudo package new` - this PR improves a bit. I'm open for discussions, but this feels a lot better to me:

- When `kudo package new` finishes, print a message and let the user know about `kudo package add parameter` etc. I didn't know it/forgot about it.
- When `kudo package new` is called without params, let the user know about the "-i". (Because that's an amazing feature, but hard to find if you don't know about it)
- Allow `kudo package new` to be called with either an operator name, or `-i` - in interactive mode the operator name can be entered anyway
- Add KubernetesVersion and AppVersion
- Add a Default Maintainer when creating a new operator. It's easy to miss, and I'd rather have this in all newly created operators - I assume not many people will use `kudo package add maintainer`
- Add a "deploy" plan and "deploy" task on the initial operator skeleton. This was the first thing I really missed when using the generator - It's nice to have the `operator.yaml` file, but I want the basic structure of the plan/phase/step that I can copy, paste and adjust to my needs.
