### PR TITLE
update for goreleaser based on deprecation

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -95,7 +95,7 @@ archives:
     format: binary
 brews:
   - name: kudo-cli
-    github:
+    tap:
       owner: kudobuilder
       name: homebrew-tap
     commit_author:


### PR DESCRIPTION
https://goreleaser.com/deprecations/#brewsgithub

to test: `goreleaser check`

Signed-off-by: Ken Sipe <kensipe@gmail.com>
