### PR TITLE
Reject null parameter values rather than crash.

### DIFF
--- a/pkg/kudoctl/cmd/params/parser.go
+++ b/pkg/kudoctl/cmd/params/parser.go
@@ -90,6 +90,10 @@ func GetParametersFromFile(filePath string, bytes []byte, parameters map[string]
 			errs = append(errs, fmt.Sprintf("%s: %v", key, err))
 			continue
 		}
+		if wrapped == nil {
+			errs = append(errs, fmt.Sprintf("%s has a null value (https://yaml.org/spec/1.2/spec.html#id2803362) which is currently not supported", key))
+			continue
+		}
 		parameters[key] = *wrapped
 	}
 	if errs != nil {

--- a/pkg/kudoctl/cmd/params/parser_test.go
+++ b/pkg/kudoctl/cmd/params/parser_test.go
@@ -124,6 +124,16 @@ func TestGetParameterMap(t *testing.T) {
 				"A": "- foo: bar\n",
 			},
 		},
+		{
+			"regression test for #1602",
+			nil,
+			[]string{"param-file"},
+			map[string]string{
+				"param-file": "a:\nb: 1\n",
+			},
+			"errors while unmarshaling following keys of the parameter file param-file: a has a null value (https://yaml.org/spec/1.2/spec.html#id2803362) which is currently not supported",
+			nil,
+		},
 	}
 	for _, test := range tests {
 		test := test


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kudo/blob/main/CONTRIBUTING.md
2. Make sure you have added and ran the tests before submitting your PR
3. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What this PR does / why we need it**:

Reject in a human-friendly manner as below rather than panic with a stack trace.

```
$ kubectl kudo install kafka -P a.yaml 
Error: could not parse parameters: errors while unmarshaling following keys of the parameter file a.yaml: a has a null value (https://yaml.org/spec/1.2/spec.html#id2803362) which is currently not supported
$ echo $?
255
```


<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1602