### PR TITLE
Fix in-cluster resolver to properly resolve x-ns OV/I resources

### DIFF
--- a/pkg/controller/instance/instance_controller.go
+++ b/pkg/controller/instance/instance_controller.go
@@ -263,7 +263,7 @@ func (r *Reconciler) resolveDependencies(i *kudov1beta1.Instance, ov *kudov1beta
 	if i.IsChildInstance() {
 		return nil
 	}
-	resolver := &InClusterResolver{ns: i.Namespace, c: r.Client}
+	resolver := &InClusterResolver{ns: ov.Namespace, c: r.Client}
 
 	_, err := dependencies.Resolve(ov, resolver)
 	if err != nil {


### PR DESCRIPTION
bu using the top-level `OperatorVersion` namespace instead of that of the `Instance` when resolving the dependencies.

Signed-off-by: Aleksey Dukhovniy <alex.dukhovniy@googlemail.com>