### PR TITLE
Do not validate parameters when --skip-instance is true

### DIFF
--- a/pkg/kudoctl/packages/install/package.go
+++ b/pkg/kudoctl/packages/install/package.go
@@ -44,10 +44,12 @@ func Package(
 
 	applyOverrides(&resources, instanceName, namespace, parameters)
 
-	if err := validateParameters(
-		*resources.Instance,
-		resources.OperatorVersion.Spec.Parameters); err != nil {
-		return err
+	if !options.SkipInstance {
+		if err := validateParameters(
+			*resources.Instance,
+			resources.OperatorVersion.Spec.Parameters); err != nil {
+			return err
+		}
 	}
 
 	if err := client.ValidateServerForOperator(resources.Operator); err != nil {

--- a/pkg/kudoctl/packages/install/package.go
+++ b/pkg/kudoctl/packages/install/package.go
@@ -45,6 +45,8 @@ func Package(
 	applyOverrides(&resources, instanceName, namespace, parameters)
 
 	if !options.SkipInstance {
+		// If skipInstance is specified, we do not need to validate the parameters - If we do, we prevent the
+		// installation of an operator version that has a parameter which is required but has no default.
 		if err := validateParameters(
 			*resources.Instance,
 			resources.OperatorVersion.Spec.Parameters); err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
If skipInstance is specified, we do not need to validate the parameters - If we do, we prevent the installation of an operator version that has a parameter which is required but has no default.


Fixes #
