### PR TITLE
Don't warn if parameter is only used as trigger

### DIFF
--- a/pkg/kudoctl/cmd/testdata/invalid-params.golden
+++ b/pkg/kudoctl/cmd/testdata/invalid-params.golden
@@ -1,6 +1,5 @@
-Warnings                                
-parameter "Cpus" defined but not used.  
-parameter "comma," defined but not used.
+Warnings                              
+parameter "Cpus" defined but not used.
 Errors                                                            
 parameter "Cpus" has a duplicate                                  
 parameter "comma," contains invalid character ','                 

--- a/pkg/kudoctl/packages/verifier/template/verify_parameters.go
+++ b/pkg/kudoctl/packages/verifier/template/verify_parameters.go
@@ -81,7 +81,10 @@ func paramsDefinedNotUsed(pf *packages.Files) verifier.Result {
 	}
 	for _, value := range pf.Params.Parameters {
 		if _, ok := tparams[value.Name]; !ok {
-			res.AddParamWarning(value.Name, "defined but not used.")
+			// A parameter could be use to trigger a plan while not being used in templates.
+			if value.Trigger == "" {
+				res.AddParamWarning(value.Name, "defined but not used.")
+			}
 		}
 	}
 	return res

--- a/pkg/kudoctl/packages/verifier/template/verify_parameters_test.go
+++ b/pkg/kudoctl/packages/verifier/template/verify_parameters_test.go
@@ -17,6 +17,7 @@ func TestTemplateParametersVerifier(t *testing.T) {
 		{Name: "UsedViaRoot"},
 		{Name: "BROKER_COUNT"},
 		{Name: "EXTERNAL_NODE_PORT"},
+		{Name: "TRIGGER_ONLY", Trigger: "foo"},
 	}
 	paramFile := packages.ParamsFile{Parameters: params}
 	templates := make(map[string]string)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kudo/blob/main/CONTRIBUTING.md
2. Make sure you have added and ran the tests before submitting your PR
3. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What this PR does / why we need it**:
Parameters can be used to only trigger plans without being used in any templates. In this case no warning should be printed when verifying a package.

<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1617
