### PR TITLE
deploy-clean should not be part of clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,10 +96,6 @@ run:
 deploy:
 	go run -ldflags "${LDFLAGS}" ./cmd/kubectl-kudo init
 
-.PHONY: deploy-clean
-deploy-clean:
-	go run ./cmd/kubectl-kudo  init --dry-run --output yaml | kubectl delete -f -
-
 .PHONY: generate
 # Generate code
 generate:

--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,7 @@ cli-install:
 
 .PHONY: clean
 # Clean all
-clean:  cli-clean test-clean manager-clean deploy-clean
+clean:  cli-clean test-clean manager-clean
 
 .PHONY: docker-build
 # Build the docker image for each supported platform


### PR DESCRIPTION
`deploy-clean` is broken now.   I hesitate to remove it but it has been broken for some time which signals that it isn't used.
IF we want it than... what is recommended to add for the controller version?

Regardless... `deploy-clean` should NOT be apart of `clean` IMO. 

Signed-off-by: Ken Sipe <kensipe@gmail.com>
