### PR TITLE
Wait for resource being deleted, retry reconciliation

### DIFF
--- a/pkg/apis/kudo/v1beta1/instance_types.go
+++ b/pkg/apis/kudo/v1beta1/instance_types.go
@@ -126,15 +126,19 @@ func (s *PhaseStatus) SetWithMessage(status ExecutionStatus, message string) {
 }
 
 func (s *PlanStatus) Set(status ExecutionStatus) {
-	s.LastUpdatedTimestamp = &metav1.Time{Time: time.Now()}
-	s.Status = status
-	s.Message = ""
+	if s.Status != status {
+		s.LastUpdatedTimestamp = &metav1.Time{Time: time.Now()}
+		s.Status = status
+		s.Message = ""
+	}
 }
 
 func (s *PlanStatus) SetWithMessage(status ExecutionStatus, message string) {
-	s.LastUpdatedTimestamp = &metav1.Time{Time: time.Now()}
-	s.Status = status
-	s.Message = message
+	if s.Status != status || s.Message != message {
+		s.LastUpdatedTimestamp = &metav1.Time{Time: time.Now()}
+		s.Status = status
+		s.Message = message
+	}
 }
 
 // ExecutionStatus captures the state of the rollout.

--- a/pkg/engine/health/health.go
+++ b/pkg/engine/health/health.go
@@ -1,20 +1,26 @@
 package health
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log"
 	"reflect"
 
+	"k8s.io/client-go/discovery"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/kubectl/pkg/polymorphichelpers"
 
 	kudov1beta1 "github.com/kudobuilder/kudo/pkg/apis/kudo/v1beta1"
 	"github.com/kudobuilder/kudo/pkg/engine"
+	"github.com/kudobuilder/kudo/pkg/engine/resource"
 	"github.com/kudobuilder/kudo/pkg/kudoctl/clog"
 )
 
@@ -26,6 +32,21 @@ func isJobTerminallyFailed(job *batchv1.Job) (bool, string) {
 		}
 	}
 	return false, ""
+}
+
+func IsDeleted(client client.Client, discovery discovery.CachedDiscoveryInterface, objs []runtime.Object) error {
+	for _, obj := range objs {
+		key, err := resource.ObjectKeyFromObject(obj, discovery)
+		if err != nil {
+			return err
+		}
+		newObj := obj.DeepCopyObject()
+		err = client.Get(context.TODO(), key, newObj)
+		if !apierrors.IsNotFound(err) {
+			return fmt.Errorf("%s/%s is not deleted", key.Namespace, key.Name)
+		}
+	}
+	return nil
 }
 
 // IsHealthy returns whether an object is healthy. Must be implemented for each type.

--- a/pkg/engine/task/task_delete.go
+++ b/pkg/engine/task/task_delete.go
@@ -2,6 +2,9 @@ package task
 
 import (
 	"fmt"
+	"log"
+
+	"github.com/kudobuilder/kudo/pkg/engine/health"
 
 	"golang.org/x/net/context"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -52,6 +55,11 @@ func (dt DeleteTask) Run(ctx Context) (bool, error) {
 	}
 
 	// 6. - Check health: always true for Delete task -
+	err = health.IsDeleted(ctx.Client, ctx.Discovery, objs)
+	if err != nil {
+		log.Printf("TaskExecution: %v", err)
+		return false, nil
+	}
 	return true, nil
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kudo/blob/main/CONTRIBUTING.md
2. Make sure you have added and ran the tests before submitting your PR
3. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What this PR does / why we need it**:
This fixes a bug when a sequence of apply-delete-apply meant that the resource did not exist in the end because we did not wait for item to be deleted out of the cache of the client we're using. Details are in #1596

The solution introduces "health check" for deletion which queries client until it's deleted. Instead of poll & wait and blocking the worker thread we're relying on reconciliation loop being re-trigerred. We now reschedule reconciliation when plan is running to prevent stalling. A simple backoff mechanism implemented as well.

<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1596
