### PR TITLE
Introduce readiness check and proper wait in `init --wait`

### DIFF
--- a/pkg/kudoctl/cmd/testdata/deploy-kudo-ns.yaml.golden
+++ b/pkg/kudoctl/cmd/testdata/deploy-kudo-ns.yaml.golden
@@ -586,6 +586,9 @@ spec:
         - containerPort: 443
           name: webhook-server
           protocol: TCP
+        readinessProbe:
+          tcpSocket:
+            port: 443
         resources:
           requests:
             cpu: 100m

--- a/pkg/kudoctl/cmd/testdata/deploy-kudo-sa.yaml.golden
+++ b/pkg/kudoctl/cmd/testdata/deploy-kudo-sa.yaml.golden
@@ -561,6 +561,9 @@ spec:
         - containerPort: 443
           name: webhook-server
           protocol: TCP
+        readinessProbe:
+          tcpSocket:
+            port: 443
         resources:
           requests:
             cpu: 100m

--- a/pkg/kudoctl/cmd/testdata/deploy-kudo.yaml.golden
+++ b/pkg/kudoctl/cmd/testdata/deploy-kudo.yaml.golden
@@ -597,6 +597,9 @@ spec:
         - containerPort: 443
           name: webhook-server
           protocol: TCP
+        readinessProbe:
+          tcpSocket:
+            port: 443
         resources:
           requests:
             cpu: 100m

--- a/pkg/kudoctl/kudoinit/manager/manager.go
+++ b/pkg/kudoctl/kudoinit/manager/manager.go
@@ -195,6 +195,13 @@ func generateDeployment(opts kudoinit.Options) *appsv1.StatefulSet {
 								// name matters for service
 								{ContainerPort: 443, Name: "webhook-server", Protocol: "TCP"},
 							},
+							StartupProbe: &corev1.Probe{
+								Handler: corev1.Handler{
+									TCPSocket: &corev1.TCPSocketAction{
+										Port: intstr.FromInt(443),
+									},
+								},
+							},
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{
 									"cpu":    resource.MustParse("100m"),

--- a/pkg/kudoctl/kudoinit/manager/manager.go
+++ b/pkg/kudoctl/kudoinit/manager/manager.go
@@ -32,8 +32,6 @@ type Initializer struct {
 	deployment *appsv1.StatefulSet
 }
 
-const Name = "manager"
-
 // NewInitializer returns the setup management object
 func NewInitializer(options kudoinit.Options) Initializer {
 	return Initializer{
@@ -192,7 +190,7 @@ func generateDeployment(opts kudoinit.Options) *appsv1.StatefulSet {
 							},
 							Image:           image,
 							ImagePullPolicy: imagePullPolicy,
-							Name:            Name,
+							Name:            kudoinit.ManagerContainerName,
 							Ports: []corev1.ContainerPort{
 								// name matters for service
 								{ContainerPort: 443, Name: "webhook-server", Protocol: "TCP"},

--- a/pkg/kudoctl/kudoinit/manager/manager.go
+++ b/pkg/kudoctl/kudoinit/manager/manager.go
@@ -32,6 +32,8 @@ type Initializer struct {
 	deployment *appsv1.StatefulSet
 }
 
+const Name = "manager"
+
 // NewInitializer returns the setup management object
 func NewInitializer(options kudoinit.Options) Initializer {
 	return Initializer{
@@ -190,12 +192,14 @@ func generateDeployment(opts kudoinit.Options) *appsv1.StatefulSet {
 							},
 							Image:           image,
 							ImagePullPolicy: imagePullPolicy,
-							Name:            "manager",
+							Name:            Name,
 							Ports: []corev1.ContainerPort{
 								// name matters for service
 								{ContainerPort: 443, Name: "webhook-server", Protocol: "TCP"},
 							},
-							StartupProbe: &corev1.Probe{
+							// Prefer for StartupProbe, however that requires 1.16
+							// ReadinessProbe defaults: failureThreshold: 3, periodSeconds: 10, successThreshold: 1, timeoutSeconds: 1
+							ReadinessProbe: &corev1.Probe{
 								Handler: corev1.Handler{
 									TCPSocket: &corev1.TCPSocketAction{
 										Port: intstr.FromInt(443),

--- a/pkg/kudoctl/kudoinit/setup/wait.go
+++ b/pkg/kudoctl/kudoinit/setup/wait.go
@@ -55,7 +55,7 @@ func isKUDOPodReady(client corev1.PodsGetter, namespace string) (bool, error) {
 // managerContainerStatus returns containerstatus for manager container or error if no manager or status discovered
 func managerContainerStatus(pod *v1.Pod) (*v1.ContainerStatus, error) {
 	for _, s := range pod.Status.ContainerStatuses {
-		if s.Name == manager.Name {
+		if s.Name == kudoinit.ManagerContainerName {
 			return &s, nil
 		}
 	}

--- a/pkg/kudoctl/kudoinit/types.go
+++ b/pkg/kudoctl/kudoinit/types.go
@@ -15,6 +15,7 @@ const (
 	DefaultServiceName    = "kudo-controller-manager-service"
 	DefaultSecretName     = "kudo-webhook-server-secret" //nolint
 	DefaultKudoLabel      = "kudo-manager"
+	ManagerContainerName  = "manager"
 	defaultGracePeriod    = 10
 	defaultServiceAccount = "kudo-manager"
 )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kudo/blob/main/CONTRIBUTING.md
2. Make sure you have added and ran the tests before submitting your PR
3. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What this PR does / why we need it**:
This is part of the solution for #1625

I ended up using startup probe instead of readiness because that's run only when manager starts, we don't need to poll the endpoint when manager is running.
