### PR TITLE
Add --output parameter to plan status to allow json/yaml output

### DIFF
--- a/pkg/kudoctl/cmd/init.go
+++ b/pkg/kudoctl/cmd/init.go
@@ -233,10 +233,8 @@ func (initCmd *initCmd) runInstall(installer *setup.Installer) error {
 		return fmt.Errorf("failed to verify installation requirements")
 	}
 
-	if initCmd.output != "" {
-		if err = initCmd.runYamlOutput(installer); err != nil {
-			return err
-		}
+	if err = initCmd.runYamlOutput(installer); err != nil {
+		return err
 	}
 
 	if !initCmd.dryRun {
@@ -256,10 +254,8 @@ func (initCmd *initCmd) runUpgrade(installer *setup.Installer) error {
 		return fmt.Errorf("failed to verify upgrade requirements")
 	}
 
-	if initCmd.output != "" {
-		if err = initCmd.runYamlOutput(installer); err != nil {
-			return err
-		}
+	if err = initCmd.runYamlOutput(installer); err != nil {
+		return err
 	}
 
 	if !initCmd.dryRun {
@@ -271,6 +267,10 @@ func (initCmd *initCmd) runUpgrade(installer *setup.Installer) error {
 }
 
 func (initCmd *initCmd) runYamlOutput(installer kudoinit.Artifacter) error {
+	if initCmd.output == "" {
+		return nil
+	}
+
 	r := installer.Resources()
 	res := []interface{}{}
 	for _, rr := range r {

--- a/pkg/kudoctl/cmd/init.go
+++ b/pkg/kudoctl/cmd/init.go
@@ -233,8 +233,10 @@ func (initCmd *initCmd) runInstall(installer *setup.Installer) error {
 		return fmt.Errorf("failed to verify installation requirements")
 	}
 
-	if err = initCmd.runYamlOutput(installer); err != nil {
-		return err
+	if initCmd.output != "" {
+		if err = initCmd.runYamlOutput(installer); err != nil {
+			return err
+		}
 	}
 
 	if !initCmd.dryRun {
@@ -254,8 +256,10 @@ func (initCmd *initCmd) runUpgrade(installer *setup.Installer) error {
 		return fmt.Errorf("failed to verify upgrade requirements")
 	}
 
-	if err = initCmd.runYamlOutput(installer); err != nil {
-		return err
+	if initCmd.output != "" {
+		if err = initCmd.runYamlOutput(installer); err != nil {
+			return err
+		}
 	}
 
 	if !initCmd.dryRun {

--- a/pkg/kudoctl/cmd/init_test.go
+++ b/pkg/kudoctl/cmd/init_test.go
@@ -160,6 +160,7 @@ func TestInitCmd_yamlOutput(t *testing.T) {
 		{"custom namespace", "deploy-kudo-ns.yaml", map[string]string{"dry-run": "true", "output": "yaml", "namespace": "foo", "version": "dev"}},
 		{"yaml output", "deploy-kudo.yaml", map[string]string{"dry-run": "true", "output": "yaml", "version": "dev"}},
 		{"service account", "deploy-kudo-sa.yaml", map[string]string{"dry-run": "true", "output": "yaml", "service-account": "safoo", "namespace": "foo", "version": "dev"}},
+		{"json output", "deploy-kudo.json", map[string]string{"dry-run": "true", "output": "json", "version": "dev"}},
 	}
 
 	for _, tt := range tests {

--- a/pkg/kudoctl/cmd/output/output.go
+++ b/pkg/kudoctl/cmd/output/output.go
@@ -1,0 +1,72 @@
+package output
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	"sigs.k8s.io/yaml"
+)
+
+const (
+	TypeYAML = "yaml"
+	TypeJSON = "json"
+)
+
+func WriteObjects(objs []interface{}, outputType string, out io.Writer) error {
+	var o []byte
+	var err error
+	if strings.ToLower(outputType) == TypeYAML {
+		for _, obj := range objs {
+			o, err = yaml.Marshal(obj)
+			if err != nil {
+				return fmt.Errorf("failed to marshal to yaml: %v", err)
+			}
+			if _, err := fmt.Fprintln(out, "---"); err != nil {
+				return err
+			}
+
+			if _, err := fmt.Fprintln(out, string(o)); err != nil {
+				return err
+			}
+		}
+
+		// YAML ending document boundary marker
+		_, err = fmt.Fprintln(out, "...")
+
+		return err
+	} else if strings.ToLower(outputType) == TypeJSON {
+		o, err = json.MarshalIndent(objs, "", "  ")
+		if err != nil {
+			return fmt.Errorf("failed to marshal to json: %v", err)
+		}
+		if _, err := fmt.Fprintln(out, string(o)); err != nil {
+			return err
+		}
+		return nil
+	}
+
+	return nil
+}
+
+func WriteObject(obj interface{}, outputType string, out io.Writer) error {
+	var o []byte
+	var err error
+	if strings.ToLower(outputType) == TypeYAML {
+		o, err = yaml.Marshal(obj)
+		if err != nil {
+			return fmt.Errorf("failed to marshal to yaml: %v", err)
+		}
+	} else if strings.ToLower(outputType) == TypeJSON {
+		o, err = json.MarshalIndent(obj, "", "  ")
+		if err != nil {
+			return fmt.Errorf("failed to marshal to json: %v", err)
+		}
+	}
+
+	if _, err := fmt.Fprintln(out, string(o)); err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/kudoctl/cmd/output/output.go
+++ b/pkg/kudoctl/cmd/output/output.go
@@ -15,58 +15,52 @@ const (
 )
 
 func WriteObjects(objs []interface{}, outputType string, out io.Writer) error {
-	var o []byte
-	var err error
 	if strings.ToLower(outputType) == TypeYAML {
+		// Write YAML objects with separators
 		for _, obj := range objs {
-			o, err = yaml.Marshal(obj)
-			if err != nil {
-				return fmt.Errorf("failed to marshal to yaml: %v", err)
-			}
 			if _, err := fmt.Fprintln(out, "---"); err != nil {
 				return err
 			}
 
-			if _, err := fmt.Fprintln(out, string(o)); err != nil {
+			if err := writeObjectYAML(obj, out); err != nil {
 				return err
 			}
 		}
 
 		// YAML ending document boundary marker
-		_, err = fmt.Fprintln(out, "...")
-
+		_, err := fmt.Fprintln(out, "...")
 		return err
 	} else if strings.ToLower(outputType) == TypeJSON {
-		o, err = json.MarshalIndent(objs, "", "  ")
-		if err != nil {
-			return fmt.Errorf("failed to marshal to json: %v", err)
-		}
-		if _, err := fmt.Fprintln(out, string(o)); err != nil {
-			return err
-		}
-		return nil
+		return writeObjectJSON(objs, out)
 	}
 
-	return nil
+	return fmt.Errorf("invalid output format, only support yaml or json")
 }
 
 func WriteObject(obj interface{}, outputType string, out io.Writer) error {
-	var o []byte
-	var err error
 	if strings.ToLower(outputType) == TypeYAML {
-		o, err = yaml.Marshal(obj)
-		if err != nil {
-			return fmt.Errorf("failed to marshal to yaml: %v", err)
-		}
+		return writeObjectYAML(obj, out)
 	} else if strings.ToLower(outputType) == TypeJSON {
-		o, err = json.MarshalIndent(obj, "", "  ")
-		if err != nil {
-			return fmt.Errorf("failed to marshal to json: %v", err)
-		}
+		return writeObjectJSON(obj, out)
 	}
 
-	if _, err := fmt.Fprintln(out, string(o)); err != nil {
-		return err
+	return fmt.Errorf("invalid output format, only support yaml or json")
+}
+
+func writeObjectJSON(obj interface{}, out io.Writer) error {
+	o, err := json.MarshalIndent(obj, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal to json: %v", err)
 	}
-	return nil
+	_, err = fmt.Fprintln(out, string(o))
+	return err
+}
+
+func writeObjectYAML(obj interface{}, out io.Writer) error {
+	o, err := yaml.Marshal(obj)
+	if err != nil {
+		return fmt.Errorf("failed to marshal to yaml: %v", err)
+	}
+	_, err = fmt.Fprintln(out, string(o))
+	return err
 }

--- a/pkg/kudoctl/cmd/plan.go
+++ b/pkg/kudoctl/cmd/plan.go
@@ -68,6 +68,7 @@ func NewPlanStatusCmd(out io.Writer) *cobra.Command {
 
 	cmd.Flags().StringVar(&options.Instance, "instance", "", "The instance name available from 'kubectl get instances'")
 	cmd.Flags().BoolVar(&options.Wait, "wait", false, "Specify if the CLI should wait for the plan to complete before returning (default \"false\")")
+	cmd.Flags().StringVarP(&options.Output, "output", "o", "", "Output format")
 
 	if err := cmd.MarkFlagRequired("instance"); err != nil {
 		clog.Printf("Please choose the instance with '--instance=<instanceName>': %v", err)

--- a/pkg/kudoctl/cmd/plan/plan_history.go
+++ b/pkg/kudoctl/cmd/plan/plan_history.go
@@ -19,6 +19,7 @@ type Options struct {
 	Out      io.Writer
 	Instance string
 	Wait     bool
+	Output   string
 }
 
 var (

--- a/pkg/kudoctl/cmd/plan/plan_status.go
+++ b/pkg/kudoctl/cmd/plan/plan_status.go
@@ -1,7 +1,6 @@
 package plan
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 	"sort"
@@ -10,9 +9,9 @@ import (
 
 	"github.com/thoas/go-funk"
 	"github.com/xlab/treeprint"
-	"sigs.k8s.io/yaml"
 
 	"github.com/kudobuilder/kudo/pkg/apis/kudo/v1beta1"
+	"github.com/kudobuilder/kudo/pkg/kudoctl/cmd/output"
 	"github.com/kudobuilder/kudo/pkg/kudoctl/env"
 	"github.com/kudobuilder/kudo/pkg/kudoctl/util/kudo"
 )
@@ -35,24 +34,7 @@ func statusFormatted(kc *kudo.Client, options *Options, ns string) error {
 	if instance == nil {
 		return fmt.Errorf("instance %s/%s does not exist", ns, options.Instance)
 	}
-
-	var o []byte
-	if strings.ToLower(options.Output) == "yaml" {
-		o, err = yaml.Marshal(instance.Status)
-		if err != nil {
-			return fmt.Errorf("failed to marshal to yaml: %v", err)
-		}
-	} else if strings.ToLower(options.Output) == "json" {
-		o, err = json.MarshalIndent(instance.Status, "", "  ")
-		if err != nil {
-			return fmt.Errorf("failed to marshal to json: %v", err)
-		}
-	}
-
-	if _, err := fmt.Fprintln(options.Out, string(o)); err != nil {
-		return err
-	}
-	return nil
+	return output.WriteObject(instance.Status, options.Output, options.Out)
 }
 
 func status(kc *kudo.Client, options *Options, ns string) error {

--- a/pkg/kudoctl/cmd/plan/plan_status_test.go
+++ b/pkg/kudoctl/cmd/plan/plan_status_test.go
@@ -2,6 +2,9 @@ package plan
 
 import (
 	"bytes"
+	"flag"
+	"io/ioutil"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -16,7 +19,8 @@ import (
 )
 
 var (
-	testTime = time.Date(2019, 10, 17, 1, 1, 1, 1, time.UTC)
+	testTime     = time.Date(2019, 10, 17, 1, 1, 1, 1, time.UTC)
+	updateGolden = flag.Bool("update", false, "update .golden files")
 )
 
 func TestStatus(t *testing.T) {
@@ -104,45 +108,60 @@ func TestStatus(t *testing.T) {
 		instanceNameArg string
 		errorMessage    string
 		expectedOutput  string
+		output          string
+		goldenFile      string
 	}{
-		{"nonexisting instance", nil, nil, "nonexisting", "Instance default/nonexisting does not exist", ""},
-		{"nonexisting ov", instance, nil, "test", "OperatorVersion test-1.0 from instance default/test does not exist", ""},
-		{"no plan run", instance, ov, "test", "", "No plan ever run for instance - nothing to show for instance test\n"},
-		{"fatal error in a plan", fatalErrInstance, ov, "test", "", `Plan(s) for "test" in namespace "default":
-.
-└── test (Operator-Version: "test-1.0" Active-Plan: "deploy")
-    ├── Plan deploy ( strategy) [FATAL_ERROR], last updated 2019-10-17 01:01:01
-    │   └── Phase deploy ( strategy) [FATAL_ERROR]
-    │       └── Step deploy [FATAL_ERROR] (error detail)
-    ├── Plan validate ( strategy) [NOT ACTIVE]
-    │   └── Phase validate ( strategy) [NOT ACTIVE]
-    │       └── Step validate [NOT ACTIVE]
-    └── Plan zzzinvalid ( strategy) [NOT ACTIVE]
-        └── Phase zzzinvalid ( strategy) [NOT ACTIVE]
-            └── Step zzzinvalid [NOT ACTIVE]
-
-`},
+		{name: "nonexisting instance", instanceNameArg: "nonexisting", errorMessage: "Instance default/nonexisting does not exist"},
+		{name: "nonexisting ov", instance: instance, instanceNameArg: "test", errorMessage: "OperatorVersion test-1.0 from instance default/test does not exist"},
+		{name: "no plan run", instance: instance, ov: ov, instanceNameArg: "test", expectedOutput: "No plan ever run for instance - nothing to show for instance test\n"},
+		{name: "text output", instance: fatalErrInstance, ov: ov, instanceNameArg: "test", goldenFile: "planstatus.txt"},
+		{name: "json output", instance: fatalErrInstance, ov: ov, instanceNameArg: "test", output: "json", goldenFile: "planstatus.json"},
+		{name: "yaml output", instance: fatalErrInstance, ov: ov, instanceNameArg: "test", output: "yaml", goldenFile: "planstatus.yaml"},
 	}
 
 	for _, tt := range tests {
-		var buf bytes.Buffer
-		kc := kudo.NewClientFromK8s(fake.NewSimpleClientset(), kubefake.NewSimpleClientset())
-		if tt.instance != nil {
-			_, err := kc.InstallInstanceObjToCluster(tt.instance, "default")
-			if err != nil {
-				t.Errorf("%s: error when setting up a test - %v", tt.name, err)
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			kc := kudo.NewClientFromK8s(fake.NewSimpleClientset(), kubefake.NewSimpleClientset())
+			if tt.instance != nil {
+				_, err := kc.InstallInstanceObjToCluster(tt.instance, "default")
+				if err != nil {
+					t.Errorf("%s: error when setting up a test - %v", tt.name, err)
+				}
 			}
-		}
-		if tt.ov != nil {
-			_, err := kc.InstallOperatorVersionObjToCluster(tt.ov, "default")
-			if err != nil {
-				t.Errorf("%s: error when setting up a test - %v", tt.name, err)
+			if tt.ov != nil {
+				_, err := kc.InstallOperatorVersionObjToCluster(tt.ov, "default")
+				if err != nil {
+					t.Errorf("%s: error when setting up a test - %v", tt.name, err)
+				}
 			}
-		}
-		err := status(kc, &Options{Out: &buf, Instance: tt.instanceNameArg}, "default")
-		if err != nil {
-			assert.Equal(t, err.Error(), tt.errorMessage)
-		}
-		assert.Equal(t, buf.String(), tt.expectedOutput)
+			err := status(kc, &Options{Out: &buf, Instance: tt.instanceNameArg, Output: tt.output}, "default")
+			if err != nil {
+				assert.Equal(t, err.Error(), tt.errorMessage)
+			}
+			if tt.goldenFile != "" {
+				gp := filepath.Join("testdata", tt.goldenFile+".golden")
+
+				if *updateGolden {
+					t.Logf("updating golden file %s", tt.goldenFile)
+
+					//nolint:gosec
+					if err := ioutil.WriteFile(gp, buf.Bytes(), 0644); err != nil {
+						t.Fatalf("failed to update golden file: %s", err)
+					}
+				}
+
+				g, err := ioutil.ReadFile(gp)
+				if err != nil {
+					t.Fatalf("failed reading .golden: %s", err)
+				}
+
+				assert.Equal(t, string(g), buf.String(), "for golden file: %s, for test %s", gp, tt.name)
+			}
+			if tt.expectedOutput != "" {
+				assert.Equal(t, buf.String(), tt.expectedOutput)
+			}
+		})
 	}
 }

--- a/pkg/kudoctl/cmd/plan/testdata/planstatus.json.golden
+++ b/pkg/kudoctl/cmd/plan/testdata/planstatus.json.golden
@@ -1,0 +1,22 @@
+{
+  "planStatus": {
+    "deploy": {
+      "name": "deploy",
+      "status": "FATAL_ERROR",
+      "lastUpdatedTimestamp": "2019-10-17T01:01:01Z",
+      "phases": [
+        {
+          "name": "deploy",
+          "status": "FATAL_ERROR",
+          "steps": [
+            {
+              "name": "deploy",
+              "message": "error detail",
+              "status": "FATAL_ERROR"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/pkg/kudoctl/cmd/plan/testdata/planstatus.txt.golden
+++ b/pkg/kudoctl/cmd/plan/testdata/planstatus.txt.golden
@@ -1,0 +1,13 @@
+Plan(s) for "test" in namespace "default":
+.
+└── test (Operator-Version: "test-1.0" Active-Plan: "deploy")
+    ├── Plan deploy ( strategy) [FATAL_ERROR], last updated 2019-10-17 01:01:01
+    │   └── Phase deploy ( strategy) [FATAL_ERROR]
+    │       └── Step deploy [FATAL_ERROR] (error detail)
+    ├── Plan validate ( strategy) [NOT ACTIVE]
+    │   └── Phase validate ( strategy) [NOT ACTIVE]
+    │       └── Step validate [NOT ACTIVE]
+    └── Plan zzzinvalid ( strategy) [NOT ACTIVE]
+        └── Phase zzzinvalid ( strategy) [NOT ACTIVE]
+            └── Step zzzinvalid [NOT ACTIVE]
+

--- a/pkg/kudoctl/cmd/plan/testdata/planstatus.yaml.golden
+++ b/pkg/kudoctl/cmd/plan/testdata/planstatus.yaml.golden
@@ -1,0 +1,13 @@
+planStatus:
+  deploy:
+    lastUpdatedTimestamp: "2019-10-17T01:01:01Z"
+    name: deploy
+    phases:
+    - name: deploy
+      status: FATAL_ERROR
+      steps:
+      - message: error detail
+        name: deploy
+        status: FATAL_ERROR
+    status: FATAL_ERROR
+

--- a/pkg/kudoctl/cmd/testdata/deploy-kudo.json.golden
+++ b/pkg/kudoctl/cmd/testdata/deploy-kudo.json.golden
@@ -1,0 +1,873 @@
+[
+  {
+    "kind": "CustomResourceDefinition",
+    "apiVersion": "apiextensions.k8s.io/v1beta1",
+    "metadata": {
+      "name": "operators.kudo.dev",
+      "creationTimestamp": null,
+      "annotations": {
+        "controller-gen.kubebuilder.io/version": "v0.3.0"
+      }
+    },
+    "spec": {
+      "group": "kudo.dev",
+      "version": "v1beta1",
+      "names": {
+        "plural": "operators",
+        "singular": "operator",
+        "kind": "Operator",
+        "listKind": "OperatorList"
+      },
+      "scope": "Namespaced",
+      "validation": {
+        "openAPIV3Schema": {
+          "description": "Operator is the Schema for the operator API",
+          "type": "object",
+          "properties": {
+            "apiVersion": {
+              "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+              "type": "string"
+            },
+            "kind": {
+              "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+              "type": "string"
+            },
+            "metadata": {
+              "type": "object"
+            },
+            "spec": {
+              "description": "OperatorSpec defines the desired state of Operator",
+              "type": "object",
+              "properties": {
+                "description": {
+                  "type": "string"
+                },
+                "kubernetesVersion": {
+                  "type": "string"
+                },
+                "kudoVersion": {
+                  "type": "string"
+                },
+                "maintainers": {
+                  "type": "array",
+                  "items": {
+                    "description": "Maintainer describes an Operator maintainer.",
+                    "type": "object",
+                    "properties": {
+                      "email": {
+                        "description": "Email is an optional email address to contact the named maintainer.",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "Name is a user name or organization name.",
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                "namespaceManifest": {
+                  "type": "string"
+                },
+                "url": {
+                  "type": "string"
+                }
+              }
+            },
+            "status": {
+              "description": "OperatorStatus defines the observed state of Operator",
+              "type": "object"
+            }
+          }
+        }
+      },
+      "versions": [
+        {
+          "name": "v1beta1",
+          "served": true,
+          "storage": true
+        }
+      ]
+    },
+    "status": {
+      "conditions": [],
+      "acceptedNames": {
+        "plural": "",
+        "kind": ""
+      },
+      "storedVersions": []
+    }
+  },
+  {
+    "kind": "CustomResourceDefinition",
+    "apiVersion": "apiextensions.k8s.io/v1beta1",
+    "metadata": {
+      "name": "operatorversions.kudo.dev",
+      "creationTimestamp": null,
+      "annotations": {
+        "controller-gen.kubebuilder.io/version": "v0.3.0"
+      }
+    },
+    "spec": {
+      "group": "kudo.dev",
+      "version": "v1beta1",
+      "names": {
+        "plural": "operatorversions",
+        "singular": "operatorversion",
+        "kind": "OperatorVersion",
+        "listKind": "OperatorVersionList"
+      },
+      "scope": "Namespaced",
+      "validation": {
+        "openAPIV3Schema": {
+          "description": "OperatorVersion is the Schema for the operatorversions API.",
+          "type": "object",
+          "properties": {
+            "apiVersion": {
+              "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+              "type": "string"
+            },
+            "kind": {
+              "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+              "type": "string"
+            },
+            "metadata": {
+              "type": "object"
+            },
+            "spec": {
+              "description": "OperatorVersionSpec defines the desired state of OperatorVersion.",
+              "type": "object",
+              "properties": {
+                "appVersion": {
+                  "type": "string"
+                },
+                "connectionString": {
+                  "description": "ConnectionString defines a templated string that can be used to connect to an instance of the Operator.",
+                  "type": "string"
+                },
+                "operator": {
+                  "description": "ObjectReference contains enough information to let you inspect or modify the referred object. --- New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.  1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.  2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular     restrictions like, \"must refer only to types A and B\" or \"UID not honored\" or \"name must be restricted\".     Those cannot be well described when embedded.  3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.  4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity     during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple     and the version of the actual struct is irrelevant.  5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type     will affect numerous schemas.  Don't make new APIs embed an underspecified API type they do not control. Instead of using this type, create a locally provided and used type that is well-focused on your reference. For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .",
+                  "type": "object",
+                  "properties": {
+                    "apiVersion": {
+                      "description": "API version of the referent.",
+                      "type": "string"
+                    },
+                    "fieldPath": {
+                      "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                      "type": "string"
+                    },
+                    "kind": {
+                      "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                      "type": "string"
+                    },
+                    "resourceVersion": {
+                      "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                      "type": "string"
+                    },
+                    "uid": {
+                      "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                      "type": "string"
+                    }
+                  }
+                },
+                "parameters": {
+                  "type": "array",
+                  "items": {
+                    "description": "Parameter captures the variability of an OperatorVersion being instantiated in an instance.",
+                    "type": "object",
+                    "properties": {
+                      "default": {
+                        "description": "Default is a default value if no parameter is provided by the instance.",
+                        "type": "string"
+                      },
+                      "description": {
+                        "description": "Description captures a longer description of how the parameter will be used.",
+                        "type": "string"
+                      },
+                      "displayName": {
+                        "description": "DisplayName can be used by UIs.",
+                        "type": "string"
+                      },
+                      "immutable": {
+                        "description": "Specifies if the parameter can be changed after the initial installation of the operator",
+                        "type": "boolean"
+                      },
+                      "name": {
+                        "description": "Name is the string that should be used in the template file for example, if `name: COUNT` then using the variable in a spec like: \n spec:   replicas:  {{ .Params.COUNT }}",
+                        "type": "string"
+                      },
+                      "required": {
+                        "description": "Required specifies if the parameter is required to be provided by all instances, or whether a default can suffice.",
+                        "type": "boolean"
+                      },
+                      "trigger": {
+                        "description": "Trigger identifies the plan that gets executed when this parameter changes in the Instance object. Default is `update` if a plan with that name exists, otherwise it's `deploy`.",
+                        "type": "string"
+                      },
+                      "value-type": {
+                        "description": "Type specifies the value type. Defaults to `string`.",
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                "plans": {
+                  "description": "Plans maps a plan name to a plan.",
+                  "type": "object",
+                  "additionalProperties": {
+                    "description": "Plan specifies a series of Phases that need to be completed.",
+                    "type": "object",
+                    "properties": {
+                      "phases": {
+                        "description": "Phases maps a phase name to a Phase object.",
+                        "type": "array",
+                        "items": {
+                          "description": "Phase specifies a list of steps that contain Kubernetes objects.",
+                          "type": "object",
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "steps": {
+                              "description": "Steps maps a step name to a list of templated Kubernetes objects stored as a string.",
+                              "type": "array",
+                              "items": {
+                                "description": "Step defines a specific set of operations that occur.",
+                                "type": "object",
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "tasks": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "strategy": {
+                              "description": "Ordering specifies how the subitems in this plan/phase should be rolled out.",
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "nullable": true
+                      },
+                      "strategy": {
+                        "description": "Ordering specifies how the subitems in this plan/phase should be rolled out.",
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "nullable": true
+                },
+                "tasks": {
+                  "description": "List of all tasks available in this OperatorVersion.",
+                  "type": "array",
+                  "items": {
+                    "description": "Task is a global, polymorphic implementation of all publicly available tasks",
+                    "type": "object",
+                    "properties": {
+                      "kind": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "spec": {
+                        "description": "TaskSpec embeds all possible task specs. This allows us to avoid writing custom un/marshallers that would only parse certain fields depending on the task Kind. The downside of this approach is, that embedded types can not have fields with the same json names as it would become ambiguous for the default parser. We might revisit this approach in the future should this become an issue.",
+                        "type": "object",
+                        "properties": {
+                          "appVersion": {
+                            "description": "a specific app version in the official repo, defaults to the most recent",
+                            "type": "string"
+                          },
+                          "done": {
+                            "type": "boolean"
+                          },
+                          "fatal": {
+                            "type": "boolean"
+                          },
+                          "instanceName": {
+                            "type": "string"
+                          },
+                          "operatorVersion": {
+                            "description": "a specific operator version in the official repo, defaults to the most recent one",
+                            "type": "string"
+                          },
+                          "package": {
+                            "description": "either repo package name, local package folder or an URL to package tarball. during operator installation, kudoctl will resolve the package and override this field with the resolved operator name.",
+                            "type": "string"
+                          },
+                          "parameter": {
+                            "type": "string"
+                          },
+                          "parameterFile": {
+                            "description": "name of the template file (located in the `templates` folder) from which the *parent* instance generates a parameter file used to populate the *child* Instance.Spec.Parameters",
+                            "type": "string"
+                          },
+                          "pipe": {
+                            "type": "array",
+                            "items": {
+                              "description": "PipeSpec describes how a file generated by a PipeTask is stored and referenced",
+                              "type": "object",
+                              "properties": {
+                                "envFile": {
+                                  "type": "string"
+                                },
+                                "file": {
+                                  "type": "string"
+                                },
+                                "key": {
+                                  "type": "string"
+                                },
+                                "kind": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "nullable": true
+                          },
+                          "pod": {
+                            "type": "string"
+                          },
+                          "resources": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            },
+                            "nullable": true
+                          },
+                          "wantErr": {
+                            "type": "boolean"
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "templates": {
+                  "description": "Templates is a list of references to YAML templates located in the templates folder and later referenced from tasks.",
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                },
+                "upgradableFrom": {
+                  "description": "UpgradableFrom lists all OperatorVersions that can upgrade to this OperatorVersion.",
+                  "type": "array",
+                  "items": {
+                    "description": "ObjectReference contains enough information to let you inspect or modify the referred object. --- New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.  1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.  2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular     restrictions like, \"must refer only to types A and B\" or \"UID not honored\" or \"name must be restricted\".     Those cannot be well described when embedded.  3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.  4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity     during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple     and the version of the actual struct is irrelevant.  5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type     will affect numerous schemas.  Don't make new APIs embed an underspecified API type they do not control. Instead of using this type, create a locally provided and used type that is well-focused on your reference. For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .",
+                    "type": "object",
+                    "properties": {
+                      "apiVersion": {
+                        "description": "API version of the referent.",
+                        "type": "string"
+                      },
+                      "fieldPath": {
+                        "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                        "type": "string"
+                      },
+                      "kind": {
+                        "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                        "type": "string"
+                      },
+                      "namespace": {
+                        "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                        "type": "string"
+                      },
+                      "resourceVersion": {
+                        "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                        "type": "string"
+                      },
+                      "uid": {
+                        "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                "version": {
+                  "type": "string"
+                }
+              }
+            },
+            "status": {
+              "description": "OperatorVersionStatus defines the observed state of OperatorVersion.",
+              "type": "object"
+            }
+          }
+        }
+      },
+      "versions": [
+        {
+          "name": "v1beta1",
+          "served": true,
+          "storage": true
+        }
+      ]
+    },
+    "status": {
+      "conditions": [],
+      "acceptedNames": {
+        "plural": "",
+        "kind": ""
+      },
+      "storedVersions": []
+    }
+  },
+  {
+    "kind": "CustomResourceDefinition",
+    "apiVersion": "apiextensions.k8s.io/v1beta1",
+    "metadata": {
+      "name": "instances.kudo.dev",
+      "creationTimestamp": null,
+      "annotations": {
+        "controller-gen.kubebuilder.io/version": "v0.3.0"
+      }
+    },
+    "spec": {
+      "group": "kudo.dev",
+      "version": "v1beta1",
+      "names": {
+        "plural": "instances",
+        "singular": "instance",
+        "kind": "Instance",
+        "listKind": "InstanceList"
+      },
+      "scope": "Namespaced",
+      "validation": {
+        "openAPIV3Schema": {
+          "description": "Instance is the Schema for the instances API.",
+          "type": "object",
+          "properties": {
+            "apiVersion": {
+              "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+              "type": "string"
+            },
+            "kind": {
+              "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+              "type": "string"
+            },
+            "metadata": {
+              "type": "object"
+            },
+            "spec": {
+              "description": "InstanceSpec defines the desired state of Instance.",
+              "type": "object",
+              "properties": {
+                "operatorVersion": {
+                  "description": "OperatorVersion specifies a reference to a specific OperatorVersion object.",
+                  "type": "object",
+                  "properties": {
+                    "apiVersion": {
+                      "description": "API version of the referent.",
+                      "type": "string"
+                    },
+                    "fieldPath": {
+                      "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                      "type": "string"
+                    },
+                    "kind": {
+                      "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                      "type": "string"
+                    },
+                    "resourceVersion": {
+                      "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                      "type": "string"
+                    },
+                    "uid": {
+                      "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                      "type": "string"
+                    }
+                  }
+                },
+                "parameters": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                },
+                "planExecution": {
+                  "description": "There are two ways a plan execution can be triggered:  1) indirectly through update of a corresponding parameter in the InstanceSpec.Parameters map  2) directly through setting of the InstanceSpec.PlanExecution.PlanName field While indirect (1) triggers happens every time a user changes a parameter, a directly (2) triggered plan is reserved for the situations when parameters doesn't change e.g. a periodic backup is triggered overriding the existing backup file. Additionally, this opens room for canceling and overriding currently running plans in the future. Note: PlanExecution field defines plan name and corresponding parameters that IS CURRENTLY executed. Once the instance controller (IC) is done with the execution, this field will be cleared. Each plan execution has a unique UID so should the same plan be re-triggered it will have a new UID",
+                  "type": "object",
+                  "properties": {
+                    "planName": {
+                      "type": "string"
+                    },
+                    "status": {
+                      "description": "ExecutionStatus captures the state of the rollout.",
+                      "type": "string"
+                    },
+                    "uid": {
+                      "description": "UID is a type that holds unique ID values, including UUIDs.  Because we don't ONLY use UUIDs, this is an alias to string.  Being a type captures intent and helps make sure that UIDs and names do not get conflated.",
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "status": {
+              "description": "InstanceStatus defines the observed state of Instance",
+              "type": "object",
+              "properties": {
+                "planStatus": {
+                  "description": "slice would be enough here but we cannot use slice because order of sequence in yaml is considered significant while here it's not",
+                  "type": "object",
+                  "additionalProperties": {
+                    "description": "PlanStatus is representing status of a plan \n These are valid states and transitions \n                       | Never executed |                               |                               v |    Error    |\u003c------\u003e|    Pending     |       ^                       |       |                       v       |               +-------+--------+       |               +-------+--------+       |                       |       v                       v | Fatal error |        |    Complete    |",
+                    "type": "object",
+                    "properties": {
+                      "lastUpdatedTimestamp": {
+                        "type": "string",
+                        "format": "date-time",
+                        "nullable": true
+                      },
+                      "message": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "phases": {
+                        "type": "array",
+                        "items": {
+                          "description": "PhaseStatus is representing status of a phase",
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "status": {
+                              "description": "ExecutionStatus captures the state of the rollout.",
+                              "type": "string"
+                            },
+                            "steps": {
+                              "type": "array",
+                              "items": {
+                                "description": "StepStatus is representing status of a step",
+                                "type": "object",
+                                "properties": {
+                                  "message": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "status": {
+                                    "description": "ExecutionStatus captures the state of the rollout.",
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "status": {
+                        "description": "ExecutionStatus captures the state of the rollout.",
+                        "type": "string"
+                      },
+                      "uid": {
+                        "description": "UID is a type that holds unique ID values, including UUIDs.  Because we don't ONLY use UUIDs, this is an alias to string.  Being a type captures intent and helps make sure that UIDs and names do not get conflated.",
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "subresources": {
+        "status": {}
+      },
+      "versions": [
+        {
+          "name": "v1beta1",
+          "served": true,
+          "storage": true
+        }
+      ]
+    },
+    "status": {
+      "conditions": [],
+      "acceptedNames": {
+        "plural": "",
+        "kind": ""
+      },
+      "storedVersions": []
+    }
+  },
+  {
+    "kind": "Namespace",
+    "apiVersion": "v1",
+    "metadata": {
+      "name": "kudo-system",
+      "creationTimestamp": null,
+      "labels": {
+        "app": "kudo-manager"
+      }
+    },
+    "spec": {},
+    "status": {}
+  },
+  {
+    "kind": "ServiceAccount",
+    "apiVersion": "v1",
+    "metadata": {
+      "name": "kudo-manager",
+      "namespace": "kudo-system",
+      "creationTimestamp": null,
+      "labels": {
+        "app": "kudo-manager"
+      }
+    }
+  },
+  {
+    "kind": "ClusterRoleBinding",
+    "apiVersion": "rbac.authorization.k8s.io/v1",
+    "metadata": {
+      "name": "kudo-manager-rolebinding",
+      "creationTimestamp": null
+    },
+    "subjects": [
+      {
+        "kind": "ServiceAccount",
+        "name": "kudo-manager",
+        "namespace": "kudo-system"
+      }
+    ],
+    "roleRef": {
+      "apiGroup": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "cluster-admin"
+    }
+  },
+  {
+    "kind": "MutatingWebhookConfiguration",
+    "apiVersion": "admissionregistration.k8s.io/v1beta1",
+    "metadata": {
+      "name": "kudo-manager-instance-admission-webhook-config",
+      "creationTimestamp": null,
+      "annotations": {
+        "cert-manager.io/inject-ca-from": "kudo-system/kudo-webhook-server-certificate"
+      }
+    },
+    "webhooks": [
+      {
+        "name": "instance-admission.kudo.dev",
+        "clientConfig": {
+          "service": {
+            "namespace": "kudo-system",
+            "name": "kudo-controller-manager-service",
+            "path": "/admit-kudo-dev-v1beta1-instance"
+          }
+        },
+        "rules": [
+          {
+            "operations": [
+              "CREATE",
+              "UPDATE"
+            ],
+            "apiGroups": [
+              "kudo.dev"
+            ],
+            "apiVersions": [
+              "v1beta1"
+            ],
+            "resources": [
+              "instances"
+            ],
+            "scope": "Namespaced"
+          }
+        ],
+        "failurePolicy": "Fail",
+        "matchPolicy": "Equivalent",
+        "sideEffects": "None"
+      }
+    ]
+  },
+  {
+    "apiVersion": "cert-manager.io/v1alpha2",
+    "kind": "Issuer",
+    "metadata": {
+      "name": "selfsigned-issuer",
+      "namespace": "kudo-system"
+    },
+    "spec": {
+      "selfSigned": {}
+    }
+  },
+  {
+    "apiVersion": "cert-manager.io/v1alpha2",
+    "kind": "Certificate",
+    "metadata": {
+      "name": "kudo-webhook-server-certificate",
+      "namespace": "kudo-system"
+    },
+    "spec": {
+      "commonName": "kudo-controller-manager-service.kudo-system.svc",
+      "dnsNames": [
+        "kudo-controller-manager-service.kudo-system.svc"
+      ],
+      "issuerRef": {
+        "kind": "Issuer",
+        "name": "selfsigned-issuer"
+      },
+      "secretName": "kudo-webhook-server-secret"
+    }
+  },
+  {
+    "kind": "Service",
+    "apiVersion": "v1",
+    "metadata": {
+      "name": "kudo-controller-manager-service",
+      "namespace": "kudo-system",
+      "creationTimestamp": null,
+      "labels": {
+        "app": "kudo-manager",
+        "control-plane": "controller-manager"
+      }
+    },
+    "spec": {
+      "ports": [
+        {
+          "name": "kudo",
+          "port": 443,
+          "targetPort": "webhook-server"
+        }
+      ],
+      "selector": {
+        "app": "kudo-manager",
+        "control-plane": "controller-manager"
+      }
+    },
+    "status": {
+      "loadBalancer": {}
+    }
+  },
+  {
+    "kind": "StatefulSet",
+    "apiVersion": "apps/v1",
+    "metadata": {
+      "name": "kudo-controller-manager",
+      "namespace": "kudo-system",
+      "creationTimestamp": null,
+      "labels": {
+        "app": "kudo-manager",
+        "control-plane": "controller-manager"
+      }
+    },
+    "spec": {
+      "selector": {
+        "matchLabels": {
+          "app": "kudo-manager",
+          "control-plane": "controller-manager"
+        }
+      },
+      "template": {
+        "metadata": {
+          "creationTimestamp": null,
+          "labels": {
+            "app": "kudo-manager",
+            "control-plane": "controller-manager"
+          }
+        },
+        "spec": {
+          "volumes": [
+            {
+              "name": "cert",
+              "secret": {
+                "secretName": "kudo-webhook-server-secret",
+                "defaultMode": 420
+              }
+            }
+          ],
+          "containers": [
+            {
+              "name": "manager",
+              "image": "kudobuilder/controller:vdev",
+              "command": [
+                "/root/manager"
+              ],
+              "ports": [
+                {
+                  "name": "webhook-server",
+                  "containerPort": 443,
+                  "protocol": "TCP"
+                }
+              ],
+              "env": [
+                {
+                  "name": "POD_NAMESPACE",
+                  "valueFrom": {
+                    "fieldRef": {
+                      "fieldPath": "metadata.namespace"
+                    }
+                  }
+                },
+                {
+                  "name": "SECRET_NAME",
+                  "value": "kudo-webhook-server-secret"
+                }
+              ],
+              "resources": {
+                "requests": {
+                  "cpu": "100m",
+                  "memory": "50Mi"
+                }
+              },
+              "volumeMounts": [
+                {
+                  "name": "cert",
+                  "readOnly": true,
+                  "mountPath": "/tmp/cert"
+                }
+              ],
+              "readinessProbe": {
+                "tcpSocket": {
+                  "port": 443
+                }
+              },
+              "imagePullPolicy": "Always"
+            }
+          ],
+          "terminationGracePeriodSeconds": 10,
+          "serviceAccountName": "kudo-manager"
+        }
+      },
+      "serviceName": "kudo-controller-manager-service",
+      "updateStrategy": {}
+    },
+    "status": {
+      "replicas": 0
+    }
+  }
+]

--- a/pkg/kudoctl/kudoinit/setup/setup.go
+++ b/pkg/kudoctl/kudoinit/setup/setup.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/runtime"
-	"sigs.k8s.io/yaml"
 
 	"github.com/kudobuilder/kudo/pkg/kudoctl/clog"
 	"github.com/kudobuilder/kudo/pkg/kudoctl/kube"
@@ -148,25 +147,12 @@ func (i *Installer) Install(client *kube.Client) error {
 	return nil
 }
 
-func (i *Installer) AsYamlManifests() ([]string, error) {
+func (i *Installer) Resources() []runtime.Object {
 	var allManifests []runtime.Object
 
 	for _, initStep := range i.steps {
 		allManifests = append(allManifests, initStep.Resources()...)
 	}
 
-	return toYaml(allManifests)
-}
-
-func toYaml(objs []runtime.Object) ([]string, error) {
-	manifests := make([]string, len(objs))
-	for i, obj := range objs {
-		o, err := yaml.Marshal(obj)
-		if err != nil {
-			return []string{}, err
-		}
-		manifests[i] = string(o)
-	}
-
-	return manifests, nil
+	return allManifests
 }


### PR DESCRIPTION
Signed-off-by: Andreas Neumann <aneumann@mesosphere.com>

**What this PR does / why we need it**:

Add `--output` parameter to `kudo plan status` to allow json/yaml output instead of human readable format


<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
