### PR TITLE
Simplify waiting for the instance to be done

### DIFF
--- a/pkg/kudoctl/cmd/plan/plan_status.go
+++ b/pkg/kudoctl/cmd/plan/plan_status.go
@@ -120,7 +120,7 @@ func status(kc *kudo.Client, options *Options, ns string) error {
 		} else {
 			break
 		}
-		done, err := kc.IsInstanceDone(instance, nil)
+		done, err := kc.IsInstanceDone(instance, instance.Spec.PlanExecution.PlanName)
 		if err != nil {
 			return err
 		}

--- a/pkg/kudoctl/cmd/plan/plan_status.go
+++ b/pkg/kudoctl/cmd/plan/plan_status.go
@@ -120,7 +120,7 @@ func status(kc *kudo.Client, options *Options, ns string) error {
 		} else {
 			break
 		}
-		done, err := kc.IsInstanceDone(instance, instance.Spec.PlanExecution.PlanName)
+		done, err := instance.IsPlanDone(instance.Spec.PlanExecution.PlanName)
 		if err != nil {
 			return err
 		}

--- a/pkg/kudoctl/packages/install/package.go
+++ b/pkg/kudoctl/packages/install/package.go
@@ -73,12 +73,13 @@ func Package(
 		return nil
 	}
 
-	if err := install.Instance(client, resources.Instance); err != nil {
+	installed, err := install.Instance(client, resources.Instance)
+	if err != nil {
 		return err
 	}
 
 	if options.Wait != nil {
-		if err := install.WaitForInstance(client, resources.Instance, *options.Wait); err != nil {
+		if err := install.WaitForInstance(client, installed, *options.Wait); err != nil {
 			return err
 		}
 	}

--- a/pkg/kudoctl/util/kudo/kudo.go
+++ b/pkg/kudoctl/util/kudo/kudo.go
@@ -270,31 +270,8 @@ func (c *Client) WaitForInstance(instance *v1beta1.Instance, timeout time.Durati
 			return false, err
 		}
 
-		return c.IsInstanceDone(i, plan)
+		return i.IsPlanDone(plan)
 	})
-}
-
-// IsInstanceDone provides a check on instance to see if it is "finished" without retries
-// oldInstance is nil if there is no previous instance
-func (c *Client) IsInstanceDone(instance *v1beta1.Instance, plan string) (bool, error) {
-
-	// a shortcut for when there is no scheduled plan
-	if plan == "" {
-		clog.V(2).Printf("%s/%s has no scheduled plan\n", instance.Namespace, instance.Name)
-		return true, nil
-	}
-
-	newPlan := instance.Spec.PlanExecution.PlanName
-
-	// if either new plan was scheduled or if the old one finishes then we're done here. If the same plan was re-triggered
-	// (same plan but new UID) than we continue waiting for this new plan.
-	if newPlan != plan {
-		clog.V(2).Printf("%s/%s plan %q finished\n", instance.Namespace, instance.Name, plan)
-		return true, nil
-	}
-
-	clog.V(4).Printf("\r%s/%s plan %q is still %s", instance.Namespace, instance.Name, plan, instance.Spec.PlanExecution.Status)
-	return false, nil
 }
 
 // ListInstances lists all instances of given operator installed in the cluster in a given ns


### PR DESCRIPTION
Summary:
previous logic relied on figuring out the plan in progress and the plan status from the instance status. However, since 1.15 this can be simplified by using the `Spec.PlanExecution` which already has the relevant information.

Signed-off-by: Aleksey Dukhovniy <alex.dukhovniy@googlemail.com>