### PR TITLE
Add "--output yaml" to kudo package verify

### DIFF
--- a/pkg/kudoctl/cmd/package_create.go
+++ b/pkg/kudoctl/cmd/package_create.go
@@ -59,7 +59,7 @@ func newPackageCreateCmd(fs afero.Fs, out io.Writer) *cobra.Command {
 	f := cmd.Flags()
 	f.StringVarP(&pkg.destination, "destination", "d", ".", "Location to write the package.")
 	f.BoolVarP(&pkg.overwrite, "overwrite", "w", false, "Overwrite existing package.")
-	f.StringVarP((*string)(&pkg.output), "output", "o", "", "Output format")
+	f.StringVarP((*string)(&pkg.output), "output", "o", "", "Output format for command results, NOT the package format.")
 
 	return cmd
 }

--- a/pkg/kudoctl/cmd/package_create.go
+++ b/pkg/kudoctl/cmd/package_create.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 
+	"github.com/kudobuilder/kudo/pkg/kudoctl/cmd/output"
 	"github.com/kudobuilder/kudo/pkg/kudoctl/packages/writer"
 )
 
@@ -27,6 +28,7 @@ type packageCreateCmd struct {
 	destination string
 	overwrite   bool
 	out         io.Writer
+	output      output.Type
 	fs          afero.Fs
 }
 
@@ -43,6 +45,9 @@ func newPackageCreateCmd(fs afero.Fs, out io.Writer) *cobra.Command {
 			if err := validateOperatorArg(args); err != nil {
 				return err
 			}
+			if err := pkg.output.Validate(); err != nil {
+				return err
+			}
 			pkg.path = args[0]
 			if err := pkg.run(); err != nil {
 				return err
@@ -54,6 +59,8 @@ func newPackageCreateCmd(fs afero.Fs, out io.Writer) *cobra.Command {
 	f := cmd.Flags()
 	f.StringVarP(&pkg.destination, "destination", "d", ".", "Location to write the package.")
 	f.BoolVarP(&pkg.overwrite, "overwrite", "w", false, "Overwrite existing package.")
+	f.StringVarP((*string)(&pkg.output), "output", "o", "", "Output format")
+
 	return cmd
 }
 
@@ -66,12 +73,12 @@ func validateOperatorArg(args []string) error {
 
 // run returns the errors associated with cmd env
 func (pkg *packageCreateCmd) run() error {
-	err := verifyPackage(pkg.fs, pkg.path, pkg.out)
+	err := verifyPackage(pkg.fs, pkg.path, pkg.out, pkg.output)
 	if err != nil {
 		return err
 	}
 	tarfile, err := writer.WriteTgz(pkg.fs, pkg.path, pkg.destination, pkg.overwrite)
-	if err == nil {
+	if err == nil && pkg.output == "" {
 		fmt.Fprintf(pkg.out, "Package created: %v\n", tarfile)
 	}
 	return err

--- a/pkg/kudoctl/cmd/package_verify.go
+++ b/pkg/kudoctl/cmd/package_verify.go
@@ -36,7 +36,7 @@ func newPackageVerifyCmd(fs afero.Fs, out io.Writer) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP((*string)(&verifyCmd.output), "output", "o", "", "Output format")
+	cmd.Flags().StringVarP((*string)(&verifyCmd.output), "output", "o", "", "Output format for command results.")
 
 	return cmd
 }

--- a/pkg/kudoctl/cmd/package_verify.go
+++ b/pkg/kudoctl/cmd/package_verify.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 
+	"github.com/kudobuilder/kudo/pkg/kudoctl/cmd/output"
 	"github.com/kudobuilder/kudo/pkg/kudoctl/cmd/verify"
 	"github.com/kudobuilder/kudo/pkg/kudoctl/packages/reader"
 )
@@ -14,12 +15,13 @@ import (
 // package verify provides verification or linting checks against the package passed to the command.
 
 type packageVerifyCmd struct {
-	fs  afero.Fs
-	out io.Writer
+	fs     afero.Fs
+	out    io.Writer
+	output output.Type
 }
 
 func newPackageVerifyCmd(fs afero.Fs, out io.Writer) *cobra.Command {
-	list := &packageVerifyCmd{fs: fs, out: out}
+	verifyCmd := &packageVerifyCmd{fs: fs, out: out}
 
 	cmd := &cobra.Command{
 		Use:     "verify [package]",
@@ -29,31 +31,40 @@ func newPackageVerifyCmd(fs afero.Fs, out io.Writer) *cobra.Command {
 			if err := validateOperatorArg(args); err != nil {
 				return err
 			}
-			return list.run(args[0])
+
+			return verifyCmd.run(args[0])
 		},
 	}
+
+	cmd.Flags().StringVarP((*string)(&verifyCmd.output), "output", "o", "", "Output format")
 
 	return cmd
 }
 
 func (c *packageVerifyCmd) run(path string) error {
-
-	return verifyPackage(c.fs, path, c.out)
+	if err := c.output.Validate(); err != nil {
+		return err
+	}
+	return verifyPackage(c.fs, path, c.out, c.output)
 }
 
-func verifyPackage(fs afero.Fs, path string, out io.Writer) error {
+func verifyPackage(fs afero.Fs, path string, out io.Writer, outType output.Type) error {
 	pf, err := reader.FromDir(fs, path)
 	if err != nil {
 		return err
 	}
 	res := verify.PackageFiles(pf)
-	res.PrintWarnings(out)
-	res.PrintErrors(out)
 
-	if res.IsValid() {
-		fmt.Fprintf(out, "package is valid\n")
-		return nil
+	if outType != "" {
+		if err = output.WriteObject(res.ForOutput(), outType, out); err != nil {
+			return err
+		}
+	} else {
+		verify.PrintResult(res, out)
 	}
 
+	if res.IsValid() {
+		return nil
+	}
 	return fmt.Errorf("found %d package verification errors", len(res.Errors))
 }

--- a/pkg/kudoctl/cmd/package_verify_test.go
+++ b/pkg/kudoctl/cmd/package_verify_test.go
@@ -7,31 +7,55 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/kudobuilder/kudo/pkg/kudoctl/cmd/output"
 )
 
 func TestOperatorVerify(t *testing.T) {
-	file := "invalid-params"
-	out := &bytes.Buffer{}
-	cmd := newPackageVerifyCmd(fs, out)
-	//	if err := cmd.RunE(cmd, []string{"testdata/invalid-zk"}); err != nil {
-	if err := cmd.RunE(cmd, []string{"./testdata/invalidzk"}); err != nil {
-		assert.Error(t, err)
+	tests := []struct {
+		name          string
+		goldenFile    string
+		output        output.Type
+		expectedError string
+	}{
+		{name: "human readable output", goldenFile: "invalid-params.txt", output: ""},
+		{name: "yaml output", goldenFile: "invalid-params.yaml", output: output.TypeYAML},
+		{name: "json output", goldenFile: "invalid-params.json", output: output.TypeJSON},
+		{name: "invalid output", expectedError: output.InvalidOutputError, output: "invalid"},
 	}
 
-	gp := filepath.Join("testdata", file+".golden")
+	for _, tt := range tests {
+		tt := tt
 
-	if *updateGolden {
-		t.Log("update golden file")
+		t.Run(tt.name, func(t *testing.T) {
+			out := &bytes.Buffer{}
+			cmd := packageVerifyCmd{fs: fs, out: out, output: tt.output}
 
-		//nolint:gosec
-		if err := ioutil.WriteFile(gp, out.Bytes(), 0644); err != nil {
-			t.Fatalf("failed to update golden file: %s", err)
-		}
+			if err := cmd.run("./testdata/invalidzk"); err != nil {
+				if tt.expectedError != "" {
+					assert.Equal(t, tt.expectedError, err.Error())
+				}
+				// We expect an error in all other cases, because we verify an invalid operator here
+			}
+
+			if tt.goldenFile != "" {
+				gp := filepath.Join("testdata", tt.goldenFile+".golden")
+
+				if *updateGolden {
+					t.Log("update golden file")
+
+					//nolint:gosec
+					if err := ioutil.WriteFile(gp, out.Bytes(), 0644); err != nil {
+						t.Fatalf("failed to update golden file: %s", err)
+					}
+				}
+				g, err := ioutil.ReadFile(gp)
+				if err != nil {
+					t.Fatalf("failed reading .golden: %s", err)
+				}
+
+				assert.Equal(t, string(g), out.String(), "output does not match .golden file %s", gp)
+			}
+		})
 	}
-	g, err := ioutil.ReadFile(gp)
-	if err != nil {
-		t.Fatalf("failed reading .golden: %s", err)
-	}
-
-	assert.Equal(t, string(g), out.String(), "yaml does not match .golden file %s", gp)
 }

--- a/pkg/kudoctl/cmd/plan.go
+++ b/pkg/kudoctl/cmd/plan.go
@@ -68,7 +68,7 @@ func NewPlanStatusCmd(out io.Writer) *cobra.Command {
 
 	cmd.Flags().StringVar(&options.Instance, "instance", "", "The instance name available from 'kubectl get instances'")
 	cmd.Flags().BoolVar(&options.Wait, "wait", false, "Specify if the CLI should wait for the plan to complete before returning (default \"false\")")
-	cmd.Flags().StringVarP(options.Output.AsStringPtr(), "output", "o", "", "Output format")
+	cmd.Flags().StringVarP(options.Output.AsStringPtr(), "output", "o", "", "Output format for command results.")
 
 	if err := cmd.MarkFlagRequired("instance"); err != nil {
 		clog.Printf("Please choose the instance with '--instance=<instanceName>': %v", err)

--- a/pkg/kudoctl/cmd/testdata/invalid-params.json.golden
+++ b/pkg/kudoctl/cmd/testdata/invalid-params.json.golden
@@ -1,0 +1,12 @@
+{
+  "errors": [
+    "parameter \"Cpus\" has a duplicate",
+    "parameter \"comma,\" contains invalid character ','",
+    "\"operatorVersion\" is required and must be semver",
+    "plan \"not-existing-plan\" used in parameter \"comma,\" is not defined"
+  ],
+  "warnings": [
+    "parameter \"Cpus\" defined but not used."
+  ],
+  "valid": false
+}

--- a/pkg/kudoctl/cmd/testdata/invalid-params.txt.golden
+++ b/pkg/kudoctl/cmd/testdata/invalid-params.txt.golden
@@ -1,0 +1,7 @@
+Warnings                              
+parameter "Cpus" defined but not used.
+Errors                                                            
+parameter "Cpus" has a duplicate                                  
+parameter "comma," contains invalid character ','                 
+"operatorVersion" is required and must be semver                  
+plan "not-existing-plan" used in parameter "comma," is not defined

--- a/pkg/kudoctl/cmd/testdata/invalid-params.yaml.golden
+++ b/pkg/kudoctl/cmd/testdata/invalid-params.yaml.golden
@@ -1,0 +1,9 @@
+errors:
+- parameter "Cpus" has a duplicate
+- parameter "comma," contains invalid character ','
+- '"operatorVersion" is required and must be semver'
+- plan "not-existing-plan" used in parameter "comma," is not defined
+valid: false
+warnings:
+- parameter "Cpus" defined but not used.
+

--- a/pkg/kudoctl/cmd/verify/verify.go
+++ b/pkg/kudoctl/cmd/verify/verify.go
@@ -2,6 +2,7 @@ package verify
 
 import (
 	"fmt"
+	"io"
 	"strings"
 
 	"github.com/kudobuilder/kudo/pkg/kudoctl/packages"
@@ -32,6 +33,15 @@ func PackageFiles(pf *packages.Files) verifier.Result {
 		res.Merge(vv.Verify(pf))
 	}
 	return res
+}
+
+func PrintResult(res verifier.Result, out io.Writer) {
+	res.PrintWarnings(out)
+	res.PrintErrors(out)
+
+	if res.IsValid() {
+		fmt.Fprintf(out, "package is valid\n")
+	}
 }
 
 // DuplicateVerifier provides verification that there are no duplicates disallowing casing (Kudo and kudo are duplicates)

--- a/pkg/kudoctl/verifier/result.go
+++ b/pkg/kudoctl/verifier/result.go
@@ -8,6 +8,13 @@ import (
 	"github.com/gosuri/uitable"
 )
 
+// ResultForOutput provides a serialization format for yaml/json output of a result
+type ResultForOutput struct {
+	Errors   []string `json:"errors"`
+	Warnings []string `json:"warnings"`
+	Valid    bool     `json:"valid"`
+}
+
 // Result holds the errors and warnings of a package verification
 type Result struct {
 	Errors   []string
@@ -32,6 +39,14 @@ func NewWarning(warn ...string) Result {
 	result := NewResult()
 	result.AddWarnings(warn...)
 	return result
+}
+
+func (vr *Result) ForOutput() ResultForOutput {
+	return ResultForOutput{
+		Errors:   vr.Errors,
+		Warnings: vr.Warnings,
+		Valid:    vr.IsValid(),
+	}
 }
 
 // AddErrors adds an arbitrary error string to the verification result


### PR DESCRIPTION
Signed-off-by: Andreas Neumann <aneumann@mesosphere.com>

**What this PR does / why we need it**:

Add `--output` parameter to `package verify` and `package create`

This allows users to easily parse the output of both commands


<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1644
