### PR TITLE
Separate execution of Go integration tests and kuttl integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - checkout
       - run: echo 'export INTEGRATION_OUTPUT_JUNIT="true"' >> $BASH_ENV
-      - run: ./test/run_tests.sh integration-test
+      - run: ./test/run_tests.sh "integration-test kuttl-test"
       - store_test_results:
           path: reports/
 

--- a/Makefile
+++ b/Makefile
@@ -43,27 +43,32 @@ else
 	go test ./pkg/... ./cmd/... -v -mod=readonly -coverprofile cover.out
 endif
 
+.PHONY: integration-test
+# Run Go integration tests
+integration-test: cli-fast manager-fast ##Runs Go integration tests
+	TEST_ONLY=$(TEST) ./hack/run-integration-tests.sh
+
+.PHONY: kuttl-test
+# Run kuttl integration tests
+kuttl-test: cli-fast manager-fast ## Runs KUTTL integration tests (prefix TEST=testname to run single suite)
+	TEST_ONLY=$(TEST) ./hack/run-kuttl-tests.sh
+
 # Run e2e tests
 .PHONY: e2e-test
-e2e-test: cli-fast manager-fast
+e2e-test: cli-fast manager-fast ## Runs KUTTL e2e tests (prefix TEST=testname to run single suite)
 	TEST_ONLY=$(TEST) ./hack/run-e2e-tests.sh
-
-.PHONY: integration-test
-# Run integration tests
-integration-test: cli-fast manager-fast ##Runs integration tests
-	TEST_ONLY=$(TEST) ./hack/run-integration-tests.sh
 
 .PHONY: operator-test
 operator-test: cli-fast manager-fast
 	./hack/run-operator-tests.sh
 
 .PHONY: upgrade-test
-upgrade-test: cli-fast manager-fast
+upgrade-test: cli-fast manager-fast ## Runs KUTTL upgrade tests (prefix TEST=testname to run single suite)
 	TEST_ONLY=$(TEST) ./hack/run-upgrade-tests.sh
 
 .PHONY: test-clean
 # Clean test reports
-test-clean:	## cleans test outputs
+test-clean:	## Cleans test outputs
 	rm -f cover.out cover-integration.out
 
 ##############################

--- a/hack/run-integration-tests.sh
+++ b/hack/run-integration-tests.sh
@@ -6,17 +6,22 @@ set -o pipefail
 set -o xtrace
 
 INTEGRATION_OUTPUT_JUNIT=${INTEGRATION_OUTPUT_JUNIT:-false}
-TEST_ONLY=${TEST_ONLY:+"--test $TEST_ONLY"}
+
+MOD_FLAGS="-mod=readonly"
+
+# When run from a Goland/IntelliJ terminal, Goland/IntelliJ already set '-mod=readonly'
+if [ "${_INTELLIJ_FORCE_SET_GOFLAGS+x}" ]
+then
+   MOD_FLAGS=""
+fi
 
 if [ "$INTEGRATION_OUTPUT_JUNIT" == true ]
 then
     echo "Running integration tests with junit output"
     mkdir -p reports/
     go get github.com/jstemmer/go-junit-report
-    go test -tags integration ./pkg/... ./cmd/... -v -mod=readonly -coverprofile cover-integration.out 2>&1 |tee /dev/fd/2 |go-junit-report -set-exit-code > reports/integration_report.xml
-    go run ./cmd/kubectl-kudo test --config test/kudo-integration-test.yaml ${TEST_ONLY} 2>&1 |tee /dev/fd/2 |go-junit-report -set-exit-code > reports/kudo_test_report.xml
+    go test -tags integration ./pkg/... ./cmd/... -v ${MOD_FLAGS} -coverprofile cover-integration.out 2>&1 |tee /dev/fd/2 |go-junit-report -set-exit-code > reports/integration_report.xml
 else
     echo "Running integration tests without junit output"
-    go test -tags integration ./pkg/... ./cmd/... -v -mod=readonly -coverprofile cover-integration.out
-    go run ./cmd/kubectl-kudo test --config test/kudo-integration-test.yaml ${TEST_ONLY}
+    go test -tags integration ./pkg/... ./cmd/... -v ${MOD_FLAGS} -coverprofile cover-integration.out
 fi

--- a/hack/run-kuttl-tests.sh
+++ b/hack/run-kuttl-tests.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+INTEGRATION_OUTPUT_JUNIT=${INTEGRATION_OUTPUT_JUNIT:-false}
+TEST_ONLY=${TEST_ONLY:+"--test $TEST_ONLY"}
+
+if [ "$INTEGRATION_OUTPUT_JUNIT" == true ]
+then
+    echo "Running integration tests with junit output"
+    mkdir -p reports/
+    go get github.com/jstemmer/go-junit-report
+    go run ./cmd/kubectl-kudo test --config test/kudo-integration-test.yaml ${TEST_ONLY} 2>&1 |tee /dev/fd/2 |go-junit-report -set-exit-code > reports/kudo_test_report.xml
+else
+    echo "Running integration tests without junit output"
+    go run ./cmd/kubectl-kudo test --config test/kudo-integration-test.yaml ${TEST_ONLY}
+fi

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -18,6 +18,7 @@ COPY config/ config/
 COPY pkg/ pkg/
 COPY cmd/ cmd/
 COPY hack/run-integration-tests.sh hack/run-integration-tests.sh
+COPY hack/run-kuttl-tests.sh hack/run-kuttl-tests.sh
 COPY hack/run-e2e-tests.sh hack/run-e2e-tests.sh
 COPY hack/run-operator-tests.sh hack/run-operator-tests.sh
 COPY hack/run-upgrade-tests.sh hack/run-upgrade-tests.sh


### PR DESCRIPTION
Use separate targets in Makefile so running a single suite is easier

- Separate Go integration tests and kuttl integration tests
- Test for Goland variable in running go integration tests
- Add more documentation to make help

Signed-off-by: Andreas Neumann <aneumann@mesosphere.com>

**What this PR does / why we need it**:
