### PR TITLE
Fix log for init --upgrade, interfers with --dry-run --output yaml

### DIFF
--- a/pkg/kudoctl/kudoinit/setup/setup.go
+++ b/pkg/kudoctl/kudoinit/setup/setup.go
@@ -89,7 +89,7 @@ func (i *Installer) PreUpgradeVerify(client *kube.Client, result *verifier.Resul
 
 	// Step 2 - Verify that any migration is possible
 	migrations := requiredMigrations()
-	clog.Printf("Verify that %d required migrations can be applied", len(migrations))
+	clog.V(1).Printf("Verify that %d required migrations can be applied", len(migrations))
 	for _, m := range migrations {
 		if err := m.CanMigrate(client); err != nil {
 			result.AddErrors(fmt.Errorf("migration %s failed install check: %v", m, err).Error())


### PR DESCRIPTION
Signed-off-by: Andreas Neumann <aneumann@mesosphere.com>

**What this PR does / why we need it**:

There is a log in the `kudo init --upgrade` path that logs directly into out. This interferes with the uninstall:

`kudo init --upgrade --dry-run --output yaml | kubectl delete -f -`