### PR TITLE
Use Verify Installation for `--wait` on init

### DIFF
--- a/pkg/engine/health/health.go
+++ b/pkg/engine/health/health.go
@@ -111,6 +111,12 @@ func IsHealthy(obj runtime.Object) error {
 		}
 		return fmt.Errorf("pod %q is not running yet: %s", obj.Name, obj.Status.Phase)
 
+	case *corev1.Namespace:
+		if obj.Status.Phase == corev1.NamespaceActive {
+			return nil
+		}
+		return fmt.Errorf("namespace %s is not active: %s", obj.Name, obj.Status.Phase)
+
 	// unless we build logic for what a healthy object is, assume it's healthy when created.
 	default:
 		log.Printf("HealthUtil: Unknown type %s is marked healthy by default", reflect.TypeOf(obj))

--- a/pkg/kudoctl/cmd/init.go
+++ b/pkg/kudoctl/cmd/init.go
@@ -218,7 +218,7 @@ func (initCmd *initCmd) run() error {
 
 	if initCmd.wait {
 		clog.Printf("⌛Waiting for KUDO controller to be ready in your cluster...")
-		err := setup.WatchKUDOUntilReady(initCmd.client.KubeClient, opts, initCmd.timeout)
+		err := setup.WatchKUDOUntilReady(installer, initCmd.client, initCmd.timeout)
 		if err != nil {
 			return errors.New("watch timed out, readiness uncertain")
 		}
@@ -287,13 +287,12 @@ func (initCmd *initCmd) runYamlOutput(installer kudoinit.Artifacter) error {
 // verifyExistingInstallation checks if the current installation is valid and as expected
 func (initCmd *initCmd) verifyExistingInstallation(v kudoinit.InstallVerifier) error {
 	clog.V(4).Printf("verify existing installation")
-	result := verifier.NewResult()
-	if err := v.VerifyInstallation(initCmd.client, &result); err != nil {
+	ok, err := setup.VerifyExistingInstallation(v, initCmd.client, initCmd.out)
+	if err != nil {
 		return err
 	}
-	result.PrintWarnings(initCmd.out)
-	if !result.IsValid() {
-		result.PrintErrors(initCmd.out)
+	if !ok {
+		return fmt.Errorf("KUDO installation is not valid")
 	}
 	return nil
 }

--- a/pkg/kudoctl/kudoinit/crd/crds.go
+++ b/pkg/kudoctl/kudoinit/crd/crds.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/yaml"
 
+	"github.com/kudobuilder/kudo/pkg/engine/health"
 	"github.com/kudobuilder/kudo/pkg/kudoctl/clog"
 	"github.com/kudobuilder/kudo/pkg/kudoctl/kube"
 	"github.com/kudobuilder/kudo/pkg/kudoctl/kudoinit"
@@ -119,6 +120,10 @@ func (c Initializer) verifyInstallation(client v1beta1.CustomResourceDefinitions
 	}
 	if existingCrd.Spec.Version != crd.Spec.Version {
 		result.AddErrors(fmt.Sprintf("Installed CRD %s has invalid version %s, expected %s", crd.Name, existingCrd.Spec.Version, crd.Spec.Version))
+		return nil
+	}
+	if err := health.IsHealthy(existingCrd); err != nil {
+		result.AddErrors(fmt.Sprintf("Installed CRD %s is not healthy: %v", crd.Name, err))
 		return nil
 	}
 	clog.V(2).Printf("CRD %s is installed with version %s", crd.Name, existingCrd.Spec.Versions[0].Name)

--- a/pkg/kudoctl/kudoinit/setup/setup.go
+++ b/pkg/kudoctl/kudoinit/setup/setup.go
@@ -2,6 +2,7 @@ package setup
 
 import (
 	"fmt"
+	"io"
 
 	"k8s.io/apimachinery/pkg/runtime"
 
@@ -166,4 +167,23 @@ func (i *Installer) Resources() []runtime.Object {
 	}
 
 	return allManifests
+}
+
+// verifyExistingInstallation checks if the current installation is valid and as expected
+func VerifyExistingInstallation(v kudoinit.InstallVerifier, client *kube.Client, out io.Writer) (bool, error) {
+	clog.V(4).Printf("verify existing installation")
+	result := verifier.NewResult()
+	if err := v.VerifyInstallation(client, &result); err != nil {
+		return false, err
+	}
+	if out != nil {
+		result.PrintWarnings(out)
+	}
+	if !result.IsValid() {
+		if out != nil {
+			result.PrintErrors(out)
+		}
+		return false, nil
+	}
+	return true, nil
 }

--- a/pkg/kudoctl/kudoinit/setup/wait.go
+++ b/pkg/kudoctl/kudoinit/setup/wait.go
@@ -1,36 +1,22 @@
 package setup
 
 import (
-	"context"
 	"time"
 
-	"github.com/kudobuilder/kudo/pkg/engine/health"
+	"github.com/kudobuilder/kudo/pkg/kudoctl/kube"
 
 	"k8s.io/apimachinery/pkg/util/wait"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
-	appsv1 "k8s.io/client-go/kubernetes/typed/apps/v1"
 
 	"github.com/kudobuilder/kudo/pkg/kudoctl/kudoinit"
 )
 
-// WatchKUDOUntilReady waits for the KUDO pod to become available.
+// WatchKUDOUntilReady waits for the KUDO installation to become available.
 //
 // Returns no error if it exists. If the timeout was reached and it could not find the pod, it returns error.
-func WatchKUDOUntilReady(client kubernetes.Interface, opts kudoinit.Options, timeout int64) error {
+func WatchKUDOUntilReady(v kudoinit.InstallVerifier, client *kube.Client, timeout int64) error {
 	return wait.PollImmediate(500*time.Millisecond, time.Duration(timeout)*time.Second,
-		func() (bool, error) { return verifyKudoStatefulset(client.AppsV1(), opts.Namespace) })
-}
-
-func verifyKudoStatefulset(client appsv1.StatefulSetsGetter, namespace string) (bool, error) {
-	ss, err := client.StatefulSets(namespace).Get(context.TODO(), kudoinit.DefaultManagerName, metav1.GetOptions{})
-	if err != nil || ss == nil {
-		return false, err
-	}
-	err = health.IsHealthy(ss)
-	if err != nil {
-		return false, nil
-	}
-	return true, nil
+		func() (bool, error) {
+			return VerifyExistingInstallation(v, client, nil)
+		},
+	)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Instead of monitoring the statefulset of the KUDO manager, we can use the installers `VerifyInstallation` to wait for all resources to be healthy.

<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1653 
