### PR TITLE
Add the used Kubernetes Version to `kudo version` output

### DIFF
--- a/pkg/kudoctl/cmd/diagnostics/print_test.go
+++ b/pkg/kudoctl/cmd/diagnostics/print_test.go
@@ -82,7 +82,7 @@ builddate: "1970-01-01T00:00:00Z"
 goversion: go1.13.4
 compiler: gc
 platform: linux/amd64
-kubernetesversion: v0.18.6
+kubernetesclientversion: v0.18.6
 `
 )
 
@@ -323,13 +323,13 @@ func TestPrinter_printYaml(t *testing.T) {
 		{
 			desc: "print Yaml OK",
 			v: version.Info{
-				GitVersion:        "dev",
-				GitCommit:         "dev",
-				BuildDate:         "1970-01-01T00:00:00Z",
-				GoVersion:         "go1.13.4",
-				Compiler:          "gc",
-				Platform:          "linux/amd64",
-				KubernetesVersion: "v0.18.6",
+				GitVersion:              "dev",
+				GitCommit:               "dev",
+				BuildDate:               "1970-01-01T00:00:00Z",
+				GoVersion:               "go1.13.4",
+				Compiler:                "gc",
+				Platform:                "linux/amd64",
+				KubernetesClientVersion: "v0.18.6",
 			},
 			parentDir: "root",
 			name:      "version",

--- a/pkg/kudoctl/cmd/diagnostics/print_test.go
+++ b/pkg/kudoctl/cmd/diagnostics/print_test.go
@@ -82,6 +82,7 @@ builddate: "1970-01-01T00:00:00Z"
 goversion: go1.13.4
 compiler: gc
 platform: linux/amd64
+kubernetesapi: v0.18.6
 `
 )
 
@@ -322,12 +323,13 @@ func TestPrinter_printYaml(t *testing.T) {
 		{
 			desc: "print Yaml OK",
 			v: version.Info{
-				GitVersion: "dev",
-				GitCommit:  "dev",
-				BuildDate:  "1970-01-01T00:00:00Z",
-				GoVersion:  "go1.13.4",
-				Compiler:   "gc",
-				Platform:   "linux/amd64",
+				GitVersion:    "dev",
+				GitCommit:     "dev",
+				BuildDate:     "1970-01-01T00:00:00Z",
+				GoVersion:     "go1.13.4",
+				Compiler:      "gc",
+				Platform:      "linux/amd64",
+				KubernetesAPI: "v0.18.6",
 			},
 			parentDir: "root",
 			name:      "version",

--- a/pkg/kudoctl/cmd/diagnostics/print_test.go
+++ b/pkg/kudoctl/cmd/diagnostics/print_test.go
@@ -82,7 +82,7 @@ builddate: "1970-01-01T00:00:00Z"
 goversion: go1.13.4
 compiler: gc
 platform: linux/amd64
-kubernetesapi: v0.18.6
+kubernetesversion: v0.18.6
 `
 )
 
@@ -323,13 +323,13 @@ func TestPrinter_printYaml(t *testing.T) {
 		{
 			desc: "print Yaml OK",
 			v: version.Info{
-				GitVersion:    "dev",
-				GitCommit:     "dev",
-				BuildDate:     "1970-01-01T00:00:00Z",
-				GoVersion:     "go1.13.4",
-				Compiler:      "gc",
-				Platform:      "linux/amd64",
-				KubernetesAPI: "v0.18.6",
+				GitVersion:        "dev",
+				GitCommit:         "dev",
+				BuildDate:         "1970-01-01T00:00:00Z",
+				GoVersion:         "go1.13.4",
+				Compiler:          "gc",
+				Platform:          "linux/amd64",
+				KubernetesVersion: "v0.18.6",
 			},
 			parentDir: "root",
 			name:      "version",

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -12,13 +12,13 @@ import (
 
 // Info contains versioning information.
 type Info struct {
-	GitVersion    string `json:"gitVersion"`
-	GitCommit     string `json:"gitCommit"`
-	BuildDate     string `json:"buildDate"`
-	GoVersion     string `json:"goVersion"`
-	Compiler      string `json:"compiler"`
-	Platform      string `json:"platform"`
-	KubernetesAPI string `json:"kubernetesApi"`
+	GitVersion        string `json:"gitVersion"`
+	GitCommit         string `json:"gitCommit"`
+	BuildDate         string `json:"buildDate"`
+	GoVersion         string `json:"goVersion"`
+	Compiler          string `json:"compiler"`
+	Platform          string `json:"platform"`
+	KubernetesVersion string `json:"kubernetesClientApi"`
 }
 
 // String returns info as a human-friendly version string.
@@ -54,8 +54,8 @@ func Get() Info {
 
 	if info, ok := debug.ReadBuildInfo(); ok {
 		for _, dep := range info.Deps {
-			if dep.Path == "k8s.io/api" {
-				result.KubernetesAPI = dep.Version
+			if dep.Path == "k8s.io/client-go" {
+				result.KubernetesVersion = dep.Version
 			}
 		}
 	}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"runtime/debug"
 	"strings"
 
 	"github.com/Masterminds/semver/v3"
@@ -11,12 +12,13 @@ import (
 
 // Info contains versioning information.
 type Info struct {
-	GitVersion string `json:"gitVersion"`
-	GitCommit  string `json:"gitCommit"`
-	BuildDate  string `json:"buildDate"`
-	GoVersion  string `json:"goVersion"`
-	Compiler   string `json:"compiler"`
-	Platform   string `json:"platform"`
+	GitVersion    string `json:"gitVersion"`
+	GitCommit     string `json:"gitCommit"`
+	BuildDate     string `json:"buildDate"`
+	GoVersion     string `json:"goVersion"`
+	Compiler      string `json:"compiler"`
+	Platform      string `json:"platform"`
+	KubernetesAPI string `json:"kubernetesApi"`
 }
 
 // String returns info as a human-friendly version string.
@@ -41,7 +43,7 @@ func Get() Info {
 		gitCommit = "dev"
 	}
 
-	return Info{
+	result := Info{
 		GitVersion: gitVersion,
 		GitCommit:  gitCommit,
 		BuildDate:  buildDate,
@@ -49,6 +51,16 @@ func Get() Info {
 		Compiler:   runtime.Compiler,
 		Platform:   fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
 	}
+
+	if info, ok := debug.ReadBuildInfo(); ok {
+		for _, dep := range info.Deps {
+			if dep.Path == "k8s.io/api" {
+				result.KubernetesAPI = dep.Version
+			}
+		}
+	}
+
+	return result
 }
 
 // Version is an extension of semver.Version

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -12,13 +12,13 @@ import (
 
 // Info contains versioning information.
 type Info struct {
-	GitVersion        string `json:"gitVersion"`
-	GitCommit         string `json:"gitCommit"`
-	BuildDate         string `json:"buildDate"`
-	GoVersion         string `json:"goVersion"`
-	Compiler          string `json:"compiler"`
-	Platform          string `json:"platform"`
-	KubernetesVersion string `json:"kubernetesClientApi"`
+	GitVersion              string `json:"gitVersion"`
+	GitCommit               string `json:"gitCommit"`
+	BuildDate               string `json:"buildDate"`
+	GoVersion               string `json:"goVersion"`
+	Compiler                string `json:"compiler"`
+	Platform                string `json:"platform"`
+	KubernetesClientVersion string `json:"kubernetesClientVersion"`
 }
 
 // String returns info as a human-friendly version string.
@@ -55,7 +55,7 @@ func Get() Info {
 	if info, ok := debug.ReadBuildInfo(); ok {
 		for _, dep := range info.Deps {
 			if dep.Path == "k8s.io/client-go" {
-				result.KubernetesVersion = dep.Version
+				result.KubernetesClientVersion = dep.Version
 			}
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Andreas Neumann <aneumann@mesosphere.com>

**What this PR does / why we need it**:

This PR shows the used Kubernetes API in the version output. Helps users to understand which version of kubernetes is supported, see #1642 
