### PR TITLE
kudo get cmd help

### DIFF
--- a/pkg/kudoctl/clog/log.go
+++ b/pkg/kudoctl/clog/log.go
@@ -59,7 +59,7 @@ func (l *Level) Set(value string) error {
 
 // Type is part of flag.Value interface
 func (l *Level) Type() string {
-	return string(*l)
+	return fmt.Sprint(*l)
 }
 
 //// pflag.Value interface ends

--- a/pkg/kudoctl/cmd/get.go
+++ b/pkg/kudoctl/cmd/get.go
@@ -10,7 +10,19 @@ import (
 )
 
 const getExample = `  # Get all available instances
-  kubectl kudo get instances 
+  kubectl kudo get instances
+  
+  # Get all available operators
+  kubectl kudo get operators
+
+  # Get all available operatorversions
+  kubectl kudo get operatorversions
+
+  # Get all installed components
+  kubectl kudo get all
+
+  # Get all installed components as yaml
+  kubectl kudo get all -o yaml
 `
 
 // newGetCmd creates a command that lists the instances in the cluster
@@ -20,8 +32,8 @@ func newGetCmd(out io.Writer) *cobra.Command {
 	}
 
 	getCmd := &cobra.Command{
-		Use:     "get instances",
-		Short:   "Gets all available instances.",
+		Use:     "get <instances|operators|operatorversions|all> [flags]",
+		Short:   "Gets list of installed components (instances, operators, operatorversions or all).",
 		Example: getExample,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, err := env.GetClient(&Settings)
@@ -35,7 +47,7 @@ func newGetCmd(out io.Writer) *cobra.Command {
 		},
 	}
 
-	getCmd.Flags().StringVarP(opts.Output.AsStringPtr(), "output", "o", "", "Output format for command results.")
+	getCmd.Flags().StringVarP(opts.Output.AsStringPtr(), "output", "o", "", "Output format. One of: json|yaml")
 
 	return getCmd
 }

--- a/pkg/kudoctl/cmd/get/get.go
+++ b/pkg/kudoctl/cmd/get/get.go
@@ -57,7 +57,7 @@ func Run(args []string, opts CmdOpts) error {
 	}
 
 	if opts.Output.IsFormattedOutput() {
-		outObj := []interface{}{}
+		var outObj []interface{}
 		for _, o := range objs {
 			outObj = append(outObj, o)
 		}
@@ -74,8 +74,8 @@ func Run(args []string, opts CmdOpts) error {
 		}
 		tree.AddBranch(name)
 	}
-	_, _ = fmt.Fprintf(opts.Out, "List of current installed %s in namespace %q:\n", args[0], opts.Namespace)
-	_, _ = fmt.Fprintln(opts.Out, tree.String())
+	fmt.Fprintf(opts.Out, "List of current installed %s in namespace %q:\n", args[0], opts.Namespace)
+	fmt.Fprintln(opts.Out, tree.String())
 	return err
 }
 
@@ -94,7 +94,7 @@ func runGetAll(opts CmdOpts) error {
 	}
 
 	if opts.Output.IsFormattedOutput() {
-		outObj := []interface{}{}
+		var outObj []interface{}
 		for _, o := range operators {
 			outObj = append(outObj, o)
 		}
@@ -132,8 +132,8 @@ func printAllTree(opts CmdOpts, operators, operatorversions, instances []runtime
 		}
 	}
 
-	_, _ = fmt.Fprintf(opts.Out, "List of current installed operators including versions and instances in namespace %q:\n", opts.Namespace)
-	_, _ = fmt.Fprintln(opts.Out, rootTree.String())
+	fmt.Fprintf(opts.Out, "List of current installed operators including versions and instances in namespace %q:\n", opts.Namespace)
+	fmt.Fprintln(opts.Out, rootTree.String())
 	return nil
 
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Update to provide proper help messaging for the get command at the root level and at the get level

```
go run cmd/kubectl-kudo/main.go -h
KUDO CLI and future sub-commands can be used to manipulate, inspect and troubleshoot KUDO-specific CRDs
and serves as an API aggregation layer.

Usage:
  kubectl-kudo [command]

Examples:
...
  # Get instances
  kubectl kudo get instances [flags]

Available Commands:
  diagnostics collect diagnostics
  get         Gets list of installed components (instances, operators, operatorversions or all).


Flags:
  -h, --help                  help for kubectl-kudo
      --home string           Location of your KUDO config. (default "/Users/kensipe/.kudo")
...
Use "kubectl-kudo [command] --help" for more information about a command.
```

and 

```
go run cmd/kubectl-kudo/main.go get -h
Gets list of installed components (instances, operators, operatorversions or all).

Usage:
  kubectl-kudo get <instances|operators|operatorversions|all> [flags]

Examples:
  # Get all available instances
  kubectl kudo get instances

  # Get all available operators
  kubectl kudo get operators

  # Get all available operatorversions
  kubectl kudo get operatorversions

  # Get all installed components
  kubectl kudo get all

  # Get all installed components as yaml
  kubectl kudo get all -o yaml


Flags:
  -h, --help            help for get
  -o, --output string   Output format. One of: json|yaml

Global Flags:
      --home string           Location of your KUDO config. (default "/Users/kensipe/.kudo")
      --kubeconfig string     Path to your Kubernetes configuration file. (default "/Users/kensipe/.kube/config")
  -n, --namespace string      Target namespace for the object. (default "default")
      --request-timeout int   Request timeout value, in seconds.  Defaults to 0 (unlimited)
  -v, --v 0                   Log level for V logs
      --validate-install      Validate KUDO installation before running. (default true)
```

Fixes #1673 
