### PR TITLE
Install operator instance from in-cluster operator version resource

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	golang.org/x/tools v0.0.0-20200723000907-a7c6fd066f6d // indirect
 	google.golang.org/genproto v0.0.0-20200117163144-32f20d992d24 // indirect
 	gopkg.in/yaml.v2 v2.3.0
+	gotest.tools v2.2.0+incompatible
 	k8s.io/api v0.18.6
 	k8s.io/apiextensions-apiserver v0.18.6
 	k8s.io/apimachinery v0.18.6

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,6 @@ require (
 	golang.org/x/tools v0.0.0-20200723000907-a7c6fd066f6d // indirect
 	google.golang.org/genproto v0.0.0-20200117163144-32f20d992d24 // indirect
 	gopkg.in/yaml.v2 v2.3.0
-	gotest.tools v2.2.0+incompatible
 	k8s.io/api v0.18.6
 	k8s.io/apiextensions-apiserver v0.18.6
 	k8s.io/apimachinery v0.18.6

--- a/go.sum
+++ b/go.sum
@@ -268,8 +268,6 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/huandu/xstrings v1.3.1 h1:4jgBlKK6tLKFvO8u5pmYjG91cqytmDCDvGh7ECVFfFs=
 github.com/huandu/xstrings v1.3.1/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
-github.com/imdario/mergo v0.3.6/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
-github.com/imdario/mergo v0.3.7/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.9 h1:UauaLniWCFHWd+Jp9oCEkTBj8VO/9DKg3PV3VCNMDIg=
 github.com/imdario/mergo v0.3.9/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
@@ -301,8 +299,6 @@ github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.5/go.mod h1:9r2w37qlBe7rQ6e1fg1S/9xpWHSnaqNdHD3WcMdbPDA=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/kudobuilder/kuttl v0.5.1 h1:wLVfztMqVCGBws6RweEfDPVXaa+ZRBirAJjJ/HiklMA=
-github.com/kudobuilder/kuttl v0.5.1/go.mod h1:o9M5BBmunm69oMnPjvNGb6biz3nm5AswAdJ0EIhTJQA=
 github.com/kudobuilder/kuttl v0.6.0 h1:5mc65Q4yShSStcCKxl672kWhTPm0kQq0nl6z6GRcxm8=
 github.com/kudobuilder/kuttl v0.6.0/go.mod h1:HAaSKGN3P7VJqbBIWQlbhrkvFcNe013oLkwvk0lM1kE=
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de h1:9TO3cAIGXtEhnIaL+V+BEER86oLrvS+kWobKpbJuye0=
@@ -440,10 +436,8 @@ github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoH
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
-github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/thoas/go-funk v0.6.0/go.mod h1:+IWnUfUmFO1+WVYQWQtIJHeRRdaIyyYglZN7xzUPe4Q=
 github.com/thoas/go-funk v0.7.0 h1:GmirKrs6j6zJbhJIficOsz2aAI7700KsU/5YrdHRM1Y=
 github.com/thoas/go-funk v0.7.0/go.mod h1:+IWnUfUmFO1+WVYQWQtIJHeRRdaIyyYglZN7xzUPe4Q=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
@@ -518,7 +512,6 @@ golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20190813141303-74dc4d7220e7/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190827160401-ba9fcec4b297/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191004110552-13f9640d40b9/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
-golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200520004742-59133d7f0dd7/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200625001655-4c5254603344 h1:vGXIOMxbNfDTk/aXCmfdLgkrSV+Z2tcbze+pEc3v5W4=
@@ -699,7 +692,6 @@ k8s.io/utils v0.0.0-20200324210504-a9aa75ae1b89/go.mod h1:sZAwmy6armz5eXlNoLmJcl
 k8s.io/utils v0.0.0-20200603063816-c1c6865ac451 h1:v8ud2Up6QK1lNOKFgiIVrZdMg7MpmSnvtrOieolJKoE=
 k8s.io/utils v0.0.0-20200603063816-c1c6865ac451/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.7/go.mod h1:PHgbrJT7lCHcxMU+mDHEm+nx46H4zuuHZkDP6icnhu0=
-sigs.k8s.io/controller-runtime v0.6.0/go.mod h1:CpYf5pdNY/B352A1TFLAS2JVSlnGQ5O2cftPHndTroo=
 sigs.k8s.io/controller-runtime v0.6.1 h1:LcK2+nk0kmaOnKGN+vBcWHqY5WDJNJNB/c5pW+sU8fc=
 sigs.k8s.io/controller-runtime v0.6.1/go.mod h1:XRYBPdbf5XJu9kpS84VJiZ7h/u1hF3gEORz0efEja7A=
 sigs.k8s.io/controller-tools v0.3.0 h1:y3YD99XOyWaXkiF1kd41uRvfp/64teWcrEZFuHxPhJ4=

--- a/pkg/controller/instance/resolver_incluster.go
+++ b/pkg/controller/instance/resolver_incluster.go
@@ -9,9 +9,10 @@ import (
 	"github.com/kudobuilder/kudo/pkg/kudoctl/packages"
 )
 
-// InClusterResolver resolves packages that are already installed in the cluster. Note, that unlike other resolvers, the
-// resulting 'packages.Package' struct does not contain package 'packages.Files' (we don't have the original files) and
-// doesn't have an Instance resource because multiple Instances of the same Operator/OperatorVersion can exist
+// InClusterResolver resolves packages that are already installed in the cluster on the server-side. Note, that unlike
+// other resolvers, the resulting 'packages.Package' struct does not contain package 'packages.Files' (we don't have
+// the original files) and doesn't have an Instance resource because multiple Instances of the same Operator/OperatorVersion
+// can exist.
 type InClusterResolver struct {
 	c  client.Client
 	ns string

--- a/pkg/controller/instance/resolver_incluster.go
+++ b/pkg/controller/instance/resolver_incluster.go
@@ -9,10 +9,16 @@ import (
 	"github.com/kudobuilder/kudo/pkg/kudoctl/packages"
 )
 
-// InClusterResolver resolves packages that are already installed in the cluster on the server-side. Note, that unlike
-// other resolvers, the resulting 'packages.Package' struct does not contain package 'packages.Files' (we don't have
-// the original files) and doesn't have an Instance resource because multiple Instances of the same Operator/OperatorVersion
-// can exist.
+// InClusterResolver is a server-side package resolver for packages that are already installed in the cluster. It is a simpler
+// version of the client-side pkg/kudoctl/packages/resolver/resolver_incluster.go. The client-side version would search
+// the installed OperatorVersions and try to resolve any valid combination of the operator name and its app and operator versions,
+// same as we would search in the repository.
+// This resolver is only used to make sure that all the dependencies of an operator exist and that referenced operator versions
+// are installed and uniquely identifiable by the passed operator name, appVersion and operatorVersion parameters
+// (see pkg/apis/kudo/v1beta1/operatorversion_types_helpers.go::OperatorVersionName method).
+// Also, note that unlike other resolvers, the resulting 'packages.Package' struct does not contain package 'packages.Files'
+// (we don't have the original files) and doesn't have an Instance resource because multiple Instances of the same
+// Operator/OperatorVersion  can exist.
 type InClusterResolver struct {
 	c  client.Client
 	ns string

--- a/pkg/kudoctl/cmd/get/get.go
+++ b/pkg/kudoctl/cmd/get/get.go
@@ -48,7 +48,7 @@ func Run(args []string, opts CmdOpts) error {
 	case Operators:
 		objs, err = opts.Client.ListOperators(opts.Namespace)
 	case OperatorVersions:
-		objs, err = opts.Client.ListOperatorVersions(opts.Namespace)
+		objs, err = opts.Client.ListOperatorVersionsAsRuntimeObject(opts.Namespace)
 	case All:
 		return runGetAll(opts)
 	}
@@ -84,7 +84,7 @@ func runGetAll(opts CmdOpts) error {
 	if err != nil {
 		return fmt.Errorf("failed to get instances")
 	}
-	operatorversions, err := opts.Client.ListOperatorVersions(opts.Namespace)
+	operatorversions, err := opts.Client.ListOperatorVersionsAsRuntimeObject(opts.Namespace)
 	if err != nil {
 		return fmt.Errorf("failed to get operatorversions")
 	}

--- a/pkg/kudoctl/cmd/get/get.go
+++ b/pkg/kudoctl/cmd/get/get.go
@@ -44,9 +44,9 @@ func Run(args []string, opts CmdOpts) error {
 	var objs []runtime.Object
 	switch args[0] {
 	case Instances:
-		objs, err = opts.Client.ListInstances(opts.Namespace)
+		objs, err = opts.Client.ListInstancesAsRuntimeObject(opts.Namespace)
 	case Operators:
-		objs, err = opts.Client.ListOperators(opts.Namespace)
+		objs, err = opts.Client.ListOperatorsAsRuntimeObject(opts.Namespace)
 	case OperatorVersions:
 		objs, err = opts.Client.ListOperatorVersionsAsRuntimeObject(opts.Namespace)
 	case All:
@@ -80,7 +80,7 @@ func Run(args []string, opts CmdOpts) error {
 }
 
 func runGetAll(opts CmdOpts) error {
-	instances, err := opts.Client.ListInstances(opts.Namespace)
+	instances, err := opts.Client.ListInstancesAsRuntimeObject(opts.Namespace)
 	if err != nil {
 		return fmt.Errorf("failed to get instances")
 	}
@@ -88,7 +88,7 @@ func runGetAll(opts CmdOpts) error {
 	if err != nil {
 		return fmt.Errorf("failed to get operatorversions")
 	}
-	operators, err := opts.Client.ListOperators(opts.Namespace)
+	operators, err := opts.Client.ListOperatorsAsRuntimeObject(opts.Namespace)
 	if err != nil {
 		return fmt.Errorf("failed to get operators")
 	}

--- a/pkg/kudoctl/cmd/install.go
+++ b/pkg/kudoctl/cmd/install.go
@@ -26,6 +26,9 @@ var (
   # Install operator from tarball at URL
   kubectl kudo install http://kudo.dev/zk.tgz
 
+  # Install operator from an in-cluster operator version
+  kubectl kudo install zookeeper --operator-version=0.3.0 --in-cluster
+
   # Specify an operator version of Kafka to install to your cluster
   kubectl kudo install kafka --operator-version=1.1.1`
 )
@@ -62,6 +65,7 @@ func newInstallCmd(fs afero.Fs) *cobra.Command {
 	installCmd.Flags().BoolVar(&options.Wait, "wait", false, "Specify if the CLI should wait for the install to complete before returning (default \"false\")")
 	installCmd.Flags().Int64Var(&options.WaitTime, "wait-time", 300, "Specify the max wait time in seconds for CLI for the install to complete before returning (default \"300\")")
 	installCmd.Flags().BoolVar(&options.CreateNameSpace, "create-namespace", false, "If set, install will create the specified namespace and will fail if it exists. (default \"false\")")
+	installCmd.Flags().BoolVar(&options.InCluster, "in-cluster", false, "Specify if the CLI should resolve the package using the operator version already installed in the cluster. (default \"false\")")
 
 	return installCmd
 }

--- a/pkg/kudoctl/cmd/install/install.go
+++ b/pkg/kudoctl/cmd/install/install.go
@@ -53,14 +53,8 @@ func validate(args []string, opts *Options) error {
 		return clog.Errorf("expecting exactly one argument - name of the package or path to install")
 	}
 
-	if opts.InCluster {
-		if opts.RepoName != "" || opts.AppVersion != "" || opts.SkipInstance {
-			return clog.Errorf("you can't use repo-name, app-version or skip-instance options when installing from in-cluster operators")
-		}
-
-		if opts.OperatorVersion == "" {
-			return clog.Errorf("when installing from in-cluster operators, please provide an operator-version")
-		}
+	if opts.InCluster && opts.SkipInstance {
+		return clog.Errorf("you can't use skip-instance option when installing from in-cluster operators")
 	}
 	return nil
 }

--- a/pkg/kudoctl/cmd/install/install.go
+++ b/pkg/kudoctl/cmd/install/install.go
@@ -57,6 +57,10 @@ func validate(args []string, opts *Options) error {
 		if opts.RepoName != "" || opts.AppVersion != "" || opts.SkipInstance {
 			return clog.Errorf("you can't use repo-name, app-version or skip-instance options when installing from in-cluster operators")
 		}
+
+		if opts.OperatorVersion == "" {
+			return clog.Errorf("when installing from in-cluster operators, please provide an operator-version")
+		}
 	}
 	return nil
 }

--- a/pkg/kudoctl/cmd/install/install.go
+++ b/pkg/kudoctl/cmd/install/install.go
@@ -53,8 +53,10 @@ func validate(args []string, opts *Options) error {
 		return clog.Errorf("expecting exactly one argument - name of the package or path to install")
 	}
 
-	if opts.InCluster && opts.SkipInstance {
-		return clog.Errorf("you can't use skip-instance option when installing from in-cluster operators")
+	if opts.InCluster {
+		if opts.SkipInstance || opts.RepoName != "" {
+			return clog.Errorf("you can't use skip-instance or repo option when installing from in-cluster operators")
+		}
 	}
 	return nil
 }

--- a/pkg/kudoctl/cmd/install/install_test.go
+++ b/pkg/kudoctl/cmd/install/install_test.go
@@ -9,16 +9,29 @@ import (
 func TestValidate(t *testing.T) {
 
 	tests := []struct {
-		arg []string
-		err string
+		args []string
+		opts *Options
+		err  string
 	}{
-		{nil, "expecting exactly one argument - name of the package or path to install"},                     // 1
-		{[]string{"arg", "arg2"}, "expecting exactly one argument - name of the package or path to install"}, // 2
-		{[]string{}, "expecting exactly one argument - name of the package or path to install"},              // 3
+		{args: nil, opts: &Options{}, err: "expecting exactly one argument - name of the package or path to install"},
+		{args: []string{"arg", "arg2"}, opts: &Options{}, err: "expecting exactly one argument - name of the package or path to install"},
+		{args: []string{}, opts: &Options{}, err: "expecting exactly one argument - name of the package or path to install"},
+		{args: []string{"arg"}, opts: &Options{
+			SkipInstance: true,
+			InCluster:    true,
+		}, err: "you can't use repo-name, app-version or skip-instance options when installing from in-cluster operators"},
+		{args: []string{"arg"}, opts: &Options{
+			RepositoryOptions: RepositoryOptions{RepoName: "foo"},
+			InCluster:         true,
+		}, err: "you can't use repo-name, app-version or skip-instance options when installing from in-cluster operators"},
+		{args: []string{"arg"}, opts: &Options{
+			AppVersion: "foo",
+			InCluster:  true,
+		}, err: "you can't use repo-name, app-version or skip-instance options when installing from in-cluster operators"},
 	}
 
 	for _, tt := range tests {
-		err := validate(tt.arg)
+		err := validate(tt.args, tt.opts)
 		if tt.err != "" {
 			assert.EqualError(t, err, tt.err)
 		}

--- a/pkg/kudoctl/cmd/install/install_test.go
+++ b/pkg/kudoctl/cmd/install/install_test.go
@@ -28,6 +28,10 @@ func TestValidate(t *testing.T) {
 			AppVersion: "foo",
 			InCluster:  true,
 		}, err: "you can't use repo-name, app-version or skip-instance options when installing from in-cluster operators"},
+		{args: []string{"arg"}, opts: &Options{
+			InCluster:       true,
+			OperatorVersion: "",
+		}, err: "when installing from in-cluster operators, please provide an operator-version"},
 	}
 
 	for _, tt := range tests {

--- a/pkg/kudoctl/cmd/install/install_test.go
+++ b/pkg/kudoctl/cmd/install/install_test.go
@@ -19,19 +19,7 @@ func TestValidate(t *testing.T) {
 		{args: []string{"arg"}, opts: &Options{
 			SkipInstance: true,
 			InCluster:    true,
-		}, err: "you can't use repo-name, app-version or skip-instance options when installing from in-cluster operators"},
-		{args: []string{"arg"}, opts: &Options{
-			RepositoryOptions: RepositoryOptions{RepoName: "foo"},
-			InCluster:         true,
-		}, err: "you can't use repo-name, app-version or skip-instance options when installing from in-cluster operators"},
-		{args: []string{"arg"}, opts: &Options{
-			AppVersion: "foo",
-			InCluster:  true,
-		}, err: "you can't use repo-name, app-version or skip-instance options when installing from in-cluster operators"},
-		{args: []string{"arg"}, opts: &Options{
-			InCluster:       true,
-			OperatorVersion: "",
-		}, err: "when installing from in-cluster operators, please provide an operator-version"},
+		}, err: "you can't use skip-instance option when installing from in-cluster operators"},
 	}
 
 	for _, tt := range tests {

--- a/pkg/kudoctl/cmd/install/install_test.go
+++ b/pkg/kudoctl/cmd/install/install_test.go
@@ -19,7 +19,7 @@ func TestValidate(t *testing.T) {
 		{args: []string{"arg"}, opts: &Options{
 			SkipInstance: true,
 			InCluster:    true,
-		}, err: "you can't use skip-instance option when installing from in-cluster operators"},
+		}, err: "you can't use skip-instance or repo option when installing from in-cluster operators"},
 	}
 
 	for _, tt := range tests {

--- a/pkg/kudoctl/packages/convert/resources.go
+++ b/pkg/kudoctl/packages/convert/resources.go
@@ -78,28 +78,32 @@ func FilesToResources(files *packages.Files) (*packages.Resources, error) {
 		Status: kudoapi.OperatorVersionStatus{},
 	}
 
-	instance := &kudoapi.Instance{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Instance",
-			APIVersion: packages.APIVersion,
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:   kudoapi.OperatorInstanceName(files.Operator.Name),
-			Labels: map[string]string{kudo.OperatorLabel: files.Operator.Name},
-		},
-		Spec: kudoapi.InstanceSpec{
-			OperatorVersion: corev1.ObjectReference{
-				Name: kudoapi.OperatorVersionName(files.Operator.Name, files.Operator.OperatorVersion),
-			},
-		},
-		Status: kudoapi.InstanceStatus{},
-	}
+	instance := BuildInstanceResource(files.Operator.Name, files.Operator.OperatorVersion)
 
 	return &packages.Resources{
 		Operator:        operator,
 		OperatorVersion: fv,
 		Instance:        instance,
 	}, nil
+}
+
+func BuildInstanceResource(operatorName, operatorVersion string) *kudoapi.Instance {
+	return &kudoapi.Instance{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Instance",
+			APIVersion: packages.APIVersion,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   kudoapi.OperatorInstanceName(operatorName),
+			Labels: map[string]string{kudo.OperatorLabel: operatorName},
+		},
+		Spec: kudoapi.InstanceSpec{
+			OperatorVersion: corev1.ObjectReference{
+				Name: kudoapi.OperatorVersionName(operatorName, operatorVersion),
+			},
+		},
+		Status: kudoapi.InstanceStatus{},
+	}
 }
 
 func validateTask(t kudoapi.Task, templates map[string]string) []string {

--- a/pkg/kudoctl/packages/resolver/resolver.go
+++ b/pkg/kudoctl/packages/resolver/resolver.go
@@ -36,10 +36,7 @@ func New(repo *repo.Client) Resolver {
 
 // NewInClusterResolver returns an initialized InClusterResolver for resolving already installed packages
 func NewInClusterResolver(c *kudo.Client, ns string) Resolver {
-	return &InClusterResolver{
-		Client:    c,
-		Namespace: ns,
-	}
+	return &InClusterResolver{c: c, ns: ns}
 }
 
 // Resolve provides a one stop to acquire any non-repo packages by trying to look for package files

--- a/pkg/kudoctl/packages/resolver/resolver.go
+++ b/pkg/kudoctl/packages/resolver/resolver.go
@@ -6,6 +6,7 @@ import (
 	"github.com/kudobuilder/kudo/pkg/kudoctl/clog"
 	"github.com/kudobuilder/kudo/pkg/kudoctl/http"
 	"github.com/kudobuilder/kudo/pkg/kudoctl/packages"
+	"github.com/kudobuilder/kudo/pkg/kudoctl/util/kudo"
 	"github.com/kudobuilder/kudo/pkg/kudoctl/util/repo"
 )
 
@@ -23,13 +24,21 @@ type PackageResolver struct {
 }
 
 // New creates an operator package resolver for non-repository packages
-func New(repo *repo.Client) *PackageResolver {
+func New(repo *repo.Client) Resolver {
 	lf := NewLocal()
 	uf := NewURL()
 	return &PackageResolver{
 		local: lf,
 		uri:   uf,
 		repo:  repo,
+	}
+}
+
+// NewInClusterResolver returns an initialized InClusterResolver for resolving already installed packages
+func NewInClusterResolver(c *kudo.Client, ns string) Resolver {
+	return &InClusterResolver{
+		Client:    c,
+		Namespace: ns,
 	}
 }
 

--- a/pkg/kudoctl/packages/resolver/resolver_incluster.go
+++ b/pkg/kudoctl/packages/resolver/resolver_incluster.go
@@ -13,21 +13,21 @@ import (
 // other resolvers, the resulting 'packages.Package' struct does not contain package 'packages.Files' (we don't have
 // the original files).
 type InClusterResolver struct {
-	Client    *kudo.Client
-	Namespace string
+	c  *kudo.Client
+	ns string
 }
 
 func (r InClusterResolver) Resolve(name string, appVersion string, operatorVersion string) (*packages.Package, error) {
 	ovn := kudoapi.OperatorVersionName(name, operatorVersion)
 
-	ov, err := r.Client.GetOperatorVersion(ovn, r.Namespace)
+	ov, err := r.c.GetOperatorVersion(ovn, r.ns)
 	if err != nil {
-		return nil, fmt.Errorf("failed to resolve operator version %s/%s:%s", r.Namespace, ovn, appVersion)
+		return nil, fmt.Errorf("failed to resolve operator version %s/%s:%s", r.ns, ovn, appVersion)
 	}
 
-	o, err := r.Client.GetOperator(name, r.Namespace)
+	o, err := r.c.GetOperator(name, r.ns)
 	if err != nil {
-		return nil, fmt.Errorf("failed to resolve operator %s/%s", r.Namespace, name)
+		return nil, fmt.Errorf("failed to resolve operator %s/%s", r.ns, name)
 	}
 
 	i := convert.BuildInstanceResource(name, operatorVersion)

--- a/pkg/kudoctl/packages/resolver/resolver_incluster.go
+++ b/pkg/kudoctl/packages/resolver/resolver_incluster.go
@@ -1,0 +1,43 @@
+package resolver
+
+import (
+	"fmt"
+
+	kudoapi "github.com/kudobuilder/kudo/pkg/apis/kudo/v1beta1"
+	"github.com/kudobuilder/kudo/pkg/kudoctl/packages"
+	"github.com/kudobuilder/kudo/pkg/kudoctl/packages/convert"
+	"github.com/kudobuilder/kudo/pkg/kudoctl/util/kudo"
+)
+
+// InClusterResolver resolves packages that are already installed in the cluster on the client-side. Note, that unlike
+// other resolvers, the resulting 'packages.Package' struct does not contain package 'packages.Files' (we don't have
+// the original files).
+type InClusterResolver struct {
+	Client    *kudo.Client
+	Namespace string
+}
+
+func (r InClusterResolver) Resolve(name string, appVersion string, operatorVersion string) (*packages.Package, error) {
+	ovn := kudoapi.OperatorVersionName(name, operatorVersion)
+
+	ov, err := r.Client.GetOperatorVersion(ovn, r.Namespace)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve operator version %s/%s:%s", r.Namespace, ovn, appVersion)
+	}
+
+	o, err := r.Client.GetOperator(name, r.Namespace)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve operator %s/%s", r.Namespace, name)
+	}
+
+	i := convert.BuildInstanceResource(name, operatorVersion)
+
+	return &packages.Package{
+		Resources: &packages.Resources{
+			Operator:        o,
+			OperatorVersion: ov,
+			Instance:        i,
+		},
+		Files: nil,
+	}, nil
+}

--- a/pkg/kudoctl/packages/resolver/resolver_incluster.go
+++ b/pkg/kudoctl/packages/resolver/resolver_incluster.go
@@ -35,7 +35,7 @@ func (r InClusterResolver) Resolve(name string, appVersion string, operatorVersi
 		return nil, err
 	}
 
-	// 4. fetch the existing O/OV and install the instance
+	// 4. fetch the existing O/OV and make the instance to install
 	ovn := version.Name
 	operatorVersion = version.OperatorVersion
 

--- a/pkg/kudoctl/packages/resolver/resolver_incluster.go
+++ b/pkg/kudoctl/packages/resolver/resolver_incluster.go
@@ -25,7 +25,7 @@ func (r InClusterResolver) Resolve(name string, appVersion string, operatorVersi
 		return nil, err
 	}
 
-	//2.  sorting packages in descending order same as the repo does it: pkg/kudoctl/util/repo/index.go::sortPackages
+	//2. sorting packages in descending order same as the repo does it: pkg/kudoctl/util/repo/index.go::sortPackages
 	// to preserve the selection rules. See sortPackages method description for more details.
 	sort.Sort(sort.Reverse(versions))
 

--- a/pkg/kudoctl/packages/resolver/resolver_incluster_test.go
+++ b/pkg/kudoctl/packages/resolver/resolver_incluster_test.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"testing"
 
-	"gotest.tools/assert"
+	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubefake "k8s.io/client-go/kubernetes/fake"

--- a/pkg/kudoctl/packages/resolver/resolver_incluster_test.go
+++ b/pkg/kudoctl/packages/resolver/resolver_incluster_test.go
@@ -1,0 +1,171 @@
+package resolver
+
+import (
+	"log"
+	"testing"
+
+	"gotest.tools/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+
+	kudoapi "github.com/kudobuilder/kudo/pkg/apis/kudo/v1beta1"
+	"github.com/kudobuilder/kudo/pkg/client/clientset/versioned/fake"
+
+	"github.com/kudobuilder/kudo/pkg/kudoctl/util/kudo"
+)
+
+func TestInClusterResolver_Resolve(t *testing.T) {
+	testOperator := &kudoapi.Operator{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "kudo.dev/v1beta1",
+			Kind:       "Operator",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo-operator",
+			Namespace: "default",
+		},
+		Spec: kudoapi.OperatorSpec{
+			Description: "A foo Operator",
+			KudoVersion: "0.16.0",
+		},
+	}
+
+	testOperatorVersion := func(operatorVersion, appVersion string) *kudoapi.OperatorVersion {
+		return &kudoapi.OperatorVersion{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "kudo.dev/v1beta1",
+				Kind:       "OperatorVersion",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      kudoapi.OperatorVersionName("foo-operator", operatorVersion),
+				Namespace: "default",
+			},
+			Spec: kudoapi.OperatorVersionSpec{
+				Operator: v1.ObjectReference{
+					APIVersion: "kudo.dev/v1beta1",
+					Kind:       "Operator",
+					Name:       "foo-operator",
+				},
+				Version:    operatorVersion,
+				AppVersion: appVersion,
+			},
+		}
+	}
+
+	c := kudo.NewClientFromK8s(fake.NewSimpleClientset(), kubefake.NewSimpleClientset())
+	r := InClusterResolver{c: c, ns: "default"}
+
+	// Init the fake client with an operator and three operator versions:
+	_, err := c.InstallOperatorObjToCluster(testOperator, "default")
+	if err != nil {
+		log.Fatal(err)
+	}
+	_, err = c.InstallOperatorVersionObjToCluster(testOperatorVersion("0.1.0", "3.12.1"), "default")
+	if err != nil {
+		log.Fatal(err)
+	}
+	_, err = c.InstallOperatorVersionObjToCluster(testOperatorVersion("0.2.0", "3.13.2"), "default")
+	if err != nil {
+		log.Fatal(err)
+	}
+	_, err = c.InstallOperatorVersionObjToCluster(testOperatorVersion("0.3.0", ""), "default")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	tests := []struct {
+		name                string
+		operatorName        string
+		appVersion          string
+		operatorVersion     string
+		wantOperatorVersion string
+		wantAppVersion      string
+		wantErr             bool
+	}{
+		{
+			name:                "resolve by only operator name returns version 0.2.0",
+			operatorName:        "foo-operator",
+			appVersion:          "",
+			operatorVersion:     "",
+			wantOperatorVersion: "0.2.0", // not 0.3.0 because operators *with* appVersion have priority
+			wantAppVersion:      "3.13.2",
+			wantErr:             false,
+		},
+		{
+			name:                "resolve by operator version returns the right version",
+			operatorName:        "foo-operator",
+			appVersion:          "",
+			operatorVersion:     "0.3.0",
+			wantOperatorVersion: "0.3.0",
+			wantAppVersion:      "",
+			wantErr:             false,
+		},
+		{
+			name:                "resolve only by the app version returns the right version",
+			operatorName:        "foo-operator",
+			appVersion:          "3.13.2",
+			operatorVersion:     "",
+			wantOperatorVersion: "0.2.0",
+			wantAppVersion:      "3.13.2",
+			wantErr:             false,
+		},
+		{
+			name:                "resolve by the app AND operator version returns the right version",
+			operatorName:        "foo-operator",
+			appVersion:          "3.13.2",
+			operatorVersion:     "0.2.0",
+			wantOperatorVersion: "0.2.0",
+			wantAppVersion:      "3.13.2",
+			wantErr:             false,
+		},
+		{
+			name:                "resolve by the wrong app version returns an error",
+			operatorName:        "foo-operator",
+			appVersion:          "3.15.0",
+			operatorVersion:     "",
+			wantOperatorVersion: "",
+			wantAppVersion:      "",
+			wantErr:             true,
+		},
+		{
+			name:                "resolve by the wrong operator version returns an error",
+			operatorName:        "foo-operator",
+			appVersion:          "",
+			operatorVersion:     "15.0.0",
+			wantOperatorVersion: "",
+			wantAppVersion:      "",
+			wantErr:             true,
+		},
+		{
+			name:                "resolve the wrong operator name",
+			operatorName:        "bar-operator",
+			appVersion:          "",
+			operatorVersion:     "",
+			wantOperatorVersion: "",
+			wantAppVersion:      "",
+			wantErr:             true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := r.Resolve(tt.operatorName, tt.appVersion, tt.operatorVersion)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Resolve() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if !tt.wantErr {
+				if got == nil {
+					t.Errorf("Resolve() failed to resolve an operator foo with operatorVersion=%s and appVersion=%s", tt.wantOperatorVersion, tt.wantAppVersion)
+					return
+				}
+
+				assert.Equal(t, got.Resources.OperatorVersion.Spec.Version, tt.wantOperatorVersion, "got: %v", got.Resources.OperatorVersion)
+			}
+		})
+	}
+
+}

--- a/pkg/kudoctl/util/kudo/kudo.go
+++ b/pkg/kudoctl/util/kudo/kudo.go
@@ -374,18 +374,27 @@ func (c *Client) ListInstances(namespace string) ([]runtime.Object, error) {
 	return existingItems, nil
 }
 
-// ListOperatorVersions lists all operatorversions installed in the cluster in a given ns
-func (c *Client) ListOperatorVersions(namespace string) ([]runtime.Object, error) {
+func (c *Client) ListOperatorVersions(namespace string) ([]kudoapi.OperatorVersion, error) {
 	ovs, err := c.kudoClientset.KudoV1beta1().OperatorVersions(namespace).List(context.TODO(), v1.ListOptions{})
 	if err != nil {
 		return nil, err
 	}
 
-	existingItems := []runtime.Object{}
-	for i := range ovs.Items {
-		existingItems = append(existingItems, &ovs.Items[i])
+	return ovs.Items, nil
+}
+
+// ListOperatorVersionsAsRuntimeObject lists all operatorversions installed in the cluster in a given ns
+func (c *Client) ListOperatorVersionsAsRuntimeObject(namespace string) ([]runtime.Object, error) {
+	ovs, err := c.ListOperatorVersions(namespace)
+	if err != nil {
+		return nil, err
 	}
-	return existingItems, nil
+
+	asObjs := []runtime.Object{}
+	for i := range ovs {
+		asObjs = append(asObjs, &ovs[i])
+	}
+	return asObjs, nil
 }
 
 // ListOperators lists all operators installed in the cluster in a given ns

--- a/pkg/kudoctl/util/kudo/kudo.go
+++ b/pkg/kudoctl/util/kudo/kudo.go
@@ -360,8 +360,8 @@ func (c *Client) IsInstanceByNameDone(name string, namespace string, oldInstance
 	return c.IsInstanceDone(instance, oldInstance)
 }
 
-// ListInstances lists all instances installed in the cluster in a given ns
-func (c *Client) ListInstances(namespace string) ([]runtime.Object, error) {
+// ListInstancesAsRuntimeObject lists all instances installed in the cluster in a given ns
+func (c *Client) ListInstancesAsRuntimeObject(namespace string) ([]runtime.Object, error) {
 	instances, err := c.kudoClientset.KudoV1beta1().Instances(namespace).List(context.TODO(), v1.ListOptions{})
 	if err != nil {
 		return nil, err
@@ -397,8 +397,8 @@ func (c *Client) ListOperatorVersionsAsRuntimeObject(namespace string) ([]runtim
 	return asObjs, nil
 }
 
-// ListOperators lists all operators installed in the cluster in a given ns
-func (c *Client) ListOperators(namespace string) ([]runtime.Object, error) {
+// ListOperatorsAsRuntimeObject lists all operators installed in the cluster in a given ns
+func (c *Client) ListOperatorsAsRuntimeObject(namespace string) ([]runtime.Object, error) {
 	operators, err := c.kudoClientset.KudoV1beta1().Operators(namespace).List(context.TODO(), v1.ListOptions{})
 	if err != nil {
 		return nil, err

--- a/pkg/kudoctl/util/kudo/kudo_test.go
+++ b/pkg/kudoctl/util/kudo/kudo_test.go
@@ -320,7 +320,7 @@ func TestKudoClient_ListInstances(t *testing.T) {
 		}
 
 		// test if OperatorVersion exists in namespace
-		existingInstances, _ := k2o.ListInstances(tt.namespace)
+		existingInstances, _ := k2o.ListInstancesAsRuntimeObject(tt.namespace)
 
 		assert.Equal(t, len(tt.expectedInstances), len(existingInstances))
 

--- a/pkg/kudoctl/util/repo/resolver_repo.go
+++ b/pkg/kudoctl/util/repo/resolver_repo.go
@@ -126,8 +126,11 @@ func (i IndexFile) FindFirstMatch(name string, appVersion string, operatorVersio
 	if !ok || len(vs) == 0 {
 		return nil, fmt.Errorf("no operator found for: %s", name)
 	}
+	return FindFirstMatchForEntries(vs, name, appVersion, operatorVersion)
+}
 
-	for _, ver := range vs {
+func FindFirstMatchForEntries(versions PackageVersions, name, appVersion, operatorVersion string) (*PackageVersion, error) {
+	for _, ver := range versions {
 		if (ver.AppVersion == appVersion || appVersion == "") &&
 			(ver.OperatorVersion == operatorVersion || operatorVersion == "") {
 			return ver, nil


### PR DESCRIPTION
Summary:
The current `kudo install ...` command accepts either a remote repo operator name, a URL, or a local folder/tgz. This PR allows the user to install an instance from an existing in-cluster operator version using the newly introduced `--in-cluster` option:

```
❯ ./bin/kubectl-kudo install first-operator --operator-version=0.2.0 --in-cluster
operatorversion default/first-operator-0.2.0 already installed
instance default/first-operator-instance created
```

This way `kudoctl` will only look for already installed operator versions (one can list them using `kudoctl get operatorversions`) and does not need access to the repo/package files.

Signed-off-by: Aleksey Dukhovniy <alex.dukhovniy@googlemail.com>

Fixes #1678
