### PR TITLE
Use a version parameter in the linter install script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ BUILD_DATE_PATH := github.com/kudobuilder/kudo/pkg/version.buildDate
 DATE_FMT := "%Y-%m-%dT%H:%M:%SZ"
 BUILD_DATE := $(shell date -u -d "@$SOURCE_DATE_EPOCH" "+${DATE_FMT}" 2>/dev/null || date -u -r "${SOURCE_DATE_EPOCH}" "+${DATE_FMT}" 2>/dev/null || date -u "+${DATE_FMT}")
 LDFLAGS := -X ${GIT_VERSION_PATH}=${GIT_VERSION:v%=%} -X ${GIT_COMMIT_PATH}=${GIT_COMMIT} -X ${BUILD_DATE_PATH}=${BUILD_DATE}
-GOLANGCI_LINT_VER = "1.31.0"
+GOLANGCI_LINT_VER = "v1.31.0"
 SUPPORTED_PLATFORMS = amd64 arm64
 
 export GO111MODULE=on

--- a/Makefile
+++ b/Makefile
@@ -188,7 +188,7 @@ generate-clean:
 # used to update imports on project.  NOT a linter.
 imports:
 ifneq (${GOLANGCI_LINT_VER}, "$(shell golangci-lint --version 2>/dev/null | cut -b 27-32)")
-	./hack/install-golangcilint.sh
+	./hack/install-golangcilint.sh ${GOLANGCI_LINT_VER}
 endif
 	golangci-lint run --disable-all -E goimports --fix
 

--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ all: test manager  ## Build manager and runs unit tests
 .PHONY: lint
 lint:	## Run golangci-lint
 ifneq (${GOLANGCI_LINT_VER}, "$(shell golangci-lint --version 2>/dev/null | cut -b 27-32)")
-	./hack/install-golangcilint.sh
+	./hack/install-golangcilint.sh ${GOLANGCI_LINT_VER}
 endif
 	golangci-lint --timeout 3m run --allow-parallel-runners
 

--- a/hack/install-golangcilint.sh
+++ b/hack/install-golangcilint.sh
@@ -4,6 +4,6 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-GOLANGCILINT_VERSION=${GOLANGCILINT_VERSION:-v1.29.0}
+GOLANGCILINT_VERSION=$1
 
 curl -sSfL "https://raw.githubusercontent.com/golangci/golangci-lint/${GOLANGCILINT_VERSION}/install.sh" | sh -s -- -b "$(go env GOPATH)/bin" "${GOLANGCILINT_VERSION}"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kudo/blob/main/CONTRIBUTING.md
2. Make sure you have added and ran the tests before submitting your PR
3. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What this PR does / why we need it**:
To avoid specifying the version of `golangci-lint` in multiple places, it is now a parameter in the `install-golangcilint.sh` script. With this change, the version of `golangci-lint` is only declared in the Makefile.


<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
