### PR TITLE
Allow empty default with non-required enum

### DIFF
--- a/pkg/apis/kudo/v1beta1/parameter_types_helpers.go
+++ b/pkg/apis/kudo/v1beta1/parameter_types_helpers.go
@@ -36,6 +36,11 @@ func (p *Parameter) ValidateDefault() error {
 		return fmt.Errorf("parameter %q has an invalid default value: %v", p.Name, err)
 	}
 	if p.IsEnum() {
+		if p.IsRequired() && *p.Default == "" {
+			// Even for an enum, if the parameter is not required we want to allow the empty string as a way to define
+			// an unset parameter
+			return nil
+		}
 		if err := ValidateParameterValueForEnum(p.EnumValues(), p.Default); err != nil {
 			return fmt.Errorf("parameter %q has an invalid default value: %v", p.Name, err)
 		}
@@ -57,6 +62,11 @@ func (p *Parameter) ValidateValue(pValue string) error {
 		return fmt.Errorf("parameter %q has an invalid value %q: %v", p.Name, pValue, err)
 	}
 	if p.IsEnum() {
+		if p.IsRequired() && *p.Default == "" {
+			// Even for an enum, if the parameter is not required we want to allow the empty string as a way to define
+			// an unset parameter
+			return nil
+		}
 		if err := ValidateParameterValueForEnum(p.EnumValues(), pValue); err != nil {
 			return fmt.Errorf("parameter %q has an invalid value %q: %v", p.Name, pValue, err)
 		}

--- a/pkg/apis/kudo/v1beta1/parameter_types_helpers.go
+++ b/pkg/apis/kudo/v1beta1/parameter_types_helpers.go
@@ -36,7 +36,7 @@ func (p *Parameter) ValidateDefault() error {
 		return fmt.Errorf("parameter %q has an invalid default value: %v", p.Name, err)
 	}
 	if p.IsEnum() {
-		if p.IsRequired() && *p.Default == "" {
+		if *p.Default == "" && !p.IsRequired() {
 			// Even for an enum, if the parameter is not required we want to allow the empty string as a way to define
 			// an unset parameter
 			return nil
@@ -62,7 +62,7 @@ func (p *Parameter) ValidateValue(pValue string) error {
 		return fmt.Errorf("parameter %q has an invalid value %q: %v", p.Name, pValue, err)
 	}
 	if p.IsEnum() {
-		if p.IsRequired() && *p.Default == "" {
+		if *p.Default == "" && !p.IsRequired() {
 			// Even for an enum, if the parameter is not required we want to allow the empty string as a way to define
 			// an unset parameter
 			return nil

--- a/pkg/kudoctl/packages/types.go
+++ b/pkg/kudoctl/packages/types.go
@@ -95,6 +95,12 @@ func (p *Parameter) ValidateDefault() error {
 		return fmt.Errorf("parameter \"%s\" has an invalid default value: %v", p.Name, err)
 	}
 	if p.IsEnum() {
+		// Even if we have an enum parameter, we want to allow the empty value to unset
+		// a parameter
+		if p.Default == "" && !p.IsRequired() {
+			return nil
+		}
+
 		for _, eValue := range p.EnumValues() {
 			if p.Default == eValue {
 				return nil

--- a/pkg/kudoctl/packages/verifier/template/verify_parameters.go
+++ b/pkg/kudoctl/packages/verifier/template/verify_parameters.go
@@ -123,7 +123,7 @@ func paramGroups(pf *packages.Files) verifier.Result {
 	for _, p := range pf.Params.Parameters {
 		if p.Group != "" {
 			if _, ok := groups[p.Group]; !ok {
-				res.AddParamError(p.Name, "has a group that is not defined in the group section")
+				res.AddParamError(p.Name, fmt.Sprintf("has a group %q that is not defined in the group section", p.Group))
 			}
 		}
 	}

--- a/pkg/kudoctl/packages/verifier/template/verify_parameters_test.go
+++ b/pkg/kudoctl/packages/verifier/template/verify_parameters_test.go
@@ -123,7 +123,8 @@ func TestEnumParams(t *testing.T) {
 		{Name: "EmptyDefaultNotRequiredEnum", Enum: &[]interface{}{"someVal"}, Default: "", Required: &falseRef},
 		{Name: "EmptyDefaultRequiredEnum", Enum: &[]interface{}{"someVal"}, Default: "", Required: &trueRef},
 		{Name: "EnumNoDefault", Enum: &[]interface{}{"someVal"}},
-		{Name: "EnumWithDefault", Enum: &[]interface{}{"someVal"}, Default: "someOtherVal"},
+		{Name: "EnumWithWrongDefault", Enum: &[]interface{}{"someVal"}, Default: "someOtherVal"},
+		{Name: "EnumWithDefault", Enum: &[]interface{}{"someVal"}, Default: "someVal"},
 		{Name: "EnumNoValues", Enum: &[]interface{}{}},
 		{Name: "EnumWrongValues", Enum: &[]interface{}{"noint", "23", "42", "1.23"}, Type: kudoapi.IntegerValueType},
 	}
@@ -139,12 +140,13 @@ func TestEnumParams(t *testing.T) {
 	verifier := ParametersVerifier{}
 	res := verifier.Verify(&pf)
 
-	assert.Equal(t, 7, len(res.Warnings)) // NotUsed Warnings
+	assert.Equal(t, 8, len(res.Warnings)) // NotUsed Warnings
 	assert.Equal(t, 5, len(res.Errors))
 	assert.Equal(t, `parameter "EnumNoValues" is an enum but has no allowed values`, res.Errors[0])
 	assert.Equal(t, `parameter "EnumWrongValues" has an invalid enum value: type is "integer" but format of "noint" is invalid: strconv.ParseInt: parsing "noint": invalid syntax`, res.Errors[1])
 	assert.Equal(t, `parameter "EnumWrongValues" has an invalid enum value: type is "integer" but format of "1.23" is invalid: strconv.ParseInt: parsing "1.23": invalid syntax`, res.Errors[2])
-	assert.Equal(t, `parameter "EnumWithDefault" has an invalid default value: value is "someOtherVal", but only allowed values are [someVal]`, res.Errors[3])
+	assert.Equal(t, `parameter "EmptyDefaultRequiredEnum" has an invalid default value: value is "", but only allowed values are [someVal]`, res.Errors[3])
+	assert.Equal(t, `parameter "EnumWithWrongDefault" has an invalid default value: value is "someOtherVal", but only allowed values are [someVal]`, res.Errors[4])
 }
 
 func TestMetadata(t *testing.T) {

--- a/pkg/kudoctl/packages/verifier/template/verify_parameters_test.go
+++ b/pkg/kudoctl/packages/verifier/template/verify_parameters_test.go
@@ -115,9 +115,13 @@ func TestImmutableParams(t *testing.T) {
 }
 
 func TestEnumParams(t *testing.T) {
+	trueRef := true
+	falseRef := false
 
 	params := []packages.Parameter{
 		{Name: "NoDefaultNoEnum"},
+		{Name: "EmptyDefaultNotRequiredEnum", Enum: &[]interface{}{"someVal"}, Default: "", Required: &falseRef},
+		{Name: "EmptyDefaultRequiredEnum", Enum: &[]interface{}{"someVal"}, Default: "", Required: &trueRef},
 		{Name: "EnumNoDefault", Enum: &[]interface{}{"someVal"}},
 		{Name: "EnumWithDefault", Enum: &[]interface{}{"someVal"}, Default: "someOtherVal"},
 		{Name: "EnumNoValues", Enum: &[]interface{}{}},
@@ -135,8 +139,8 @@ func TestEnumParams(t *testing.T) {
 	verifier := ParametersVerifier{}
 	res := verifier.Verify(&pf)
 
-	assert.Equal(t, 5, len(res.Warnings)) // NotUsed Warnings
-	assert.Equal(t, 4, len(res.Errors))
+	assert.Equal(t, 7, len(res.Warnings)) // NotUsed Warnings
+	assert.Equal(t, 5, len(res.Errors))
 	assert.Equal(t, `parameter "EnumNoValues" is an enum but has no allowed values`, res.Errors[0])
 	assert.Equal(t, `parameter "EnumWrongValues" has an invalid enum value: type is "integer" but format of "noint" is invalid: strconv.ParseInt: parsing "noint": invalid syntax`, res.Errors[1])
 	assert.Equal(t, `parameter "EnumWrongValues" has an invalid enum value: type is "integer" but format of "1.23" is invalid: strconv.ParseInt: parsing "1.23": invalid syntax`, res.Errors[2])
@@ -167,5 +171,5 @@ func TestMetadata(t *testing.T) {
 	assert.Equal(t, 3, len(res.Errors))
 	assert.Equal(t, `parameter "InvalidGroup" has a group with invalid character '/'`, res.Errors[0])
 	assert.Equal(t, `parameter "InvalidAdvanced" is marked as advanced, but also as required and has no default. An advanced parameter must either be optional or have a default value`, res.Errors[1])
-	assert.Equal(t, `parameter "InvalidGroup" has a group that is not defined in the group section`, res.Errors[2])
+	assert.Equal(t, `parameter "InvalidGroup" has a group "some/group" that is not defined in the group section`, res.Errors[2])
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
When working on the Cassandra Parameters, I encountered enum parameters that had an empty default - Which kind of makes sense for non-required parameters. 



