### PR TITLE
Fixing false warnings for the `KudoOperatorTask`

### DIFF
--- a/pkg/kudoctl/packages/verifier/task/verify_build.go
+++ b/pkg/kudoctl/packages/verifier/task/verify_build.go
@@ -1,6 +1,8 @@
 package task
 
 import (
+	"fmt"
+
 	"github.com/kudobuilder/kudo/pkg/engine/task"
 	"github.com/kudobuilder/kudo/pkg/kudoctl/packages"
 	"github.com/kudobuilder/kudo/pkg/kudoctl/verifier"
@@ -22,8 +24,15 @@ func tasksWellDefined(pf *packages.Files) verifier.Result {
 	for _, tt := range pf.Operator.Tasks {
 		tt := tt
 
-		if _, err := task.Build(&tt); err != nil {
-			result.AddErrors(err.Error())
+		switch tt.Kind {
+		case task.KudoOperatorTaskKind:
+			if tt.Spec.KudoOperatorTaskSpec.Package == "" {
+				result.AddErrors(fmt.Sprintf("task validation error: kudo operator task '%s' has an empty package name", tt.Name))
+			}
+		default:
+			if _, err := task.Build(&tt); err != nil {
+				result.AddErrors(err.Error())
+			}
 		}
 	}
 	return result


### PR DESCRIPTION
Summary:
in many cases, the task's `OperatorVersion` is being set by the dependency resolver during the package installation, so that it is valid for the field to be empty during verification.

Signed-off-by: Aleksey Dukhovniy <alex.dukhovniy@googlemail.com>