### PR TITLE
Proper handling of the `appVersion` when resolving dependencies

### DIFF
--- a/pkg/kudoctl/resources/install/operator.go
+++ b/pkg/kudoctl/resources/install/operator.go
@@ -138,6 +138,7 @@ func updateKudoOperatorTasks(
 				if tasks[i].Spec.KudoOperatorTaskSpec.Package == dependency.PackageName {
 					tasks[i].Spec.KudoOperatorTaskSpec.Package = dependency.Operator.Name
 					tasks[i].Spec.KudoOperatorTaskSpec.OperatorVersion = dependency.OperatorVersion.Spec.Version
+					tasks[i].Spec.KudoOperatorTaskSpec.AppVersion = dependency.OperatorVersion.Spec.AppVersion
 					break
 				}
 			}


### PR DESCRIPTION
Summary:
This is necessary due to a recent [change](https://github.com/kudobuilder/kudo/commit/5e7546bf11f07924d7b1889bdebc8ed0b440ca0b) in OV naming rules: KUDO now uses the `appVersion` in the OV name if it exists and so we need to set it when `KudoOperatorTaskSpec` package is resolved.

Signed-off-by: Aleksey Dukhovniy <alex.dukhovniy@googlemail.com>