### PR TITLE
Use 'envtest.WaitForCRDs'

### DIFF
--- a/pkg/kudoctl/cmd/init_integration_test.go
+++ b/pkg/kudoctl/cmd/init_integration_test.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	testutils "github.com/kudobuilder/kuttl/pkg/test/utils"
 	"github.com/spf13/afero"
@@ -23,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/yaml"
 
 	"github.com/kudobuilder/kudo/pkg/kudoctl/clog"
@@ -130,7 +132,10 @@ func TestIntegInitForCRDs(t *testing.T) {
 	err = cmd.run()
 	assert.NoError(t, err)
 	// WaitForCRDs to be created... the init cmd did NOT wait
-	assert.NoError(t, testutils.WaitForCRDs(testenv.DiscoveryClient, crds))
+	assert.NoError(t, envtest.WaitForCRDs(testenv.Config, crds, envtest.CRDInstallOptions{
+		PollInterval: 100 * time.Millisecond,
+		MaxTime:      10 * time.Second,
+	}))
 	defer func() {
 		assert.NoError(t, deleteObjects(crds, testClient))
 	}()
@@ -196,7 +201,10 @@ func TestIntegInitWithNameSpace(t *testing.T) {
 	}()
 
 	// WaitForCRDs to be created... the init cmd did NOT wait
-	assert.NoError(t, testutils.WaitForCRDs(testenv.DiscoveryClient, crds))
+	assert.NoError(t, envtest.WaitForCRDs(testenv.Config, crds, envtest.CRDInstallOptions{
+		PollInterval: 100 * time.Millisecond,
+		MaxTime:      10 * time.Second,
+	}))
 
 	// make sure that the controller lives in the correct namespace
 	kclient = getKubeClient(t)
@@ -344,7 +352,10 @@ func TestInitWithServiceAccount(t *testing.T) {
 				}()
 
 				// WaitForCRDs to be created... the init cmd did NOT wait
-				assert.NoError(t, testutils.WaitForCRDs(testenv.DiscoveryClient, crds))
+				assert.NoError(t, envtest.WaitForCRDs(testenv.Config, crds, envtest.CRDInstallOptions{
+					PollInterval: 100 * time.Millisecond,
+					MaxTime:      10 * time.Second,
+				}))
 
 				// make sure that the controller lives in the correct namespace
 				kclient = getKubeClient(t)
@@ -398,7 +409,10 @@ func TestReInitFails(t *testing.T) {
 	assert.NoError(t, err)
 
 	// WaitForCRDs to be created... the init cmd did NOT wait
-	assert.NoError(t, testutils.WaitForCRDs(testenv.DiscoveryClient, crds))
+	assert.NoError(t, envtest.WaitForCRDs(testenv.Config, crds, envtest.CRDInstallOptions{
+		PollInterval: 100 * time.Millisecond,
+		MaxTime:      10 * time.Second,
+	}))
 	defer func() {
 		assert.NoError(t, deleteObjects(crds, testClient))
 	}()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kudo/blob/main/CONTRIBUTING.md
2. Make sure you have added and ran the tests before submitting your PR
3. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What this PR does / why we need it**:
This removes `testutils.WaitForCRDs` in favor of `envtest.WaitForCRDs` as this function will be removed from kuttl in a future release.
See: https://github.com/kudobuilder/kuttl/pull/250


<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
