### PR TITLE
lint bump 1.32.2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,22 +1,30 @@
 linters:
   auto-fix: false
   enable:
-    - dupl
-    - errcheck
-    - goconst
-    - gocyclo
-    - goimports
-    - golint
-    - gosec
-    - interfacer
-    - lll
-    - misspell
-    - nakedret
-    - scopelint
-    - stylecheck
-    - unconvert
-    - unparam
+  - deadcode
+  - dupl
+  - errcheck
+  - goconst
+  - gocyclo
+  - gofmt
+  - goimports
+  - golint
+  - gosec
+  - gosimple
+  - ineffassign
+  - lll
+  - misspell
+  - nakedret
+  - scopelint
+  - staticcheck
+  - structcheck
+  - stylecheck
+  - unconvert
+  - unparam
+  - unused
+  - varcheck
 run:
+  timeout: 3m
   build-tags:
     - integration
   skip-dirs:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,21 +1,21 @@
 linters:
   auto-fix: false
   enable:
+    - dupl
     - errcheck
+    - goconst
+    - gocyclo
     - goimports
     - golint
     - gosec
+    - interfacer
+    - lll
     - misspell
+    - nakedret
     - scopelint
+    - stylecheck
     - unconvert
     - unparam
-    - interfacer
-    - nakedret
-    - gocyclo
-    - dupl
-    - goconst
-    - lll
-    - stylecheck
 run:
   build-tags:
     - integration
@@ -31,3 +31,9 @@ linters-settings:
     threshold: 400
   goimports:
     local-prefixes: github.com/kudobuilder/kudo
+issues:
+  # ignore gosec for test files
+  exclude-rules:
+  - path: _test\.go
+    linters:
+    - gosec

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ BUILD_DATE_PATH := github.com/kudobuilder/kudo/pkg/version.buildDate
 DATE_FMT := "%Y-%m-%dT%H:%M:%SZ"
 BUILD_DATE := $(shell date -u -d "@$SOURCE_DATE_EPOCH" "+${DATE_FMT}" 2>/dev/null || date -u -r "${SOURCE_DATE_EPOCH}" "+${DATE_FMT}" 2>/dev/null || date -u "+${DATE_FMT}")
 LDFLAGS := -X ${GIT_VERSION_PATH}=${GIT_VERSION:v%=%} -X ${GIT_COMMIT_PATH}=${GIT_COMMIT} -X ${BUILD_DATE_PATH}=${BUILD_DATE}
-GOLANGCI_LINT_VER = "v1.31.0"
+GOLANGCI_LINT_VER = "v1.32.2"
 SUPPORTED_PLATFORMS = amd64 arm64
 
 export GO111MODULE=on

--- a/pkg/engine/renderer/enhancer_test.go
+++ b/pkg/engine/renderer/enhancer_test.go
@@ -405,7 +405,7 @@ func statefulSet(name string, namespace string) *appsv1.StatefulSet {
 				Spec: corev1.PodSpec{},
 			},
 			VolumeClaimTemplates: []corev1.PersistentVolumeClaim{
-				corev1.PersistentVolumeClaim{
+				{
 					ObjectMeta: metav1.ObjectMeta{
 						Labels: map[string]string{
 							"vct1": "vct1label",
@@ -413,7 +413,7 @@ func statefulSet(name string, namespace string) *appsv1.StatefulSet {
 					},
 					Spec: corev1.PersistentVolumeClaimSpec{},
 				},
-				corev1.PersistentVolumeClaim{
+				{
 					ObjectMeta: metav1.ObjectMeta{
 						Labels: map[string]string{
 							"vct2": "vct2label",

--- a/pkg/kudoctl/cmd/plan/plan_status_test.go
+++ b/pkg/kudoctl/cmd/plan/plan_status_test.go
@@ -38,10 +38,10 @@ func TestStatus(t *testing.T) {
 			Plans: map[string]kudoapi.Plan{
 				"zzzinvalid": {
 					Phases: []kudoapi.Phase{
-						kudoapi.Phase{
+						{
 							Name: "zzzinvalid",
 							Steps: []kudoapi.Step{
-								kudoapi.Step{
+								{
 									Name: "zzzinvalid",
 								},
 							},
@@ -50,10 +50,10 @@ func TestStatus(t *testing.T) {
 				},
 				"validate": {
 					Phases: []kudoapi.Phase{
-						kudoapi.Phase{
+						{
 							Name: "validate",
 							Steps: []kudoapi.Step{
-								kudoapi.Step{
+								{
 									Name: "validate",
 								},
 							},

--- a/pkg/kudoctl/packages/verifier/template/verify_render_test.go
+++ b/pkg/kudoctl/packages/verifier/template/verify_render_test.go
@@ -115,12 +115,12 @@ spec:
 
 func TestTemplateRenderVerifierParameterTypes(t *testing.T) {
 	params := []packages.Parameter{
-		packages.Parameter{
+		{
 			Name:    "labels",
 			Default: map[string]string{"a": "a", "b": "b"},
 			Type:    kudoapi.MapValueType,
 		},
-		packages.Parameter{
+		{
 			Name:    "containers",
 			Default: []string{"a", "b"},
 			Type:    kudoapi.ArrayValueType,


### PR DESCRIPTION
* Updated golangci-lint to version 1.32.2
* Reorganized linters to be alphabetical (making it easy to discover which are included or not)
* ignoring `gosec` for tests


Fixes #
