### PR TITLE
Integration test command should run all integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - checkout
       - run: echo 'export INTEGRATION_OUTPUT_JUNIT="true"' >> $BASH_ENV
-      - run: ./test/run_tests.sh "integration-test kuttl-test"
+      - run: ./test/run_tests.sh "integration-test"
       - store_test_results:
           path: reports/
 

--- a/Makefile
+++ b/Makefile
@@ -44,8 +44,8 @@ else
 endif
 
 .PHONY: integration-test
-# Run Go integration tests
-integration-test: cli-fast manager-fast ##Runs Go integration tests
+# Run all integration tests
+integration-test: cli-fast manager-fast
 	TEST_ONLY=$(TEST) ./hack/run-integration-tests.sh
 
 .PHONY: kuttl-test

--- a/hack/run-integration-tests.sh
+++ b/hack/run-integration-tests.sh
@@ -17,7 +17,7 @@ fi
 
 if [ "$INTEGRATION_OUTPUT_JUNIT" == true ]
 then
-    echo "Running integration tests with junit output"
+    echo "Running go integration tests with junit output"
     mkdir -p reports/
     go get github.com/jstemmer/go-junit-report
     go test -tags integration ./pkg/... ./cmd/... -v ${MOD_FLAGS} -coverprofile cover-integration.out 2>&1 |tee /dev/fd/2 |go-junit-report -set-exit-code > reports/integration_report.xml
@@ -25,3 +25,7 @@ else
     echo "Running integration tests without junit output"
     go test -tags integration ./pkg/... ./cmd/... -v ${MOD_FLAGS} -coverprofile cover-integration.out
 fi
+
+echo "Running KUTTL integration tests"
+
+./hack/run-kuttl-tests.sh


### PR DESCRIPTION
We agreed on this with Andreas here https://kubernetes.slack.com/archives/CG3HTFCMV/p1603361976115700?thread_ts=1603360951.111500&cid=CG3HTFCMV

Context: There was a PR that has splitted KUTTL tests out of integration-test command. The reason was to be easily able to run just a single test. But as a result, command that's named `integration-test` now runs only a subset of integration tests and I think that's very confusing. The solution is to keep kuttl test separate for whoever needs it but have all integration tests again under one makefile command.