### PR TITLE
Add test for cassandra parameter regression

### DIFF
--- a/test/e2e/immutable-parameter-with-default/00-assert.yaml
+++ b/test/e2e/immutable-parameter-with-default/00-assert.yaml
@@ -1,0 +1,18 @@
+apiVersion: kudo.dev/v1beta1
+kind: Instance
+metadata:
+  name: immutable-param
+status:
+  planStatus:
+    deploy:
+      status: COMPLETE
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  template:
+    metadata:
+      labels:
+        fixedLabel: cannotchange

--- a/test/e2e/immutable-parameter-with-default/00-install.yaml
+++ b/test/e2e/immutable-parameter-with-default/00-install.yaml
@@ -1,0 +1,5 @@
+apiVersion: kudo.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl kudo install --instance immutable-param ./immutable-param
+    namespaced: true

--- a/test/e2e/immutable-parameter-with-default/immutable-param/operator.yaml
+++ b/test/e2e/immutable-parameter-with-default/immutable-param/operator.yaml
@@ -1,0 +1,24 @@
+apiVersion: kudo.dev/v1beta1
+name: "immutable-param"
+operatorVersion: "0.1.0"
+kubernetesVersion: 1.13.0
+maintainers:
+  - name: Your name
+    email: <your@email.com>
+url: https://kudo.dev
+tasks:
+  - name: app
+    kind: Apply
+    spec:
+      resources:
+        - deployment.yaml
+plans:
+  deploy:
+    strategy: serial
+    phases:
+      - name: main
+        strategy: parallel
+        steps:
+          - name: everything
+            tasks:
+              - app

--- a/test/e2e/immutable-parameter-with-default/immutable-param/params.yaml
+++ b/test/e2e/immutable-parameter-with-default/immutable-param/params.yaml
@@ -1,0 +1,10 @@
+apiVersion: kudo.dev/v1beta1
+parameters:
+  - name: replicas
+    description: Number of replicas that should be run as part of the deployment
+    default: 2
+  - name: unchangeable
+    description: An unchangeable parameter
+    required: true
+    immutable: true
+    default: "cannotchange"

--- a/test/e2e/immutable-parameter-with-default/immutable-param/templates/deployment.yaml
+++ b/test/e2e/immutable-parameter-with-default/immutable-param/templates/deployment.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  selector:
+    matchLabels:
+      app: nginx
+  replicas: {{ .Params.replicas }} # tells deployment to run 2 pods matching the template
+  template:
+    metadata:
+      labels:
+        app: nginx
+        fixedLabel: {{ .Params.unchangeable }}
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.7.9
+          ports:
+            - containerPort: 80


### PR DESCRIPTION
Signed-off-by: Alena Varkockova <varkockova.a@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kudo/blob/main/CONTRIBUTING.md
2. Make sure you have added and ran the tests before submitting your PR
3. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What this PR does / why we need it**:
Cassandra 1.0.2 marked a parameter as immutable, that also has a default value. That caused a regression being fixed in #1738

This is a test covering that regression. We already have a test for immutable params but they are providing a param value on install and that means the bug does not get triggered.
