### PR TITLE
Initialise plan status correctly if an upgraded plan adds new phases or steps

### DIFF
--- a/pkg/apis/kudo/v1beta1/instance_types.go
+++ b/pkg/apis/kudo/v1beta1/instance_types.go
@@ -116,6 +116,16 @@ func (s *StepStatus) SetWithMessage(status ExecutionStatus, message string) {
 	s.Message = message
 }
 
+// Step returns the StepStatus with the given name, or nil if no such step status exists
+func (s *PhaseStatus) Step(name string) *StepStatus {
+	for _, stepStatus := range s.Steps {
+		if stepStatus.Name == name {
+			return &stepStatus
+		}
+	}
+	return nil
+}
+
 func (s *PhaseStatus) Set(status ExecutionStatus) {
 	s.Status = status
 	s.Message = ""
@@ -124,6 +134,16 @@ func (s *PhaseStatus) Set(status ExecutionStatus) {
 func (s *PhaseStatus) SetWithMessage(status ExecutionStatus, message string) {
 	s.Status = status
 	s.Message = message
+}
+
+// Step returns the PhaseStatus with the given name, or nil if no such phase status exists
+func (s *PlanStatus) Phase(name string) *PhaseStatus {
+	for _, phaseStatus := range s.Phases {
+		if phaseStatus.Name == name {
+			return &phaseStatus
+		}
+	}
+	return nil
 }
 
 func (s *PlanStatus) Set(status ExecutionStatus) {

--- a/pkg/controller/instance/instance_controller_test.go
+++ b/pkg/controller/instance/instance_controller_test.go
@@ -575,6 +575,57 @@ func Test_ensurePlanStatusInitialized(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "a new phase is correctly initialized",
+			i:    instance,
+			ov: func() *kudoapi.OperatorVersion {
+				modifiedOv := ov.DeepCopy()
+				pln := modifiedOv.Spec.Plans["deploy"]
+				pln.Phases = append(pln.Phases, kudoapi.Phase{
+					Name: "newphase",
+					Steps: []kudoapi.Step{
+						{
+							Name:  "additionalstep",
+							Tasks: []string{},
+						},
+					},
+				})
+				modifiedOv.Spec.Plans["deploy"] = pln
+				return modifiedOv
+			}(),
+			want: kudoapi.InstanceStatus{
+				PlanStatus: map[string]kudoapi.PlanStatus{
+					"deploy": {
+						Name:   "deploy",
+						Status: kudoapi.ExecutionNeverRun,
+						UID:    "",
+						Phases: []kudoapi.PhaseStatus{
+							{
+								Name:   "phase",
+								Status: kudoapi.ExecutionNeverRun,
+								Steps: []kudoapi.StepStatus{
+									{
+										Name:   "step",
+										Status: kudoapi.ExecutionNeverRun,
+									},
+								},
+							},
+							{
+								Name:   "newphase",
+								Status: kudoapi.ExecutionNeverRun,
+								Steps: []kudoapi.StepStatus{
+									{
+										Name:   "additionalstep",
+										Status: kudoapi.ExecutionNeverRun,
+									},
+								},
+							},
+						},
+					},
+					"backup": backupStatus,
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/test/e2e/upgrade/00-assert.yaml
+++ b/test/e2e/upgrade/00-assert.yaml
@@ -1,0 +1,16 @@
+apiVersion: kudo.dev/v1beta1
+kind: Instance
+metadata:
+  name: upgrade-operator
+status:
+  conditions:
+    - type: Ready
+      status: "True"
+  planStatus:
+    deploy:
+      status: COMPLETE
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment

--- a/test/e2e/upgrade/00-install.yaml
+++ b/test/e2e/upgrade/00-install.yaml
@@ -1,0 +1,5 @@
+apiVersion: kudo.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl kudo install --instance upgrade-operator ./first-operator
+    namespaced: true

--- a/test/e2e/upgrade/01-assert.yaml
+++ b/test/e2e/upgrade/01-assert.yaml
@@ -3,9 +3,6 @@ kind: Instance
 metadata:
   name: upgrade-operator
 status:
-  conditions:
-    - type: Ready
-      status: "True"
   planStatus:
     deploy:
       status: COMPLETE

--- a/test/e2e/upgrade/01-assert.yaml
+++ b/test/e2e/upgrade/01-assert.yaml
@@ -1,0 +1,21 @@
+apiVersion: kudo.dev/v1beta1
+kind: Instance
+metadata:
+  name: upgrade-operator
+status:
+  conditions:
+    - type: Ready
+      status: "True"
+  planStatus:
+    deploy:
+      status: COMPLETE
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test

--- a/test/e2e/upgrade/01-upgrade.yaml
+++ b/test/e2e/upgrade/01-upgrade.yaml
@@ -1,0 +1,5 @@
+apiVersion: kudo.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl kudo upgrade --instance upgrade-operator ./first-operator-v2
+    namespaced: true

--- a/test/e2e/upgrade/first-operator-v2/operator.yaml
+++ b/test/e2e/upgrade/first-operator-v2/operator.yaml
@@ -1,0 +1,36 @@
+apiVersion: kudo.dev/v1beta1
+name: "first-operator"
+operatorVersion: "0.2.0"
+appVersion: "1.7.9"
+kubernetesVersion: 1.17.0
+maintainers:
+  - name: Your name
+    email: <your@email.com>
+url: https://kudo.dev
+tasks:
+  - name: app
+    kind: Apply
+    spec:
+      resources:
+        - deployment.yaml
+  - name: config
+    kind: Apply
+    spec:
+      resources:
+        - configmap.yaml
+plans:
+  deploy:
+    strategy: serial
+    phases:
+      - name: newphase
+        strategy: parallel
+        steps:
+          - name: config
+            tasks:
+              - config
+      - name: main
+        strategy: parallel
+        steps:
+          - name: everything
+            tasks:
+              - app

--- a/test/e2e/upgrade/first-operator-v2/params.yaml
+++ b/test/e2e/upgrade/first-operator-v2/params.yaml
@@ -1,0 +1,5 @@
+apiVersion: kudo.dev/v1beta1
+parameters:
+  - name: replicas
+    description: Number of replicas that should be run as part of the deployment
+    default: 2

--- a/test/e2e/upgrade/first-operator-v2/templates/configmap.yaml
+++ b/test/e2e/upgrade/first-operator-v2/templates/configmap.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test
+data:
+  foo: bar

--- a/test/e2e/upgrade/first-operator-v2/templates/deployment.yaml
+++ b/test/e2e/upgrade/first-operator-v2/templates/deployment.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  selector:
+    matchLabels:
+      app: nginx
+  replicas: {{ .Params.replicas }} # tells deployment to run 2 pods matching the template
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:{{ .AppVersion }}
+          ports:
+            - containerPort: 80

--- a/test/e2e/upgrade/first-operator/operator.yaml
+++ b/test/e2e/upgrade/first-operator/operator.yaml
@@ -1,0 +1,25 @@
+apiVersion: kudo.dev/v1beta1
+name: "first-operator"
+operatorVersion: "0.1.0"
+appVersion: "1.7.9"
+kubernetesVersion: 1.17.0
+maintainers:
+  - name: Your name
+    email: <your@email.com>
+url: https://kudo.dev
+tasks:
+  - name: app
+    kind: Apply
+    spec:
+      resources:
+        - deployment.yaml
+plans:
+  deploy:
+    strategy: serial
+    phases:
+      - name: main
+        strategy: parallel
+        steps:
+          - name: everything
+            tasks:
+              - app

--- a/test/e2e/upgrade/first-operator/params.yaml
+++ b/test/e2e/upgrade/first-operator/params.yaml
@@ -1,0 +1,5 @@
+apiVersion: kudo.dev/v1beta1
+parameters:
+  - name: replicas
+    description: Number of replicas that should be run as part of the deployment
+    default: 2

--- a/test/e2e/upgrade/first-operator/templates/deployment.yaml
+++ b/test/e2e/upgrade/first-operator/templates/deployment.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  selector:
+    matchLabels:
+      app: nginx
+  replicas: {{ .Params.replicas }} # tells deployment to run 2 pods matching the template
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:{{ .AppVersion }}
+          ports:
+            - containerPort: 80


### PR DESCRIPTION
**What this PR does / why we need it**:
Initialise plan status correctly if an upgraded plan adds new phases or steps

<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1754
