### PR TITLE
Do not trigger an update when a parameter is added by an OV upgrade. 

### DIFF
--- a/test/e2e/update-with-upgrade/00-assert.yaml
+++ b/test/e2e/update-with-upgrade/00-assert.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test
+data:
+  origin: deploy
+  foo: bar

--- a/test/e2e/update-with-upgrade/00-install.yaml
+++ b/test/e2e/update-with-upgrade/00-install.yaml
@@ -1,0 +1,5 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl kudo install --instance update-with-upgrade ./update-with-upgrade-v1
+    namespaced: true

--- a/test/e2e/update-with-upgrade/01-assert.yaml
+++ b/test/e2e/update-with-upgrade/01-assert.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test
+data:
+  origin: upgrade
+  foo: bar
+  bar: baz

--- a/test/e2e/update-with-upgrade/01-upgrade-operator-version.yaml
+++ b/test/e2e/update-with-upgrade/01-upgrade-operator-version.yaml
@@ -1,0 +1,5 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl kudo upgrade --instance update-with-upgrade ./update-with-upgrade-v2 -p bar=baz
+    namespaced: true

--- a/test/e2e/update-with-upgrade/update-with-upgrade-v1/operator.yaml
+++ b/test/e2e/update-with-upgrade/update-with-upgrade-v1/operator.yaml
@@ -1,0 +1,50 @@
+apiVersion: kudo.dev/v1beta1
+name: "update-with-upgrade"
+operatorVersion: "0.1.0"
+kubernetesVersion: 1.13.0
+tasks:
+  - name: deploy-configmap
+    kind: Apply
+    spec:
+      resources:
+        - configmap-deployed.yaml
+  - name: update-configmap
+    kind: Apply
+    spec:
+      resources:
+        - configmap-updated.yaml
+  - name: upgrade-configmap
+    kind: Apply
+    spec:
+      resources:
+        - configmap-upgraded.yaml
+plans:
+  deploy:
+    strategy: serial
+    phases:
+      - name: deploy-configmap
+        strategy: serial
+        steps:
+          - name: deploy-configmap
+            tasks:
+              - deploy-configmap
+  # This should not occur when upgrading the operator:
+  update:
+    strategy: serial
+    phases:
+      - name: update-configmap
+        strategy: serial
+        steps:
+          - name: update-configmap
+            tasks:
+              - update-configmap
+  # Instead, this should occur when upgrading the operator:
+  upgrade:
+    strategy: serial
+    phases:
+      - name: upgrade-configmap
+        strategy: serial
+        steps:
+          - name: upgrade-configmap
+            tasks:
+              - upgrade-configmap

--- a/test/e2e/update-with-upgrade/update-with-upgrade-v1/params.yaml
+++ b/test/e2e/update-with-upgrade/update-with-upgrade-v1/params.yaml
@@ -1,0 +1,5 @@
+apiVersion: kudo.dev/v1beta1
+parameters:
+  - name: foo
+    required: true
+    default: "bar"

--- a/test/e2e/update-with-upgrade/update-with-upgrade-v1/templates/configmap-deployed.yaml
+++ b/test/e2e/update-with-upgrade/update-with-upgrade-v1/templates/configmap-deployed.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test
+data:
+  # This field is used to determine the plan which created the config map
+  origin: deploy
+  # This field introduces a dependency on a parameter
+  foo: "{{ .Params.foo }}"

--- a/test/e2e/update-with-upgrade/update-with-upgrade-v1/templates/configmap-updated.yaml
+++ b/test/e2e/update-with-upgrade/update-with-upgrade-v1/templates/configmap-updated.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test
+data:
+  # This field is used to determine the plan which created the config map
+  origin: update
+  # This field introduces a dependency on a parameter
+  foo: "{{ .Params.foo }}"

--- a/test/e2e/update-with-upgrade/update-with-upgrade-v1/templates/configmap-upgraded.yaml
+++ b/test/e2e/update-with-upgrade/update-with-upgrade-v1/templates/configmap-upgraded.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test
+data:
+  # This field is used to determine the plan which created the config map
+  origin: upgrade
+  # This field introduces a dependency on a parameter
+  foo: "{{ .Params.foo }}"

--- a/test/e2e/update-with-upgrade/update-with-upgrade-v2/operator.yaml
+++ b/test/e2e/update-with-upgrade/update-with-upgrade-v2/operator.yaml
@@ -1,0 +1,50 @@
+apiVersion: kudo.dev/v1beta1
+name: "update-with-upgrade"
+operatorVersion: "0.2.0"
+kubernetesVersion: 1.13.0
+tasks:
+  - name: deploy-configmap
+    kind: Apply
+    spec:
+      resources:
+        - configmap-deployed.yaml
+  - name: update-configmap
+    kind: Apply
+    spec:
+      resources:
+        - configmap-updated.yaml
+  - name: upgrade-configmap
+    kind: Apply
+    spec:
+      resources:
+        - configmap-upgraded.yaml
+plans:
+  deploy:
+    strategy: serial
+    phases:
+      - name: deploy-configmap
+        strategy: serial
+        steps:
+          - name: deploy-configmap
+            tasks:
+              - deploy-configmap
+  # This should not occur when upgrading the operator:
+  update:
+    strategy: serial
+    phases:
+      - name: update-configmap
+        strategy: serial
+        steps:
+          - name: update-configmap
+            tasks:
+              - update-configmap
+  # Instead, this should occur when upgrading the operator:
+  upgrade:
+    strategy: serial
+    phases:
+      - name: upgrade-configmap
+        strategy: serial
+        steps:
+          - name: upgrade-configmap
+            tasks:
+              - upgrade-configmap

--- a/test/e2e/update-with-upgrade/update-with-upgrade-v2/params.yaml
+++ b/test/e2e/update-with-upgrade/update-with-upgrade-v2/params.yaml
@@ -1,0 +1,9 @@
+apiVersion: kudo.dev/v1beta1
+parameters:
+  - name: foo
+    required: true
+    default: "bar"
+  # NOTE: "bar" intentionally specifies no default,
+  # so that upgrade is impossible without setting the value.
+  - name: bar
+    required: true

--- a/test/e2e/update-with-upgrade/update-with-upgrade-v2/templates/configmap-deployed.yaml
+++ b/test/e2e/update-with-upgrade/update-with-upgrade-v2/templates/configmap-deployed.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test
+data:
+  # This field is used to determine the plan which created the config map
+  origin: deploy
+  # This field introduces a dependency on a parameter
+  foo: "{{ .Params.foo }}"
+  bar: "{{ .Params.bar }}"

--- a/test/e2e/update-with-upgrade/update-with-upgrade-v2/templates/configmap-updated.yaml
+++ b/test/e2e/update-with-upgrade/update-with-upgrade-v2/templates/configmap-updated.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test
+data:
+  # This field is used to determine the plan which created the config map
+  origin: update
+  # This field introduces a dependency on a parameter
+  foo: "{{ .Params.foo }}"
+  bar: "{{ .Params.bar }}"

--- a/test/e2e/update-with-upgrade/update-with-upgrade-v2/templates/configmap-upgraded.yaml
+++ b/test/e2e/update-with-upgrade/update-with-upgrade-v2/templates/configmap-upgraded.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test
+data:
+  # This field is used to determine the plan which created the config map
+  origin: upgrade
+  # This field introduces a dependency on a parameter
+  foo: "{{ .Params.foo }}"
+  bar: "{{ .Params.bar }}"


### PR DESCRIPTION
Now, parameters added by a new operator version (for example, when
a new OV brings in a new required parameter with no default, so that
it is necessary to set a value together with upgrade) no longer trigger
an update plan.

Fixes #1776