### PR TITLE
Improve long parameter handling

### DIFF
--- a/pkg/apis/kudo/v1beta1/parameter_types_helpers.go
+++ b/pkg/apis/kudo/v1beta1/parameter_types_helpers.go
@@ -85,6 +85,21 @@ func ValidateParameterValueForType(pType ParameterType, pValue interface{}) erro
 	return nil
 }
 
+func ValidateParameterType(pType ParameterType) error {
+	switch pType {
+	case "", // An empty parameter type defaults to "StringValue"
+		StringValueType,
+		IntegerValueType,
+		NumberValueType,
+		BooleanValueType,
+		ArrayValueType,
+		MapValueType:
+		return nil
+	default:
+		return fmt.Errorf("invalid type %s", pType)
+	}
+}
+
 func validateIntegerType(pValue interface{}) error {
 	switch v := pValue.(type) {
 	case int, int8, int16, int32, int64:
@@ -96,6 +111,8 @@ func validateIntegerType(pValue interface{}) error {
 		if err != nil {
 			return fmt.Errorf("type is %q but format of %q is invalid: %v", IntegerValueType, pValue, err)
 		}
+	case float32, float64:
+		return fmt.Errorf("type is %q but format of %s is invalid. Try using quotes around the number", IntegerValueType, pValue)
 	default:
 		return fmt.Errorf("type is %q but format of %s is invalid", IntegerValueType, pValue)
 	}

--- a/pkg/apis/kudo/v1beta1/parameter_types_helpers.go
+++ b/pkg/apis/kudo/v1beta1/parameter_types_helpers.go
@@ -112,6 +112,7 @@ func validateIntegerType(pValue interface{}) error {
 			return fmt.Errorf("type is %q but format of %q is invalid: %v", IntegerValueType, pValue, err)
 		}
 	case float32, float64:
+		// This happens when a user defines a big number without quotes. The YAML parser then reads the value as a float...
 		return fmt.Errorf("type is %q but format of %s is invalid. Try using quotes around the number", IntegerValueType, pValue)
 	default:
 		return fmt.Errorf("type is %q but format of %s is invalid", IntegerValueType, pValue)

--- a/pkg/apis/kudo/v1beta1/parameter_types_helpers_test.go
+++ b/pkg/apis/kudo/v1beta1/parameter_types_helpers_test.go
@@ -167,6 +167,17 @@ func TestValidateType(t *testing.T) {
 			pType:  IntegerValueType,
 		},
 		{
+			name:   "longAsString",
+			pValue: "432000000",
+			pType:  IntegerValueType,
+		},
+		{
+			name:        "longAsUnquotedNumber",
+			pValue:      float64(432000000),
+			pType:       IntegerValueType,
+			expectedErr: true,
+		},
+		{
 			name:   "float32",
 			pValue: float32(3.14),
 			pType:  NumberValueType,

--- a/pkg/engine/renderer/engine_test.go
+++ b/pkg/engine/renderer/engine_test.go
@@ -30,6 +30,14 @@ func TestRender(t *testing.T) {
 			},
 			expected: "  Baz: Quux\n  Foo: Bar",
 		},
+		{
+			name:     "longRender",
+			template: "{{ .Params.LongParam }}",
+			params: map[string]interface{}{
+				"LongParam": int64(432000000),
+			},
+			expected: "432000000",
+		},
 	}
 
 	engine := New()

--- a/pkg/kudoctl/packages/types.go
+++ b/pkg/kudoctl/packages/types.go
@@ -109,6 +109,13 @@ func (p *Parameter) ValidateDefault() error {
 	return nil
 }
 
+func (p *Parameter) ValidateType() error {
+	if err := kudoapi.ValidateParameterType(p.Type); err != nil {
+		return fmt.Errorf("parameter \"%s\" has an invalid type: %v", p.Name, err)
+	}
+	return nil
+}
+
 func (p *Parameter) EnumValues() []interface{} {
 	if p.IsEnum() {
 		return *p.Enum

--- a/pkg/kudoctl/packages/verifier/template/verify_parameters.go
+++ b/pkg/kudoctl/packages/verifier/template/verify_parameters.go
@@ -25,6 +25,7 @@ func (ParametersVerifier) Verify(pf *packages.Files) verifier.Result {
 	res.Merge(immutableParams(pf))
 	res.Merge(enumParams(pf))
 	res.Merge(paramDefaults(pf))
+	res.Merge(paramTypes(pf))
 	res.Merge(metadata(pf))
 	res.Merge(paramGroups(pf))
 
@@ -54,6 +55,16 @@ func immutableParams(pf *packages.Files) verifier.Result {
 			if !p.HasDefault() && !p.IsRequired() {
 				res.AddParamError(p.Name, "is immutable but is not marked as required or has a default value")
 			}
+		}
+	}
+	return res
+}
+
+func paramTypes(pf *packages.Files) verifier.Result {
+	res := verifier.NewResult()
+	for _, p := range pf.Params.Parameters {
+		if err := p.ValidateType(); err != nil {
+			res.AddErrors(err.Error())
 		}
 	}
 	return res

--- a/pkg/kudoctl/packages/verifier/template/verify_parameters_test.go
+++ b/pkg/kudoctl/packages/verifier/template/verify_parameters_test.go
@@ -169,3 +169,26 @@ func TestMetadata(t *testing.T) {
 	assert.Equal(t, `parameter "InvalidAdvanced" is marked as advanced, but also as required and has no default. An advanced parameter must either be optional or have a default value`, res.Errors[1])
 	assert.Equal(t, `parameter "InvalidGroup" has a group "some/group" that is not defined in the group section`, res.Errors[2])
 }
+
+func TestTypes(t *testing.T) {
+	params := []packages.Parameter{
+		{Name: "InvalidType", Type: "long"},
+		{Name: "ValidEmptyType", Type: ""},
+		{Name: "ValidTypeInteger", Type: kudoapi.IntegerValueType},
+	}
+	paramFile := packages.ParamsFile{Parameters: params}
+	templates := make(map[string]string)
+
+	operator := packages.OperatorFile{}
+	pf := packages.Files{
+		Templates: templates,
+		Operator:  &operator,
+		Params:    &paramFile,
+	}
+	verifier := ParametersVerifier{}
+	res := verifier.Verify(&pf)
+
+	assert.Equal(t, 3, len(res.Warnings)) // NotUsed Warnings
+	assert.Equal(t, 1, len(res.Errors))
+	assert.Equal(t, `parameter "InvalidType" has an invalid type: invalid type long`, res.Errors[0])
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kudo/blob/main/CONTRIBUTING.md
2. Make sure you have added and ran the tests before submitting your PR
3. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What this PR does / why we need it**:
- Improves the error messages for long integers in parameters
- Adds a check that throws an error on invalid parameter types (such as "long")


<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1779 
