### PR TITLE
Update leftover apiVersion from kudo to kuttl

### DIFF
--- a/test/e2e/dependencies-hash/05-update-param-and-replica.yaml
+++ b/test/e2e/dependencies-hash/05-update-param-and-replica.yaml
@@ -1,4 +1,4 @@
-apiVersion: kudo.dev/v1beta1
+apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands: # Update a parameter that modifies the config map dependency and deploys the parent
   - command: kubectl kudo update --instance depop -p OTHER_CONFIG_VALUE=SecondChangedValue

--- a/test/e2e/immutable-parameter/01-fail-to-update-param.yaml
+++ b/test/e2e/immutable-parameter/01-fail-to-update-param.yaml
@@ -1,4 +1,4 @@
-apiVersion: kudo.dev/v1beta1
+apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
   - script: '! kubectl kudo update --namespace $NAMESPACE --instance immutable-param -p unchangeable=changedvalue'

--- a/test/e2e/plan-trigger/00-install.yaml
+++ b/test/e2e/plan-trigger/00-install.yaml
@@ -1,4 +1,4 @@
-apiVersion: kudo.dev/v1beta1
+apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
   - command: kubectl kudo install --instance feature-operator-instance ./feature-operator

--- a/test/e2e/plan-trigger/01-trigger.yaml
+++ b/test/e2e/plan-trigger/01-trigger.yaml
@@ -1,4 +1,4 @@
-apiVersion: kudo.dev/v1beta1
+apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
   - command: kubectl kudo plan trigger --instance feature-operator-instance --name custom

--- a/test/e2e/terminal-failed-job/00-install.yaml
+++ b/test/e2e/terminal-failed-job/00-install.yaml
@@ -1,4 +1,4 @@
-apiVersion: kudo.dev/v1beta1
+apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
   - command: kubectl kudo install --instance failjob-operator-instance ./failjob-operator

--- a/test/e2e/terminal-failed-job/01-install-timeout.yaml
+++ b/test/e2e/terminal-failed-job/01-install-timeout.yaml
@@ -1,4 +1,4 @@
-apiVersion: kudo.dev/v1beta1
+apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
   - command: kubectl kudo uninstall --instance failjob-operator-instance

--- a/test/e2e/toggle-task/00-install.yaml
+++ b/test/e2e/toggle-task/00-install.yaml
@@ -1,4 +1,4 @@
-apiVersion: kudo.dev/v1beta1
+apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
   - command: kubectl kudo install --instance feature-operator-instance ./feature-operator

--- a/test/e2e/toggle-task/02-update.yaml
+++ b/test/e2e/toggle-task/02-update.yaml
@@ -1,4 +1,4 @@
-apiVersion: kudo.dev/v1beta1
+apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
   - command: kubectl kudo update --instance feature-operator-instance -p enable_cm=true

--- a/test/e2e/upgrade/00-install.yaml
+++ b/test/e2e/upgrade/00-install.yaml
@@ -1,4 +1,4 @@
-apiVersion: kudo.dev/v1beta1
+apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
   - command: kubectl kudo install --instance upgrade-operator ./first-operator

--- a/test/e2e/upgrade/01-upgrade.yaml
+++ b/test/e2e/upgrade/01-upgrade.yaml
@@ -1,4 +1,4 @@
-apiVersion: kudo.dev/v1beta1
+apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
   - command: kubectl kudo upgrade --instance upgrade-operator ./first-operator-v2

--- a/test/integration/cli-install/00-install.yaml
+++ b/test/integration/cli-install/00-install.yaml
@@ -1,4 +1,4 @@
-apiVersion: kudo.dev/v1beta1
+apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
   - command: kubectl kudo install --instance cli-install ./cli-install-operator

--- a/test/integration/install-existing-crds-in-operator/00-install-operator.yaml
+++ b/test/integration/install-existing-crds-in-operator/00-install-operator.yaml
@@ -1,4 +1,4 @@
-apiVersion: kudo.dev/v1beta1
+apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
   - command: kubectl kudo install --instance crd-instance ./crd-operator

--- a/test/integration/invalid-crd-install/00-install.yaml
+++ b/test/integration/invalid-crd-install/00-install.yaml
@@ -1,4 +1,4 @@
-apiVersion: kudo.dev/v1beta1
+apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
   - command: kubectl kudo install --instance op-with-crd ./op-with-crd

--- a/test/integration/operator-with-custom-crd/00-install-crd.yaml
+++ b/test/integration/operator-with-custom-crd/00-install-crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: kudo.dev/v1beta1
+apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
   - command: kubectl kudo install --instance crd-instance ./operator

--- a/test/integration/operator-with-dependencies/01-install.yaml
+++ b/test/integration/operator-with-dependencies/01-install.yaml
@@ -1,4 +1,4 @@
-apiVersion: kudo.dev/v1beta1
+apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
   - command: kubectl kudo install --instance dummy-instance ./parent-operator

--- a/test/integration/operator-with-subdirectory-resources/00-install.yaml
+++ b/test/integration/operator-with-subdirectory-resources/00-install.yaml
@@ -1,4 +1,4 @@
-apiVersion: kudo.dev/v1beta1
+apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
   - command: kubectl kudo install --instance subdirectory ./operator

--- a/test/integration/parameter-types-operator/01-install.yaml
+++ b/test/integration/parameter-types-operator/01-install.yaml
@@ -1,4 +1,4 @@
-apiVersion: kudo.dev/v1beta1
+apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
   - command: kubectl kudo install --instance parameter-test-instance ./operator

--- a/test/integration/remove-pod-container/00-install.yaml
+++ b/test/integration/remove-pod-container/00-install.yaml
@@ -1,4 +1,4 @@
-apiVersion: kudo.dev/v1beta1
+apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
   - command: kubectl kudo install --instance dual-pod ./dual-pod-operator -p  WITH_PRIORITY="false"

--- a/test/integration/remove-pod-container/01-update.yaml
+++ b/test/integration/remove-pod-container/01-update.yaml
@@ -1,4 +1,4 @@
-apiVersion: kudo.dev/v1beta1
+apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
   - command: kubectl kudo update --instance dual-pod -p SECOND_CONTAINER="false" -p WITH_PRIORITY="true"

--- a/test/integration/remove-pod-container/02-update_param.yaml
+++ b/test/integration/remove-pod-container/02-update_param.yaml
@@ -1,4 +1,4 @@
-apiVersion: kudo.dev/v1beta1
+apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
   - command: kubectl kudo update --instance dual-pod -p WITH_PRIORITY="false"

--- a/test/integration/upgrade-with-dependencies/00-install.yaml
+++ b/test/integration/upgrade-with-dependencies/00-install.yaml
@@ -1,4 +1,4 @@
-apiVersion: kudo.dev/v1beta1
+apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
   - command: kubectl kudo install --instance operator-instance ./operator-1.0

--- a/test/integration/upgrade-with-dependencies/01-upgrade.yaml
+++ b/test/integration/upgrade-with-dependencies/01-upgrade.yaml
@@ -1,4 +1,4 @@
-apiVersion: kudo.dev/v1beta1
+apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
   - command: kubectl kudo upgrade --instance operator-instance ./operator-2.0

--- a/test/upgrade/cert-manager-detection/00-install-cert-manager-0-16-0.yaml
+++ b/test/upgrade/cert-manager-detection/00-install-cert-manager-0-16-0.yaml
@@ -1,4 +1,4 @@
-apiVersion: kudo.dev/v1beta1
+apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
   - command: kubectl apply --validate=false -f cert-manager/cert-manager-0.16.0.yaml

--- a/test/upgrade/cert-manager-detection/01-install-kudo.yaml
+++ b/test/upgrade/cert-manager-detection/01-install-kudo.yaml
@@ -1,4 +1,4 @@
-apiVersion: kudo.dev/v1beta1
+apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
   - command: sleep 10


### PR DESCRIPTION
Signed-off-by: Rishabh Bohra <rishabhbohra01@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kudo/blob/main/CONTRIBUTING.md
2. Make sure you have added and ran the tests before submitting your PR
3. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What this PR does / why we need it**:
Updates the `apiVersion` to `kuttl.dev/v1beta1` for the tests that were missed in the PR https://github.com/kudobuilder/kudo/pull/1762

<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
