### PR TITLE
Remove Gerred from ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,7 +5,7 @@
 # the repo. Unless a later match takes precedence,
 # @global-owner1 and @global-owner2 will be requested for
 # review when someone opens a pull request.
-*       @gerred @kensipe @alenkacz @zen-dog
+*       @kensipe @alenkacz @zen-dog
 
 # In this example, @doctocat owns any files in the build/logs
 # directory at the root of the repository and any of its

--- a/OWNERS
+++ b/OWNERS
@@ -1,6 +1,5 @@
 maintainers:
 - alenkacz
-- gerred
 kudo-core-maintainers:
 - runyontr
 - zen-dog


### PR DESCRIPTION
Hi all,

It has been a pleasure working with the KUDO community. I've enjoyed building it from proposal, to first commit, and working to make developing controllers on Kubernetes more accessible for everyone. This PR is me passing the torch off to others who are contributing today. Other things are consuming most of my time and the ownership of this project should be in the hands of everyone who's working hard to make KUDO better!

Thanks all!

Signed-off-by: Gerred Dillon <hello@gerred.org>
