### PR TITLE
Automation for KUDO release process to replace manual release process

### DIFF
--- a/.github/workflows/release-on-tag.yml
+++ b/.github/workflows/release-on-tag.yml
@@ -1,0 +1,28 @@
+name: KUDO Release Automation
+on:
+  push:
+    tags:
+     - '*'
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+     - name: Checkout Code
+       uses: actions/checkout@v1
+     - name: Login to GitHub Package Registry
+       env:
+         DOCKER_USERNAME: ${{ secrets.DOCKER_GITHUB_USERNAME }}
+         DOCKER_PASSWORD: ${{ secrets.DOCKER_GITHUB_KEY }}
+         DOCKER_REGISTRY_URL: "docker.pkg.github.com"
+       run: docker login -u ${DOCKER_USERNAME} -p ${DOCKER_PASSWORD} ${DOCKER_REGISTRY_URL}
+     - name: Download and Install Go
+       run: |
+         sudo snap install --classic --channel=1.15/stable go
+     - name: Download and Extract GoReleaser
+       run: |
+         curl -Ls https://github.com/goreleaser/goreleaser/releases/download/v0.164.0/goreleaser_Linux_x86_64.tar.gz | tar -xzf - -C /tmp
+     - name: Run the Release
+       env:
+         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+       run: |
+         /tmp/goreleaser --rm-dist

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -45,7 +45,7 @@ builds:
 dockers:
   # always push a docker image on release for the .Tag version
   - dockerfile: Dockerfile.goreleaser
-    binaries:
+    ids:
       - manager
     goos: linux
     goarch: amd64
@@ -53,7 +53,7 @@ dockers:
       - "kudobuilder/controller:{{ .Tag }}"
   # only update the docker :latest for a full release (not RC)
   - dockerfile: Dockerfile.goreleaser
-    binaries:
+    ids:
       - manager
     goos: linux
     goarch: amd64
@@ -62,7 +62,7 @@ dockers:
     skip_push: auto
   # always push a docker image on release for the .Tag version
   - dockerfile: Dockerfile.goreleaser
-    binaries:
+    ids:
       - manager
     goos: linux
     goarch: arm64
@@ -70,7 +70,7 @@ dockers:
       - "kudobuilder/controller-arm64:{{ .Tag }}"
   # only update the docker :latest for a full release (not RC)
   - dockerfile: Dockerfile.goreleaser
-    binaries:
+    ids:
       - manager
     goos: linux
     goarch: arm64


### PR DESCRIPTION
JIRA Ticket: [D2IQ-75413](https://jira.d2iq.com/browse/D2IQ-75413)

**What this PR does / why we need it**:
This PR addresses the automation of the release process. It adds GitHub Action to carry out the release. GitHub Action would be triggered on `tag` push and it in turns call `goreleaser` do the actual release.
