### PR TITLE
chore: migrate from k8s.gcr.io to registry.k8s.io

### DIFF
--- a/pkg/kudoctl/cmd/testdata/invalidzk/templates/statefulset.yaml
+++ b/pkg/kudoctl/cmd/testdata/invalidzk/templates/statefulset.yaml
@@ -22,7 +22,7 @@ spec:
       containers:
         - name: kubernetes-zookeeper
           imagePullPolicy: Always
-          image: "k8s.gcr.io/kubernetes-zookeeper:1.0-3.4.10"
+          image: "registry.k8s.io/kubernetes-zookeeper:1.0-3.4.10"
           resources:
             requests:
               memory: "{{ .Params.memory }}"

--- a/pkg/kudoctl/cmd/testdata/invalidzk/templates/validation.yaml
+++ b/pkg/kudoctl/cmd/testdata/invalidzk/templates/validation.yaml
@@ -11,7 +11,7 @@ spec:
       containers:
       - name: kubernetes-zookeeper
         imagePullPolicy: Always
-        image: "k8s.gcr.io/kubernetes-zookeeper:1.0-3.4.10"
+        image: "registry.k8s.io/kubernetes-zookeeper:1.0-3.4.10"
         env:
         - name: CONN
           value: zk-zk-0.zk-hs:2181,zk-zk-1.zk-hs:2181,zk-zk-2.zk-hs:2181

--- a/pkg/kudoctl/packages/testdata/zk-crd-golden1/operatorversion.golden
+++ b/pkg/kudoctl/packages/testdata/zk-crd-golden1/operatorversion.golden
@@ -96,7 +96,7 @@ spec:
             containers:
               - name: kubernetes-zookeeper
                 imagePullPolicy: Always
-                image: "k8s.gcr.io/kubernetes-zookeeper:1.0-3.4.10"
+                image: "registry.k8s.io/kubernetes-zookeeper:1.0-3.4.10"
                 resources:
                   requests:
                     memory: "{{ .Params.memory }}"
@@ -184,7 +184,7 @@ spec:
             containers:
               - name: kubernetes-zookeeper
                 imagePullPolicy: Always
-                image: "k8s.gcr.io/kubernetes-zookeeper:1.0-3.4.10"
+                image: "registry.k8s.io/kubernetes-zookeeper:1.0-3.4.10"
                 resources:
                   requests:
                     memory: "{{ .Params.memory }}"
@@ -261,7 +261,7 @@ spec:
             containers:
             - name: kubernetes-zookeeper
               imagePullPolicy: Always
-              image: "k8s.gcr.io/kubernetes-zookeeper:1.0-3.4.10"
+              image: "registry.k8s.io/kubernetes-zookeeper:1.0-3.4.10"
               env:
               - name: CONN
                 value: zk-zk-0.zk-hs:2181,zk-zk-1.zk-hs:2181,zk-zk-2.zk-hs:2181

--- a/pkg/kudoctl/packages/testdata/zk-crd-golden2/operatorversion.golden
+++ b/pkg/kudoctl/packages/testdata/zk-crd-golden2/operatorversion.golden
@@ -96,7 +96,7 @@ spec:
             containers:
               - name: kubernetes-zookeeper
                 imagePullPolicy: Always
-                image: "k8s.gcr.io/kubernetes-zookeeper:1.0-3.4.10"
+                image: "registry.k8s.io/kubernetes-zookeeper:1.0-3.4.10"
                 resources:
                   requests:
                     memory: "{{ .Params.memory }}"
@@ -184,7 +184,7 @@ spec:
             containers:
               - name: kubernetes-zookeeper
                 imagePullPolicy: Always
-                image: "k8s.gcr.io/kubernetes-zookeeper:1.0-3.4.10"
+                image: "registry.k8s.io/kubernetes-zookeeper:1.0-3.4.10"
                 resources:
                   requests:
                     memory: "{{ .Params.memory }}"
@@ -261,7 +261,7 @@ spec:
             containers:
             - name: kubernetes-zookeeper
               imagePullPolicy: Always
-              image: "k8s.gcr.io/kubernetes-zookeeper:1.0-3.4.10"
+              image: "registry.k8s.io/kubernetes-zookeeper:1.0-3.4.10"
               env:
               - name: CONN
                 value: zk-zk-0.zk-hs:2181,zk-zk-1.zk-hs:2181,zk-zk-2.zk-hs:2181

--- a/pkg/kudoctl/packages/testdata/zk/templates/statefulset.yaml
+++ b/pkg/kudoctl/packages/testdata/zk/templates/statefulset.yaml
@@ -22,7 +22,7 @@ spec:
       containers:
         - name: kubernetes-zookeeper
           imagePullPolicy: Always
-          image: "k8s.gcr.io/kubernetes-zookeeper:1.0-3.4.10"
+          image: "registry.k8s.io/kubernetes-zookeeper:1.0-3.4.10"
           resources:
             requests:
               memory: "{{ .Params.memory }}"

--- a/pkg/kudoctl/packages/testdata/zk/templates/subfolder/statefulset2.yaml
+++ b/pkg/kudoctl/packages/testdata/zk/templates/subfolder/statefulset2.yaml
@@ -22,7 +22,7 @@ spec:
       containers:
         - name: kubernetes-zookeeper
           imagePullPolicy: Always
-          image: "k8s.gcr.io/kubernetes-zookeeper:1.0-3.4.10"
+          image: "registry.k8s.io/kubernetes-zookeeper:1.0-3.4.10"
           resources:
             requests:
               memory: "{{ .Params.memory }}"

--- a/pkg/kudoctl/packages/testdata/zk/templates/validation.yaml
+++ b/pkg/kudoctl/packages/testdata/zk/templates/validation.yaml
@@ -11,7 +11,7 @@ spec:
       containers:
       - name: kubernetes-zookeeper
         imagePullPolicy: Always
-        image: "k8s.gcr.io/kubernetes-zookeeper:1.0-3.4.10"
+        image: "registry.k8s.io/kubernetes-zookeeper:1.0-3.4.10"
         env:
         - name: CONN
           value: zk-zk-0.zk-hs:2181,zk-zk-1.zk-hs:2181,zk-zk-2.zk-hs:2181


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kudobuilder/kudo/blob/main/CONTRIBUTING.md
2. Make sure you have added and ran the tests before submitting your PR
3. If the PR is unfinished, start it as a Draft PR: https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

**What this PR does / why we need it**:
Kubernetes is migrating its image registry from [k8s.gcr.io](http://k8s.gcr.io/) to [registry.k8s.io](http://registry.k8s.io/).

Part of kubernetes/k8s.io#4780.

<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

@kensipe can you PTAL?